### PR TITLE
fix: allow CSV read exception to propagate instead of catching it

### DIFF
--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -325,13 +325,8 @@ export let readCsv = (pathname, delimiter = ',') => {
     skip_empty_lines: true,
     skip_lines_with_empty_values: true
   }
-  try {
-    let data = B.read(pathname)
-    result = parseCsv(data, CSV_PARSE_OPTS)
-  } catch (error) {
-    console.error(`ERROR: CSV file ${pathname} not found`)
-  }
-  return result
+  let data = B.read(pathname)
+  return parseCsv(data, CSV_PARSE_OPTS)
 }
 // Convert the var name and subscript names to canonical form separately.
 export let canonicalVensimName = vname => {


### PR DESCRIPTION
Removed the try/catch block as agreed.

This is an additional fix for #81 as discussed in PR #82; will be merged into the `todd/81-direct-data-csv` branch.

Chris edit: I'm pasting the additional context from [Todd's comment](https://github.com/climateinteractive/SDEverywhere/pull/82#issuecomment-887027179) from #82:

> I removed the try/catch block around the CSV parse. I tested it with a bad pathname and got the following unhandled exception error message:

```
Error: ENOENT: no such file or directory, open '/Users/toddfincannon/Projects/SDEverywhere/models/directdata/x_data.csv'
```

>  think this is clear enough that we don't need a special error message.