### PR TITLE
feat: remove inline comments in the preprocessor

### DIFF
--- a/models/comments/comments.dat
+++ b/models/comments/comments.dat
@@ -1,0 +1,23 @@
+a[A1]
+0	0
+a[A2]
+0	1
+a[A3]
+0	2
+b
+0	3
+c
+0	4
+d
+0	8760
+e
+0	42
+1	42
+FINAL TIME
+0	1
+INITIAL TIME
+0	0
+SAVEPER
+0	1
+TIME STEP
+0	1

--- a/models/comments/comments.mdl
+++ b/models/comments/comments.mdl
@@ -1,0 +1,53 @@
+{UTF-8}
+DimA: A1, A2, A3 ~~|
+
+a[DimA]=
+  0,  {transportation sector}
+  1,  {electricity sector}
+  2  {geoengineering sector - NOT USED}
+  ~
+  ~  ~  :SUPPLEMENTARY
+  |
+
+b = 3  {transportation sector}
+  ~
+  ~  ~  :SUPPLEMENTARY
+  |
+
+c = 4
+  {first part and
+    the second part}
+  ~
+  ~  ~  :SUPPLEMENTARY
+  |
+
+d=
+  8760
+
+  {
+  We ignore leap years so that we can get consistent results
+  for various values used in the model that should not change
+  every four years.  If we want to change this value for leap
+  years, instead use the following code:
+
+
+  IF THEN ELSE(
+     (MODULO(Time, 4) = 0 :AND: MODULO(Time, 100) <> 0) :OR: MODULO(Time, 400) = 0,
+     8784 {leap year},
+     8760 {normal year}
+  )
+  }
+  ~  hours
+  ~  Calculates the number of hours in the year, ignoring leap years.
+  ~  :SUPPLEMENTARY
+  |
+
+e = 41 {first part} + 1 {second part}
+  ~
+  ~  ~  :SUPPLEMENTARY
+  |
+
+INITIAL TIME  = 0 ~~|
+FINAL TIME  = 1 ~~|
+SAVEPER  = 1 ~~|
+TIME STEP  = 1 ~~|

--- a/models/comments/comments_check.sh
+++ b/models/comments/comments_check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+MODEL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SDE='node ../../src/sde.js'
+
+cd $MODEL_DIR
+$SDE generate --preprocess comments.mdl
+
+diff expected.mdl build/comments.mdl > build/diff.txt 2>&1
+if [ $? != 0 ]; then
+  echo
+  echo "ERROR: 'sde generate --preprocess' produced unexpected results:"
+  echo
+  cat build/diff.txt
+  echo
+  exit 1
+fi
+
+echo "All validation checks passed!"

--- a/models/comments/comments_vars.txt
+++ b/models/comments/comments_vars.txt
@@ -1,0 +1,69 @@
+a[DimA]: const (non-apply-to-all)
+= 0,1,2
+refId(_a[_a1])
+families(_dima)
+subscripts(_a1)
+separationDims(_dima)
+hasInitValue(false)
+
+a[DimA]: const (non-apply-to-all)
+= 0,1,2
+refId(_a[_a2])
+families(_dima)
+subscripts(_a2)
+separationDims(_dima)
+hasInitValue(false)
+
+a[DimA]: const (non-apply-to-all)
+= 0,1,2
+refId(_a[_a3])
+families(_dima)
+subscripts(_a3)
+separationDims(_dima)
+hasInitValue(false)
+
+b: const
+= 3
+refId(_b)
+hasInitValue(false)
+
+c: const
+= 4
+refId(_c)
+hasInitValue(false)
+
+d: const
+= 8760
+refId(_d)
+hasInitValue(false)
+
+e: const
+= 41+1
+refId(_e)
+hasInitValue(false)
+
+FINAL TIME: const
+= 1
+refId(_final_time)
+hasInitValue(false)
+
+INITIAL TIME: const
+= 0
+refId(_initial_time)
+hasInitValue(false)
+
+SAVEPER: const
+= 1
+refId(_saveper)
+hasInitValue(false)
+
+Time: const
+= 
+refId(_time)
+hasInitValue(false)
+
+TIME STEP: const
+= 1
+refId(_time_step)
+hasInitValue(false)
+

--- a/models/comments/expected.mdl
+++ b/models/comments/expected.mdl
@@ -1,0 +1,36 @@
+{UTF-8}
+
+a[DimA]=
+  0,
+  1,
+  2
+	~~|
+
+b = 3
+	~~|
+
+c = 4
+	~~|
+
+d=
+  8760
+	~~|
+
+DimA: A1, A2, A3
+	~~|
+
+e = 41  + 1
+	~~|
+
+FINAL TIME  = 1
+	~~|
+
+INITIAL TIME  = 0
+	~~|
+
+SAVEPER  = 1
+	~~|
+
+TIME STEP  = 1
+	~~|
+

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -6,7 +6,6 @@ const sh = require('shelljs')
 const split = require('split-string')
 const byline = require('byline')
 const XLSX = require('xlsx')
-const num = require('numbro')
 const B = require('bufx')
 
 // Set true to print a stack trace in vlog
@@ -379,6 +378,34 @@ let matchRegexCaptures = (str, regex) => {
     return []
   }
 }
+// Match delimiters recursively. Replace delimited strings globally.
+let replaceDelimitedStrings = (str, open, close, newStr) => {
+  // str is the string to operate on.
+  // open and close are the opening and closing delimiter characters.
+  // newStr is the string to replace delimited substrings with.
+  let result = ''
+  let start = 0
+  let depth = 0
+  let n = str.length
+  for (let i = 0; i < n; i++) {
+    if (str.charAt(i) === open) {
+      if (depth === 0) {
+        result += str.substring(start, i)
+      }
+      depth++
+    } else if (str.charAt(i) === close && depth > 0) {
+      depth--
+      if (depth === 0) {
+        result += newStr
+        start = i + 1
+      }
+    }
+  }
+  if (start < n) {
+    result += str.substring(start)
+  }
+  return result
+}
 
 /**
  * Return the cartesian product of the given array of arrays.
@@ -474,6 +501,7 @@ module.exports = {
   readDat,
   readXlsx,
   replaceInArray,
+  replaceDelimitedStrings,
   rest,
   splitEquations,
   strings,

--- a/src/Preprocessor.js
+++ b/src/Preprocessor.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const R = require('ramda')
 const B = require('bufx')
-const { splitEquations } = require('./Helpers')
+const { splitEquations, replaceDelimitedStrings } = require('./Helpers')
 
 let preprocessModel = (mdlFilename, spec, profile = 'genc', writeFiles = false, outDecls = []) => {
   const MACROS_FILENAME = 'macros.txt'
@@ -134,6 +134,8 @@ let preprocessModel = (mdlFilename, spec, profile = 'genc', writeFiles = false, 
     eqn = eqn.replace('{UTF-8}', '')
     // Remove ":RAW:" flag; it is not needed by SDE and causes problems if left in
     eqn = eqn.replace(/:RAW:/g, '')
+    // Remove inline comments
+    eqn = replaceDelimitedStrings(eqn, '{', '}', '')
     // Remove whitespace
     eqn = eqn.trim()
     if (eqn.length > 0) {


### PR DESCRIPTION
Fixes #73 

This PR changes the preprocessor to remove inline comments from the model before parsing it. A test model is included that illustrates several use cases. A special string scanner function was required because a regular expression could not cover all cases. A regexp would need to be greedy to match the case with nested comments, but cannot be greedy to match the case with two comments in one string.