### PR TITLE
fix: use correct subdimension index for delay aux vars

### DIFF
--- a/models/delay/delay_vars.txt
+++ b/models/delay/delay_vars.txt
@@ -1,301 +1,631 @@
 _aux1: aux
 = delay
 refId(__aux1)
+hasInitValue(false)
+refs(_delay)
 
-_aux10: aux
-= ((delay)/3)
+_aux10[DimA]: aux
+= delay
 refId(__aux10)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(_delay)
 
 _aux11[DimA]: aux
-= _level9[DimA]/((delay a[DimA])/3)
+= delay a[DimA]
 refId(__aux11)
 families(_dima)
 subscripts(_dima)
-refs(__level9)
+hasInitValue(false)
+refs(_delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
 _aux12[DimA]: aux
-= _level10[DimA]/((delay a[DimA])/3)
+= delay
 refId(__aux12)
 families(_dima)
 subscripts(_dima)
-refs(__level10)
+hasInitValue(false)
+refs(_delay)
 
 _aux13[DimA]: aux
-= ((delay a[DimA])/3)
+= delay a[DimA]
 refId(__aux13)
 families(_dima)
 subscripts(_dima)
+hasInitValue(false)
+refs(_delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_aux14[a2]: aux
-= ((delay 2)/3)
-refId(__aux14)
+_aux14[a2]: aux (non-apply-to-all)
+= delay 2
+refId(__aux14[_a2])
 families(_dima)
 subscripts(_a2)
+hasInitValue(false)
+refs(_delay_2)
 
-_aux15[a3]: aux
-= ((delay 2)/3)
-refId(__aux15)
+_aux15[a3]: aux (non-apply-to-all)
+= delay 2
+refId(__aux15[_a3])
 families(_dima)
 subscripts(_a3)
+hasInitValue(false)
+refs(_delay_2)
 
-_aux2[DimA]: aux
-= delay
+_aux16: aux
+= _level12/((delay)/3)
+refId(__aux16)
+hasInitValue(false)
+refs(__level12, _delay)
+
+_aux17: aux
+= _level13/((delay)/3)
+refId(__aux17)
+hasInitValue(false)
+refs(__level13, _delay)
+
+_aux18: aux
+= _level14/((delay)/3)
+refId(__aux18)
+hasInitValue(false)
+refs(__level14, _delay)
+
+_aux19: aux
+= ((delay)/3)
+refId(__aux19)
+hasInitValue(false)
+refs(_delay)
+
+_aux2: aux
+= _level2/((delay)/3)
 refId(__aux2)
+hasInitValue(false)
+refs(__level2, _delay)
+
+_aux20[DimA]: aux
+= _level15[DimA]/((delay a[DimA])/3)
+refId(__aux20)
 families(_dima)
 subscripts(_dima)
+hasInitValue(false)
+refs(__level15, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_aux3[DimA]: aux
-= delay a[DimA]
+_aux21[DimA]: aux
+= _level16[DimA]/((delay a[DimA])/3)
+refId(__aux21)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(__level16, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_aux22[DimA]: aux
+= _level17[DimA]/((delay a[DimA])/3)
+refId(__aux22)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(__level17, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_aux23[DimA]: aux
+= ((delay a[DimA])/3)
+refId(__aux23)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(_delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_aux3: aux
+= _level3/((delay)/3)
 refId(__aux3)
-families(_dima)
-subscripts(_dima)
+hasInitValue(false)
+refs(__level3, _delay)
 
-_aux4[DimA]: aux
-= delay
+_aux4: aux
+= _level4/((delay)/3)
 refId(__aux4)
-families(_dima)
-subscripts(_dima)
+hasInitValue(false)
+refs(__level4, _delay)
 
-_aux5[DimA]: aux
-= delay a[DimA]
+_aux5: aux
+= ((delay)/3)
 refId(__aux5)
+hasInitValue(false)
+refs(_delay)
+
+_aux6[DimA]: aux
+= _level5[DimA]/((delay a[DimA])/3)
+refId(__aux6)
 families(_dima)
 subscripts(_dima)
+hasInitValue(false)
+refs(__level5, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_aux6[SubA]: aux
-= delay 2
-refId(__aux6)
-families(_dima)
-subscripts(_a2)
-separationDims(_suba)
-
-_aux6[SubA]: aux
-= delay 2
-refId(__aux6)
-families(_dima)
-subscripts(_a3)
-separationDims(_suba)
-
-_aux7[SubA]: aux
-= delay 2
+_aux7[DimA]: aux
+= _level6[DimA]/((delay a[DimA])/3)
 refId(__aux7)
 families(_dima)
-subscripts(_a3)
-separationDims(_suba)
+subscripts(_dima)
+hasInitValue(false)
+refs(__level6, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_aux7[SubA]: aux
-= delay 2
-refId(__aux7)
-families(_dima)
-subscripts(_a2)
-separationDims(_suba)
-
-_aux8: aux
-= _level6/((delay)/3)
+_aux8[DimA]: aux
+= _level7[DimA]/((delay a[DimA])/3)
 refId(__aux8)
-refs(__level6)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(__level7, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_aux9: aux
-= _level7/((delay)/3)
+_aux9[DimA]: aux
+= ((delay a[DimA])/3)
 refId(__aux9)
-refs(__level7)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(_delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_aux_d12_1[a2]: aux
+= _level_d12_1[a2]/((delay 2)/3)
+refId(__aux_d12_1)
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(__level_d12_1[_a2], _delay_2)
+
+_aux_d12_1[a3]: aux
+= _level_d12_1[a3]/((delay 2)/3)
+refId(__aux_d12_1)
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(__level_d12_1[_a3], _delay_2)
+
+_aux_d12_2[a2]: aux
+= _level_d12_2[a2]/((delay 2)/3)
+refId(__aux_d12_2)
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(__level_d12_2[_a2], _delay_2)
+
+_aux_d12_2[a3]: aux
+= _level_d12_2[a3]/((delay 2)/3)
+refId(__aux_d12_2)
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(__level_d12_2[_a3], _delay_2)
+
+_aux_d12_3[a2]: aux
+= _level_d12_3[a2]/((delay 2)/3)
+refId(__aux_d12_3)
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(__level_d12_3[_a2], _delay_2)
+
+_aux_d12_3[a3]: aux
+= _level_d12_3[a3]/((delay 2)/3)
+refId(__aux_d12_3)
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(__level_d12_3[_a3], _delay_2)
+
+_aux_d12_4[a2]: aux (non-apply-to-all)
+= ((delay 2)/3)
+refId(__aux_d12_4[_a2])
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(_delay_2)
+
+_aux_d12_4[a3]: aux (non-apply-to-all)
+= ((delay 2)/3)
+refId(__aux_d12_4[_a3])
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(_delay_2)
 
 _aux_d9_1[a2]: aux
 = _level_d9_1[a2]/((delay 2)/3)
 refId(__aux_d9_1)
 families(_dima)
 subscripts(_a2)
-refs(__level_d9_1[_a2])
+hasInitValue(false)
+refs(__level_d9_1[_a2], _delay_2)
 
 _aux_d9_1[a3]: aux
 = _level_d9_1[a3]/((delay 2)/3)
 refId(__aux_d9_1)
 families(_dima)
 subscripts(_a3)
-refs(__level_d9_1[_a3])
-
-_aux_d9_2[a3]: aux
-= _level_d9_2[a3]/((delay 2)/3)
-refId(__aux_d9_2)
-families(_dima)
-subscripts(_a3)
-refs(__level_d9_2[_a3])
+hasInitValue(false)
+refs(__level_d9_1[_a3], _delay_2)
 
 _aux_d9_2[a2]: aux
 = _level_d9_2[a2]/((delay 2)/3)
 refId(__aux_d9_2)
 families(_dima)
 subscripts(_a2)
-refs(__level_d9_2[_a2])
+hasInitValue(false)
+refs(__level_d9_2[_a2], _delay_2)
+
+_aux_d9_2[a3]: aux
+= _level_d9_2[a3]/((delay 2)/3)
+refId(__aux_d9_2)
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(__level_d9_2[_a3], _delay_2)
+
+_aux_d9_3[a2]: aux
+= _level_d9_3[a2]/((delay 2)/3)
+refId(__aux_d9_3)
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(__level_d9_3[_a2], _delay_2)
+
+_aux_d9_3[a3]: aux
+= _level_d9_3[a3]/((delay 2)/3)
+refId(__aux_d9_3)
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(__level_d9_3[_a3], _delay_2)
+
+_aux_d9_4[a2]: aux (non-apply-to-all)
+= ((delay 2)/3)
+refId(__aux_d9_4[_a2])
+families(_dima)
+subscripts(_a2)
+hasInitValue(false)
+refs(_delay_2)
+
+_aux_d9_4[a3]: aux (non-apply-to-all)
+= ((delay 2)/3)
+refId(__aux_d9_4[_a3])
+families(_dima)
+subscripts(_a3)
+hasInitValue(false)
+refs(_delay_2)
 
 _level1: level
 = INTEG(input-d1,input*delay)
 refId(__level1)
+hasInitValue(true)
 refs(_input, _d1)
-initRefs(_input)
+initRefs(_input, _delay)
 
 _level10[DimA]: level
-= INTEG(_aux11[DimA]-_aux12[DimA],_level11[DimA])
+= INTEG(input-d4[DimA],init a[DimA]*delay)
 refId(__level10)
 families(_dima)
 subscripts(_dima)
-refs(__aux11, __aux12)
-initRefs(__level11)
+hasInitValue(true)
+refs(_input, _d4)
+initRefs(_init_a, _delay)
 
 _level11[DimA]: level
-= INTEG(_aux12[DimA]-d8[DimA],input*((delay a[DimA])/3))
+= INTEG(input a[DimA]-d5[DimA],init a[DimA]*delay a[DimA])
 refId(__level11)
 families(_dima)
 subscripts(_dima)
-refs(__aux12, _d8)
-initRefs(_input)
+hasInitValue(true)
+refs(_input_a[_a1], _input_a[_a2], _input_a[_a3], _d5)
+initRefs(_init_a, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_level2[DimA]: level
-= INTEG(input a[DimA]-d2[DimA],init*delay)
+_level12: level
+= INTEG(input-_aux16,input*((delay)/3))
+refId(__level12)
+hasInitValue(true)
+refs(_input, __aux16)
+initRefs(_input, _delay)
+
+_level13: level
+= INTEG(_aux16-_aux17,input*((delay)/3))
+refId(__level13)
+hasInitValue(true)
+refs(__aux16, __aux17)
+initRefs(_input, _delay)
+
+_level14: level
+= INTEG(_aux17-_aux18,input*((delay)/3))
+refId(__level14)
+hasInitValue(true)
+refs(__aux17, __aux18)
+initRefs(_input, _delay)
+
+_level15[DimA]: level
+= INTEG(input-_aux20[DimA],input*((delay a[DimA])/3))
+refId(__level15)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(_input, __aux20)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_level16[DimA]: level
+= INTEG(_aux20[DimA]-_aux21[DimA],input*((delay a[DimA])/3))
+refId(__level16)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(__aux20, __aux21)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_level17[DimA]: level
+= INTEG(_aux21[DimA]-_aux22[DimA],input*((delay a[DimA])/3))
+refId(__level17)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(__aux21, __aux22)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_level2: level
+= INTEG(input-_aux2,input*((delay)/3))
 refId(__level2)
-families(_dima)
-subscripts(_dima)
-refs(_d2)
+hasInitValue(true)
+refs(_input, __aux2)
+initRefs(_input, _delay)
 
-_level3[DimA]: level
-= INTEG(input-d3[DimA],init*delay a[DimA])
+_level3: level
+= INTEG(_aux2-_aux3,input*((delay)/3))
 refId(__level3)
-families(_dima)
-subscripts(_dima)
-refs(_input, _d3)
+hasInitValue(true)
+refs(__aux2, __aux3)
+initRefs(_input, _delay)
 
-_level4[DimA]: level
-= INTEG(input-d4[DimA],init a[DimA]*delay)
+_level4: level
+= INTEG(_aux3-_aux4,input*((delay)/3))
 refId(__level4)
-families(_dima)
-subscripts(_dima)
-refs(_input, _d4)
+hasInitValue(true)
+refs(__aux3, __aux4)
+initRefs(_input, _delay)
 
 _level5[DimA]: level
-= INTEG(input a[DimA]-d5[DimA],init a[DimA]*delay a[DimA])
+= INTEG(input-_aux6[DimA],input*((delay a[DimA])/3))
 refId(__level5)
 families(_dima)
 subscripts(_dima)
-refs(_d5)
+hasInitValue(true)
+refs(_input, __aux6)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_level6: level
-= INTEG(input-_aux8,_level8)
+_level6[DimA]: level
+= INTEG(_aux6[DimA]-_aux7[DimA],input*((delay a[DimA])/3))
 refId(__level6)
-refs(_input, __aux8)
-initRefs(__level8)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(__aux6, __aux7)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_level7: level
-= INTEG(_aux8-_aux9,_level8)
+_level7[DimA]: level
+= INTEG(_aux7[DimA]-_aux8[DimA],input*((delay a[DimA])/3))
 refId(__level7)
-refs(__aux8, __aux9)
-initRefs(__level8)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(__aux7, __aux8)
+initRefs(_input, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
 
-_level8: level
-= INTEG(_aux9-d7,input*((delay)/3))
+_level8[DimA]: level
+= INTEG(input a[DimA]-d2[DimA],init 1*delay)
 refId(__level8)
-refs(__aux9, _d7)
-initRefs(_input)
+families(_dima)
+subscripts(_dima)
+hasInitValue(true)
+refs(_input_a[_a1], _input_a[_a2], _input_a[_a3], _d2)
+initRefs(_init_1, _delay)
 
 _level9[DimA]: level
-= INTEG(input-_aux11[DimA],_level11[DimA])
+= INTEG(input-d3[DimA],init 1*delay a[DimA])
 refId(__level9)
 families(_dima)
 subscripts(_dima)
-refs(_input, __aux11)
-initRefs(__level11)
+hasInitValue(true)
+refs(_input, _d3)
+initRefs(_init_1, _delay_a[_a1], _delay_a[_a2], _delay_a[_a3])
+
+_level_d12_1[a2]: level (non-apply-to-all)
+= INTEG(input 2[a2]-_aux_d12_1[a2],init 2[a2]*((delay 2)/3))
+refId(__level_d12_1[_a2])
+families(_dima)
+subscripts(_a2)
+hasInitValue(true)
+refs(_input_2[_a2], __aux_d12_1)
+initRefs(_init_2[_a2], _delay_2)
+
+_level_d12_1[a3]: level (non-apply-to-all)
+= INTEG(input 2[a3]-_aux_d12_1[a3],init 2[a3]*((delay 2)/3))
+refId(__level_d12_1[_a3])
+families(_dima)
+subscripts(_a3)
+hasInitValue(true)
+refs(_input_2[_a3], __aux_d12_1)
+initRefs(_init_2[_a3], _delay_2)
+
+_level_d12_2[a2]: level (non-apply-to-all)
+= INTEG(_aux_d12_1[a2]-_aux_d12_2[a2],init 2[a2]*((delay 2)/3))
+refId(__level_d12_2[_a2])
+families(_dima)
+subscripts(_a2)
+hasInitValue(true)
+refs(__aux_d12_1, __aux_d12_2)
+initRefs(_init_2[_a2], _delay_2)
+
+_level_d12_2[a3]: level (non-apply-to-all)
+= INTEG(_aux_d12_1[a3]-_aux_d12_2[a3],init 2[a3]*((delay 2)/3))
+refId(__level_d12_2[_a3])
+families(_dima)
+subscripts(_a3)
+hasInitValue(true)
+refs(__aux_d12_1, __aux_d12_2)
+initRefs(_init_2[_a3], _delay_2)
+
+_level_d12_3[a2]: level (non-apply-to-all)
+= INTEG(_aux_d12_2[a2]-_aux_d12_3[a2],init 2[a2]*((delay 2)/3))
+refId(__level_d12_3[_a2])
+families(_dima)
+subscripts(_a2)
+hasInitValue(true)
+refs(__aux_d12_2, __aux_d12_3)
+initRefs(_init_2[_a2], _delay_2)
+
+_level_d12_3[a3]: level (non-apply-to-all)
+= INTEG(_aux_d12_2[a3]-_aux_d12_3[a3],init 2[a3]*((delay 2)/3))
+refId(__level_d12_3[_a3])
+families(_dima)
+subscripts(_a3)
+hasInitValue(true)
+refs(__aux_d12_2, __aux_d12_3)
+initRefs(_init_2[_a3], _delay_2)
 
 _level_d6_1[a2]: level (non-apply-to-all)
 = INTEG(input 2[a2]-d6[a2],init 2[a2]*delay 2)
 refId(__level_d6_1[_a2])
 families(_dima)
 subscripts(_a2)
-refs(_d6[_a2])
+hasInitValue(true)
+refs(_input_2[_a2], _d6[_a2])
+initRefs(_init_2[_a2], _delay_2)
 
 _level_d6_1[a3]: level (non-apply-to-all)
 = INTEG(input 2[a3]-d6[a3],init 2[a3]*delay 2)
 refId(__level_d6_1[_a3])
 families(_dima)
 subscripts(_a3)
-refs(_d6[_a3])
+hasInitValue(true)
+refs(_input_2[_a3], _d6[_a3])
+initRefs(_init_2[_a3], _delay_2)
 
 _level_d9_1[a2]: level (non-apply-to-all)
-= INTEG(input 2[a2]-_aux_d9_1[a2],_level_d9_3[a2])
+= INTEG(input 2[a2]-_aux_d9_1[a2],init 2[a2]*((delay 2)/3))
 refId(__level_d9_1[_a2])
 families(_dima)
 subscripts(_a2)
-refs(__aux_d9_1)
-initRefs(__level_d9_3[_a2])
+hasInitValue(true)
+refs(_input_2[_a2], __aux_d9_1)
+initRefs(_init_2[_a2], _delay_2)
 
 _level_d9_1[a3]: level (non-apply-to-all)
-= INTEG(input 2[a3]-_aux_d9_1[a3],_level_d9_3[a3])
+= INTEG(input 2[a3]-_aux_d9_1[a3],init 2[a3]*((delay 2)/3))
 refId(__level_d9_1[_a3])
 families(_dima)
 subscripts(_a3)
-refs(__aux_d9_1)
-initRefs(__level_d9_3[_a3])
+hasInitValue(true)
+refs(_input_2[_a3], __aux_d9_1)
+initRefs(_init_2[_a3], _delay_2)
 
 _level_d9_2[a2]: level (non-apply-to-all)
-= INTEG(_aux_d9_1[a2]-_aux_d9_2[a2],_level_d9_3[a2])
+= INTEG(_aux_d9_1[a2]-_aux_d9_2[a2],init 2[a2]*((delay 2)/3))
 refId(__level_d9_2[_a2])
 families(_dima)
 subscripts(_a2)
+hasInitValue(true)
 refs(__aux_d9_1, __aux_d9_2)
-initRefs(__level_d9_3[_a2])
+initRefs(_init_2[_a2], _delay_2)
 
 _level_d9_2[a3]: level (non-apply-to-all)
-= INTEG(_aux_d9_1[a3]-_aux_d9_2[a3],_level_d9_3[a3])
+= INTEG(_aux_d9_1[a3]-_aux_d9_2[a3],init 2[a3]*((delay 2)/3))
 refId(__level_d9_2[_a3])
 families(_dima)
 subscripts(_a3)
+hasInitValue(true)
 refs(__aux_d9_1, __aux_d9_2)
-initRefs(__level_d9_3[_a3])
+initRefs(_init_2[_a3], _delay_2)
 
 _level_d9_3[a2]: level (non-apply-to-all)
-= INTEG(_aux_d9_2[a2]-d9[a2],init 2[a2]*((delay 2)/3))
+= INTEG(_aux_d9_2[a2]-_aux_d9_3[a2],init 2[a2]*((delay 2)/3))
 refId(__level_d9_3[_a2])
 families(_dima)
 subscripts(_a2)
-refs(__aux_d9_2, _d9[_a2])
+hasInitValue(true)
+refs(__aux_d9_2, __aux_d9_3)
+initRefs(_init_2[_a2], _delay_2)
 
 _level_d9_3[a3]: level (non-apply-to-all)
-= INTEG(_aux_d9_2[a3]-d9[a3],init 2[a3]*((delay 2)/3))
+= INTEG(_aux_d9_2[a3]-_aux_d9_3[a3],init 2[a3]*((delay 2)/3))
 refId(__level_d9_3[_a3])
 families(_dima)
 subscripts(_a3)
-refs(__aux_d9_2, _d9[_a3])
+hasInitValue(true)
+refs(__aux_d9_2, __aux_d9_3)
+initRefs(_init_2[_a3], _delay_2)
 
 d1: aux
 = DELAY1(input,delay)
 refId(_d1)
+hasInitValue(false)
 refs(__level1, __aux1)
 
+d10: aux
+= k*DELAY3(input,delay)
+refId(_d10)
+hasInitValue(false)
+refs(_k, __level4, __level3, __level2, __aux5)
+
+d11[DimA]: aux
+= k*DELAY3(input,delay a[DimA])
+refId(_d11)
+families(_dima)
+subscripts(_dima)
+hasInitValue(false)
+refs(_k, __level7, __level6, __level5, __aux9[_dima])
+
+d12[SubA]: aux (non-apply-to-all)
+= k*DELAY3I(input 2[SubA],delay 2,init 2[SubA])
+refId(_d12[_a2])
+families(_dima)
+subscripts(_a2)
+separationDims(_suba)
+hasInitValue(false)
+refs(_k, __level_d12_3[_a2], __level_d12_2[_a2], __level_d12_1[_a2], __aux_d12_4[_a2])
+
+d12[SubA]: aux (non-apply-to-all)
+= k*DELAY3I(input 2[SubA],delay 2,init 2[SubA])
+refId(_d12[_a3])
+families(_dima)
+subscripts(_a3)
+separationDims(_suba)
+hasInitValue(false)
+refs(_k, __level_d12_3[_a3], __level_d12_2[_a3], __level_d12_1[_a3], __aux_d12_4[_a3])
+
 d2[DimA]: aux
-= DELAY1I(input a[DimA],delay,init)
+= DELAY1I(input a[DimA],delay,init 1)
 refId(_d2)
 families(_dima)
 subscripts(_dima)
-refs(__level2, __aux2)
+hasInitValue(false)
+refs(__level8, __aux10[_dima])
 
 d3[DimA]: aux
-= DELAY1I(input,delay a[DimA],init)
+= DELAY1I(input,delay a[DimA],init 1)
 refId(_d3)
 families(_dima)
 subscripts(_dima)
-refs(__level3, __aux3)
+hasInitValue(false)
+refs(__level9, __aux11[_dima])
 
 d4[DimA]: aux
 = DELAY1I(input,delay,init a[DimA])
 refId(_d4)
 families(_dima)
 subscripts(_dima)
-refs(__level4, __aux4)
+hasInitValue(false)
+refs(__level10, __aux12[_dima])
 
 d5[DimA]: aux
 = DELAY1I(input a[DimA],delay a[DimA],init a[DimA])
 refId(_d5)
 families(_dima)
 subscripts(_dima)
-refs(__level5, __aux5)
+hasInitValue(false)
+refs(__level11, __aux13[_dima])
 
 d6[SubA]: aux (non-apply-to-all)
 = DELAY1I(input 2[SubA],delay 2,init 2[SubA])
@@ -303,7 +633,8 @@ refId(_d6[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_suba)
-refs(__level_d6_1[_a2], __aux6)
+hasInitValue(false)
+refs(__level_d6_1[_a2], __aux14[_a2])
 
 d6[SubA]: aux (non-apply-to-all)
 = DELAY1I(input 2[SubA],delay 2,init 2[SubA])
@@ -311,19 +642,22 @@ refId(_d6[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_suba)
-refs(__level_d6_1[_a3], __aux7)
+hasInitValue(false)
+refs(__level_d6_1[_a3], __aux15[_a3])
 
 d7: aux
 = DELAY3(input,delay)
 refId(_d7)
-refs(__level8, __level7, __level6, __aux10)
+hasInitValue(false)
+refs(__level14, __level13, __level12, __aux19)
 
 d8[DimA]: aux
 = DELAY3(input,delay a[DimA])
 refId(_d8)
 families(_dima)
 subscripts(_dima)
-refs(__level11, __level10, __level9, __aux13)
+hasInitValue(false)
+refs(__level17, __level16, __level15, __aux23[_dima])
 
 d9[SubA]: aux (non-apply-to-all)
 = DELAY3I(input 2[SubA],delay 2,init 2[SubA])
@@ -331,7 +665,8 @@ refId(_d9[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_suba)
-refs(__level_d9_3[_a2], __level_d9_2[_a2], __level_d9_1[_a2], __aux14)
+hasInitValue(false)
+refs(__level_d9_3[_a2], __level_d9_2[_a2], __level_d9_1[_a2], __aux_d9_4[_a2])
 
 d9[SubA]: aux (non-apply-to-all)
 = DELAY3I(input 2[SubA],delay 2,init 2[SubA])
@@ -339,15 +674,18 @@ refId(_d9[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_suba)
-refs(__level_d9_3[_a3], __level_d9_2[_a3], __level_d9_1[_a3], __aux15)
+hasInitValue(false)
+refs(__level_d9_3[_a3], __level_d9_2[_a3], __level_d9_1[_a3], __aux_d9_4[_a3])
 
 delay: const
 = 5
 refId(_delay)
+hasInitValue(false)
 
 delay 2: const
 = 5
 refId(_delay_2)
+hasInitValue(false)
 
 delay a[DimA]: const (non-apply-to-all)
 = 1,2,3
@@ -355,6 +693,7 @@ refId(_delay_a[_a1])
 families(_dima)
 subscripts(_a1)
 separationDims(_dima)
+hasInitValue(false)
 
 delay a[DimA]: const (non-apply-to-all)
 = 1,2,3
@@ -362,6 +701,7 @@ refId(_delay_a[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_dima)
+hasInitValue(false)
 
 delay a[DimA]: const (non-apply-to-all)
 = 1,2,3
@@ -369,14 +709,17 @@ refId(_delay_a[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_dima)
+hasInitValue(false)
 
 FINAL TIME: const
 = 10
 refId(_final_time)
+hasInitValue(false)
 
-init: const
+init 1: const
 = 0
-refId(_init)
+refId(_init_1)
+hasInitValue(false)
 
 init 2[SubA]: const (non-apply-to-all)
 = 0
@@ -384,6 +727,7 @@ refId(_init_2[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_suba)
+hasInitValue(false)
 
 init 2[SubA]: const (non-apply-to-all)
 = 0
@@ -391,20 +735,24 @@ refId(_init_2[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_suba)
+hasInitValue(false)
 
 init a[DimA]: const
 = 0
 refId(_init_a)
 families(_dima)
 subscripts(_dima)
+hasInitValue(false)
 
 INITIAL TIME: const
 = 0
 refId(_initial_time)
+hasInitValue(false)
 
 input: aux
 = STEP(10,0)-STEP(10,4)
 refId(_input)
+hasInitValue(false)
 
 input 2[SubA]: const (non-apply-to-all)
 = 20,30
@@ -412,6 +760,7 @@ refId(_input_2[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_suba)
+hasInitValue(false)
 
 input 2[SubA]: const (non-apply-to-all)
 = 20,30
@@ -419,6 +768,7 @@ refId(_input_2[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_suba)
+hasInitValue(false)
 
 input a[DimA]: const (non-apply-to-all)
 = 10,20,30
@@ -426,6 +776,7 @@ refId(_input_a[_a1])
 families(_dima)
 subscripts(_a1)
 separationDims(_dima)
+hasInitValue(false)
 
 input a[DimA]: const (non-apply-to-all)
 = 10,20,30
@@ -433,6 +784,7 @@ refId(_input_a[_a2])
 families(_dima)
 subscripts(_a2)
 separationDims(_dima)
+hasInitValue(false)
 
 input a[DimA]: const (non-apply-to-all)
 = 10,20,30
@@ -440,16 +792,26 @@ refId(_input_a[_a3])
 families(_dima)
 subscripts(_a3)
 separationDims(_dima)
+hasInitValue(false)
+
+k: const
+= 42
+refId(_k)
+hasInitValue(false)
 
 SAVEPER: aux
 = TIME STEP
 refId(_saveper)
+hasInitValue(false)
+refs(_time_step)
 
 Time: const
 = 
 refId(_time)
+hasInitValue(false)
 
 TIME STEP: const
 = 1
 refId(_time_step)
+hasInitValue(false)
 

--- a/src/EquationGen.js
+++ b/src/EquationGen.js
@@ -613,12 +613,12 @@ export default class EquationGen extends ModelReader {
       this.emit(smoothVar.varName)
       this.emit(this.rhsSubscriptGen(smoothVar.subscripts))
     } else if (isTrendFunction(fn)) {
-      // For delay  functions, replace the entire call with the expansion variable generated earlier.
+      // For trend functions, replace the entire call with the expansion variable generated earlier.
       let trendVar = Model.varWithRefId(this.var.trendVarName)
       let rhsSubs = this.rhsSubscriptGen(trendVar.subscripts)
       this.emit(`${this.var.trendVarName}${rhsSubs}`)
     } else if (isDelayFunction(fn)) {
-      // For delay  functions, replace the entire call with the expansion variable generated earlier.
+      // For delay functions, replace the entire call with the expansion variable generated earlier.
       let delayVar = Model.varWithRefId(this.var.delayVarRefId)
       let rhsSubs = this.rhsSubscriptGen(delayVar.subscripts)
       this.emit(`(${delayVar.varName}${rhsSubs} / ${this.var.delayTimeVarName}${rhsSubs})`)

--- a/src/EquationReader.js
+++ b/src/EquationReader.js
@@ -455,8 +455,8 @@ export default class EquationReader extends ModelReader {
         }
         if (index) {
           let re = new RegExp(sepDim, 'gi')
-          let newGenSubs = genSubs.replace(re, index)
-          levelLHS = `${level}${newGenSubs}`
+          genSubs = genSubs.replace(re, index)
+          levelLHS = `${level}${genSubs}`
           levelRefId = canonicalVensimName(levelLHS)
           input = input.replace(re, index)
           varLHS = varLHS.replace(re, index)
@@ -474,10 +474,13 @@ export default class EquationReader extends ModelReader {
       // Generate an aux var to hold the delay time expression.
       let delayTimeVarName = newAuxVarName()
       this.var.delayTimeVarName = canonicalName(delayTimeVarName)
+      if (isSeparatedVar(this.var)) {
+        Model.addNonAtoAVar(this.var.delayTimeVarName, [true])
+      }
       let delayTimeEqn = `${delayTimeVarName}${genSubs} = ${delay}`
       this.addVariable(delayTimeEqn)
       // Add a reference to the var, since it won't show up until code gen time.
-      this.var.references.push(this.var.delayTimeVarName)
+      this.var.references.push(canonicalVensimName(`${delayTimeVarName}${genSubs}`))
     } else if (fn === '_DELAY3' || fn === '_DELAY3I') {
       let level1, level1LHS, level1RefId
       let level2, level2LHS, level2RefId
@@ -513,14 +516,14 @@ export default class EquationReader extends ModelReader {
         }
         if (index) {
           let re = new RegExp(sepDim, 'gi')
-          let newGenSubs = genSubs.replace(re, index)
-          level1LHS = `${level1}${newGenSubs}`
-          level2LHS = `${level2}${newGenSubs}`
-          level3LHS = `${level3}${newGenSubs}`
-          aux1LHS = `${aux1}${newGenSubs}`
-          aux2LHS = `${aux2}${newGenSubs}`
-          aux3LHS = `${aux3}${newGenSubs}`
-          aux4LHS = `${aux4}${newGenSubs}`
+          genSubs = genSubs.replace(re, index)
+          level1LHS = `${level1}${genSubs}`
+          level2LHS = `${level2}${genSubs}`
+          level3LHS = `${level3}${genSubs}`
+          aux1LHS = `${aux1}${genSubs}`
+          aux2LHS = `${aux2}${genSubs}`
+          aux3LHS = `${aux3}${genSubs}`
+          aux4LHS = `${aux4}${genSubs}`
           level1RefId = canonicalVensimName(level1LHS)
           level2RefId = canonicalVensimName(level2LHS)
           level3RefId = canonicalVensimName(level3LHS)
@@ -561,9 +564,12 @@ export default class EquationReader extends ModelReader {
       this.addVariable(`${aux3LHS} = ${level3LHS} / ${delay3}`)
       // Generate an aux var to hold the delay time expression.
       this.var.delayTimeVarName = canonicalName(aux4)
+      if (isSeparatedVar(this.var)) {
+        Model.addNonAtoAVar(this.var.delayTimeVarName, [true])
+      }
       this.addVariable(`${aux4LHS} = ${delay3}`)
       // Add a reference to the var, since it won't show up until code gen time.
-      this.var.references.push(this.var.delayTimeVarName)
+      this.var.references.push(canonicalVensimName(`${aux4}${genSubs}`))
     }
   }
   generateDelayLevel(levelLHS, levelRefId, input, aux, init) {


### PR DESCRIPTION
Fixes #91 

The delay test generated NaN values for aux vars subscripted with a subdimension. Aux vars are generated as part of internal delay equation generation. They are added in the analysis stage after the model vars have already been read. The problem was that vars on a subdimension must be separated into individually indexed vars, and this was not being done for the generated aux vars. There is a mechanism to add "non a-to-a" (separated vars in XMILE terminology) after the initial scan of model variables. This was used to add separated aux vars and get the correct refid for references. The DELAY1 and DELAY3 functions both needed this change in somewhat different variations. I regenerated the variable listing too to account for the new aux vars. The delay test now passes without the NaN error messages.