### PR TITLE
perf: improve code gen performance by avoiding linear searches

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -196,7 +196,7 @@ function checkSpecVars(spec, extData) {
     if (isIterable(varNames)) {
       for (let varName of varNames) {
         if (!R.contains('[', varName)) {
-          if (!R.find(R.propEq('refId', varName), variables)) {
+          if (!varWithRefId(varName)) {
             // Look for a variable in external data.
             if (extData.has(varName)) {
               // console.error(`found ${specType} ${varName} in extData`)

--- a/src/Model.js
+++ b/src/Model.js
@@ -716,10 +716,17 @@ function sortInitVars() {
   // printVars(vars);
   // R.forEach(v => { console.error(v.refId); console.error(v.references); }, vars);
 
+  // Keep track of which var ref ids are currently in the queue for faster lookup
+  const queueRefIds = new Set()
+  for (const v of vars) {
+    queueRefIds.add(v.refId)
+  }
+
   // Build a map of dependencies indexed by the lhs of each var.
-  let depsMap = new Map()
+  const depsMap = new Map()
   while (vars.length > 0) {
     let v = vars.pop()
+    queueRefIds.delete(v.refId)
     // console.error(`- ${v.refId} (${vars.length})`);
     addDepsToMap(v)
   }
@@ -740,8 +747,9 @@ function sortInitVars() {
           // console.error(refId);
           let refVar = varWithRefId(refId)
           if (refVar) {
-            if (refVar.varType !== 'const' && !R.contains(refVar, vars)) {
+            if (refVar.varType !== 'const' && !queueRefIds.has(refVar.refId)) {
               vars.push(refVar)
+              queueRefIds.add(refVar.refId)
               // console.error(`+ ${refVar.refId}`);
             }
           } else {


### PR DESCRIPTION
More details in the issue comments (#62).

In summary, running `sde generate --genc` for the En-ROADS model used to take 2 minutes 2 seconds on my laptop, and with these changes, it now takes under 5 seconds.

Fixes #62 
