### PR TITLE
perf: replace vensim wrapper functions with macros

### DIFF
--- a/src/c/vensim.c
+++ b/src/c/vensim.c
@@ -6,59 +6,11 @@ extern double _time_step;
 double _epsilon = 1e-6;
 
 //
-// Helpers
-//
-typedef enum {
-  Interpolate, Forward, Backward
-} LookupMode;
-
-double bool_cond(double cond) {
-	return (cond != 0.0);
-}
-//
 // Vensim functions
 // See the Vensim Reference Manual for descriptions of the functions.
 // http://www.vensim.com/documentation/index.html?22300.htm
 //
-double _ABS(double x) {
-	return fabs(x);
-}
-double _COS(double x) {
-	return cos(x);
-}
-double _EXP(double x) {
-  return exp(x);
-}
-double _GAME(double x) {
-  return x;
-}
-double _IF_THEN_ELSE(double condition, double true_value, double false_value) {
-	// TODO Generate a special form that only evaluates one argument instead of calling a function.
-	if (bool_cond(condition)) {
-		return true_value;
-	}
-	else {
-		return false_value;
-	}
-}
-double _INTEG(double value, double rate) {
-	return (value + rate * _time_step);
-}
-double _INTEGER(double x) {
-	return trunc(x);
-}
-double _LN(double x) {
-  return log(x);
-}
-double _MAX(double a, double b) {
-  return fmax(a, b);
-}
-double _MIN(double a, double b) {
-  return fmin(a, b);
-}
-double _MODULO(double a, double b) {
-  return fmod(a, b);
-}
+
 double _PULSE(double start, double width) {
 	double time_plus = _time + _time_step / 2.0;
 	if (width == 0.0) {
@@ -92,25 +44,6 @@ double _RAMP(double slope, double start_time, double end_time) {
 		return 0.0;
 	}
 }
-double _SAMPLE_IF_TRUE(double currentValue, double condition, double input) {
-  // TODO Generate a special form that only evaluates one argument instead of calling a function.
-	if (bool_cond(condition)) {
-		return input;
-	}
-	else {
-		return currentValue;
-	}
-}
-double _SIN(double x) {
-	return sin(x);
-}
-double _SQRT(double x) {
-  return sqrt(x);
-}
-double _STEP(double height, double step_time) {
-	double __time_plus = _time + _time_step / 2.0;
-	return fgt(__time_plus, step_time) ? height : 0.0;
-}
 double _XIDZ(double a, double b, double x) {
 	return fz(b) ? x : a / b;
 }
@@ -121,6 +54,7 @@ double _ZIDZ(double a, double b) {
 		return a / b;
 	}
 }
+
 //
 // Lookups
 //
@@ -199,18 +133,6 @@ double __lookup(double* data, size_t n, double input, LookupMode mode) {
   }
   // The input is greater than all the x values, so return the high end of the range.
 	return *(data + 2 * (n - 1) + 1);
-}
-double _LOOKUP(Lookup* lookup, double x) {
-	return __lookup(lookup->data, lookup->n, x, Interpolate);
-}
-double _LOOKUP_FORWARD(Lookup* lookup, double x) {
-	return __lookup(lookup->data, lookup->n, x, Forward);
-}
-double _LOOKUP_BACKWARD(Lookup* lookup, double x) {
-	return __lookup(lookup->data, lookup->n, x, Backward);
-}
-double _WITH_LOOKUP(double x, Lookup* lookup) {
-  return __lookup(lookup->data, lookup->n, x, Interpolate);
 }
 double _LOOKUP_INVERT(Lookup* lookup, double y) {
 	if (lookup->inverted_data == NULL) {

--- a/src/c/vensim.h
+++ b/src/c/vensim.h
@@ -4,46 +4,63 @@
 extern "C" {
 #endif
 
+//
+// Helpers
+//
+#define _NA_ (-DBL_MAX)
+#define bool_cond(cond) ((double)(cond) != 0.0)
+
+//
+// Vensim functions
+// See the Vensim Reference Manual for descriptions of the functions.
+// http://www.vensim.com/documentation/index.html?22300.htm
+//
+#define _ABS(x) fabs(x)
+#define _COS(x) cos(x)
+#define _EXP(x) exp(x)
+#define _GAME(x) (x)
+#define _IF_THEN_ELSE(c, t, f) (bool_cond(c) ? (t) : (f))
+#define _INTEG(value, rate) ((value) + (rate) * _time_step)
+#define _INTEGER(x) trunc(x)
+#define _LN(x) log(x)
+#define _MAX(a, b) fmax(a, b)
+#define _MIN(a, b) fmin(a, b)
+#define _MODULO(a, b) fmod(a, b)
+#define _SAMPLE_IF_TRUE(current, condition, input) (bool_cond(condition) ? (input) : (current))
+#define _SIN(x) sin(x)
+#define _SQRT(x) sqrt(x)
+#define _STEP(height, step_time) (fgt(_time + _time_step / 2.0, (step_time)) ? (height) : 0.0)
+double _PULSE(double start, double width);
+double _PULSE_TRAIN(double start, double width, double interval, double end);
+double _RAMP(double slope, double start_time, double end_time);
+double* _VECTOR_SORT_ORDER(double* vector, size_t size, double direction);
+double _XIDZ(double a, double b, double x);
+double _ZIDZ(double a, double b);
+
+//
+// Lookups
+//
+typedef enum {
+  Interpolate, Forward, Backward
+} LookupMode;
+
 typedef struct {
   double* data;
   size_t n;
   double* inverted_data;
 } Lookup;
+
 Lookup* __new_lookup(size_t size, ...);
 void __delete_lookup(Lookup* lookup);
 void __print_lookup(Lookup* lookup);
 
-double bool_cond(double cond);
-
-#define _NA_ (-DBL_MAX)
-
-double _ABS(double x);
-double _COS(double x);
-double _EXP(double x);
-double _GAME(double x);
-double _IF_THEN_ELSE(double condition, double true_value, double false_value);
-double _INTEG(double value, double rate);
-double _INTEGER(double x);
-double _LN(double x);
-double _LOOKUP_BACKWARD(Lookup* lookup, double x);
+double __lookup(double* data, size_t n, double input, LookupMode mode);
+#define _LOOKUP(lookup, x) __lookup((lookup)->data, (lookup)->n, x, Interpolate)
+#define _LOOKUP_FORWARD(lookup, x) __lookup((lookup)->data, (lookup)->n, x, Forward)
+#define _LOOKUP_BACKWARD(lookup, x) __lookup((lookup)->data, (lookup)->n, x, Backward)
+#define _WITH_LOOKUP(x, lookup) __lookup((lookup)->data, (lookup)->n, x, Interpolate)
 double _LOOKUP_INVERT(Lookup* lookup, double y);
-double _LOOKUP(Lookup* lookup, double input);
-double _LOOKUP_FORWARD(Lookup* lookup, double x);
-double _MAX(double a, double b);
-double _MIN(double a, double b);
-double _MODULO(double a, double b);
-double _PULSE(double start, double width);
-double _PULSE_TRAIN(double start, double width, double interval, double end);
-double _RAMP(double slope, double start_time, double end_time);
-double _SAMPLE_IF_TRUE(double currentValue, double condition, double input);
-double _SIN(double x);
-double _SQRT(double x);
-double _STEP(double height, double step_time);
-double _WITH_LOOKUP(double x, Lookup* lookup);
-double _XIDZ(double a, double b, double x);
-double _ZIDZ(double a, double b);
 
-double* _VECTOR_SORT_ORDER(double* vector, size_t size, double direction);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
More details in #22.  In short, most wrapper functions in `vensim.c` have been replaced by macros defined in `vensim.h`.  There are some wrapper functions that I left unchanged where a macro implementation would be too complex or wouldn't provide a performance improvement.  For example, `_XIDZ` and `_ZIDZ` reference the `b` parameter twice which in macro form could lead to double evaluation.

Fixes #22 
