### PR TITLE
fix: use case-insensitive sort and remove trailing whitespace in preprocessor

### DIFF
--- a/models/preprocess/expected.mdl
+++ b/models/preprocess/expected.mdl
@@ -1,0 +1,65 @@
+{UTF-8}
+
+Apple 1  = 1
+	~~|
+
+Apple 2  = 1
+	~~|
+
+apple 3  = 1
+	~~|
+
+Banana 1  = 1
+	~~|
+
+Banana 2  = 1
+	~~|
+
+banana 3  =
+  Banana 1
+    * Banana 2
+	~~|
+
+carrot 1  = 1
+	~~|
+
+carrot 2  = 1
+	~~|
+
+carrot 3 Data 1
+	~~|
+
+Carrot 3 Data 2
+	~~|
+
+DimA: A1, A2, A3
+	~~|
+
+dimB: B1, B2, B3
+	~~|
+
+FINAL TIME  = 10
+	~~|
+
+INITIAL TIME  = 0
+	~~|
+
+Look1((0,0),(1,1),(2,2))
+	~~|
+
+Look2((0,0),(1,1),(2,2))
+	~~|
+
+"Quotes 1"  = 1
+	~~|
+
+" quotes 2 with extra whitespace "  = 1
+	~~|
+
+SAVEPER  =
+        TIME STEP
+	~~|
+
+TIME STEP  = 1
+	~~|
+

--- a/models/preprocess/input.mdl
+++ b/models/preprocess/input.mdl
@@ -1,0 +1,104 @@
+{UTF-8}
+
+" quotes 2 with extra whitespace "  = 1
+	~ dmnl
+	~ Comment
+	|
+
+"Quotes 1"  = 1
+	~ dmnl
+	~ Comment
+	|
+
+apple 3  = 1
+	~ dmnl
+	~ Comment
+	|
+
+Carrot 3 Data 2 :RAW:
+	~	Tons
+	~		|
+
+banana 3  =   	
+  Banana 1
+    * Banana 2
+	~ dmnl
+	~ Comment
+	|
+
+carrot 3 Data 1 :RAW:
+	~	Tons
+	~		|
+
+carrot 2  = 1  
+	~ dmnl  
+	~ Comment
+	|
+
+Look2((0,0),(1,1),(2,2))
+	~~|
+
+Look1((0,0),(1,1),(2,2))
+	~~|
+
+Apple 2  = 1   
+	~ dmnl
+	~ Comment
+	|
+
+carrot 1  = 1
+	~ dmnl
+	~ Comment
+	|
+
+Banana 2  = 1
+	~ dmnl
+	~ Comment
+	|
+
+Banana 1  = 1
+	~ dmnl
+	~ Comment
+	|
+
+Apple 1  = 1
+	~ dmnl
+	~ Comment
+	|
+
+dimB: B1, B2, B3
+  ~~|
+
+DimA: A1, A2, A3
+  ~~|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 10
+	~	Month
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 0
+	~	Month
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  =
+        TIME STEP
+	~	Month [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 1
+	~	Month [0,?]
+	~	The time step for the simulation.
+	|
+
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*View 1

--- a/models/preprocess/preprocess_check.sh
+++ b/models/preprocess/preprocess_check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+MODEL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SDE='node ../../src/sde.js'
+
+cd $MODEL_DIR
+$SDE generate --preprocess input.mdl
+
+diff expected.mdl build/input.mdl > build/diff.txt 2>&1
+if [ $? != 0 ]; then
+  echo
+  echo "ERROR: 'sde generate --preprocess' produced unexpected results:"
+  echo
+  cat build/diff.txt
+  echo
+  exit 1
+fi
+
+echo "All validation checks passed!"

--- a/src/tests/modeltests
+++ b/src/tests/modeltests
@@ -19,14 +19,16 @@ function test {
   # Clean up before
   $SDE clean --modeldir $MODEL_DIR
 
-  # Test
-  SPEC_FILE=$MODEL_DIR/${MODEL}_spec.json
-  if [[ -f $SPEC_FILE ]]; then
-    TEST_ARGS="--spec $SPEC_FILE"
-  else
-    TEST_ARGS=
+  # Test (only if there is a dat file to compare against)
+  if [[ -f $MODEL_DIR/${MODEL}.dat ]]; then
+    SPEC_FILE=$MODEL_DIR/${MODEL}_spec.json
+    if [[ -f $SPEC_FILE ]]; then
+      TEST_ARGS="--spec $SPEC_FILE"
+    else
+      TEST_ARGS=
+    fi
+    $SDE test $TEST_ARGS -p 1e-4 $MODEL_DIR/$MODEL
   fi
-  $SDE test $TEST_ARGS -p 1e-4 $MODEL_DIR/$MODEL
 
   # Run additional script to validate output
   VALIDATE_SCRIPT=$MODEL_DIR/${MODEL}_check.sh


### PR DESCRIPTION
This fixes the case insensitivity part of the previous commit, and improves upon it by also removing trailing whitespace and fixing the placement of the comment marker so that the markers are consistent for all declarations.

I've also added a test that checks that the output of the preprocessor matches a reference mdl file.

Fixes #55 
