### PR TITLE
feat: allow for selecting different model-check baseline bundle in local dev mode

### DIFF
--- a/examples/hello-world/.gitignore
+++ b/examples/hello-world/.gitignore
@@ -1,1 +1,2 @@
+baselines
 sde-prep

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "sde bundle",
     "dev": "sde dev",
+    "save-baseline": "sde-check baseline --save",
     "serve": "sirv ./sde-prep/check-report"
   },
   "dependencies": {

--- a/examples/sample-check-app/src/index.ts
+++ b/examples/sample-check-app/src/index.ts
@@ -25,10 +25,8 @@ if (suiteSummaryJson) {
 const checkOptions = getConfigOptions(baselineBundle() as Bundle, currentBundle() as Bundle)
 
 // Initialize the root Svelte component
-const appShell = initAppShell(checkOptions, suiteSummary)
-
-document.addEventListener('sde-check-bundle', e => {
-  console.log(e)
+const appShell = initAppShell(checkOptions, {
+  suiteSummary
 })
 
 export default appShell

--- a/examples/sample-check-app/src/index.ts
+++ b/examples/sample-check-app/src/index.ts
@@ -27,4 +27,8 @@ const checkOptions = getConfigOptions(baselineBundle() as Bundle, currentBundle(
 // Initialize the root Svelte component
 const appShell = initAppShell(checkOptions, suiteSummary)
 
+document.addEventListener('sde-check-bundle', e => {
+  console.log(e)
+})
+
 export default appShell

--- a/examples/template-default/.gitignore
+++ b/examples/template-default/.gitignore
@@ -1,3 +1,4 @@
+baselines
 sde-prep
 *.vdf
 *.vdfx

--- a/examples/template-default/package.json
+++ b/examples/template-default/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "sde bundle",
     "dev": "sde dev",
-    "start": "sde dev"
+    "save-baseline": "sde-check baseline --save"
   },
   "workspaces": [
     "packages/core",

--- a/examples/template-minimal/.gitignore
+++ b/examples/template-minimal/.gitignore
@@ -1,1 +1,2 @@
+baselines
 sde-prep

--- a/examples/template-minimal/package.json
+++ b/examples/template-minimal/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "sde bundle",
-    "dev": "sde dev"
+    "dev": "sde dev",
+    "save-baseline": "sde-check baseline --save"
   },
   "dependencies": {
     "@sdeverywhere/build": "^0.2.0",

--- a/packages/check-ui-shell/src/_shared/stores.ts
+++ b/packages/check-ui-shell/src/_shared/stores.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Climate Interactive / New Venture Fund
+
+import type { Writable } from 'svelte/store'
+import { writable } from 'svelte/store'
+
+/**
+ * Return a Svelte writable store that is backed by local storage.
+ */
+export function localStorageWritableBoolean(key: string, defaultValue: boolean): Writable<boolean> {
+  const initialStringValue = localStorage.getItem(key)
+  let initialValue: boolean
+  if (initialStringValue !== undefined) {
+    initialValue = initialStringValue === '1'
+  } else {
+    initialValue = defaultValue
+  }
+
+  let currentValue = initialValue
+  const { subscribe, set } = writable(initialValue)
+
+  const _set = (newValue: boolean) => {
+    currentValue = newValue
+    localStorage.setItem(key, newValue ? '1' : '0')
+    set(newValue)
+  }
+
+  const _update = (updater: (value: boolean) => boolean) => {
+    _set(updater(currentValue))
+  }
+
+  return {
+    subscribe,
+    set: _set,
+    update: _update
+  }
+}

--- a/packages/check-ui-shell/src/app-init.ts
+++ b/packages/check-ui-shell/src/app-init.ts
@@ -7,12 +7,15 @@ import { initAppModel } from './model/app-model'
 import { default as AppShell } from './app-shell.svelte'
 import { AppViewModel } from './app-vm'
 
-export function initAppShell(
-  configOptions: ConfigOptions,
-  suiteSummary?: SuiteSummary,
-  containerId = 'app-shell-container'
-): AppShell {
+export interface AppShellOptions {
+  suiteSummary?: SuiteSummary
+  containerId?: string
+  bundleNames?: string[]
+}
+
+export function initAppShell(configOptions: ConfigOptions, appShellOptions?: AppShellOptions): AppShell {
   // Initialize the root Svelte component
+  const containerId = appShellOptions?.containerId || 'app-shell-container'
   const appShell = new AppShell({
     target: document.getElementById(containerId),
     props: {
@@ -23,8 +26,17 @@ export function initAppShell(
   // Initialize the app model asynchronously
   initAppModel(configOptions)
     .then(appModel => {
-      // Create the app view model and update the AppShell component
-      const appViewModel = new AppViewModel(appModel, suiteSummary)
+      // Create the app view model
+      const appViewModel = new AppViewModel(appModel, appShellOptions?.suiteSummary)
+
+      if (appShellOptions?.bundleNames) {
+        // Set the list of available bundle names
+        // TODO: Pass these to AppViewModel constructor instead of setting them here
+        appViewModel.headerViewModel.bundleNamesL.set(appShellOptions.bundleNames)
+        appViewModel.headerViewModel.bundleNamesR.set(appShellOptions.bundleNames)
+      }
+
+      // Update the AppShell component
       appShell.$set({
         appViewModel
       })

--- a/packages/check-ui-shell/src/app.svelte
+++ b/packages/check-ui-shell/src/app.svelte
@@ -31,12 +31,11 @@ let viewMode: ViewMode = 'summary'
 // occurs more frequently in Firefox and Chrome than in Safari.)  As a workaround,
 // observe loading of the font used by the graphs (Roboto Condensed 400) so
 // that we can wait for it to be loaded before rendering the app.
-// const graphFont = new FontFaceObserver('Roboto Condensed', { weight: 400 })
-// let graphFontReady = false
-// graphFont.load().then(() => {
-//   graphFontReady = true
-// })
-const graphFontReady = true
+const graphFont = new FontFaceObserver('Roboto Condensed', { weight: 400 })
+let graphFontReady = false
+graphFont.load().then(() => {
+  graphFontReady = true
+})
 
 // Wait for the fonts to be loaded before we render the app
 let viewReady = false

--- a/packages/check-ui-shell/src/app.svelte
+++ b/packages/check-ui-shell/src/app.svelte
@@ -31,11 +31,12 @@ let viewMode: ViewMode = 'summary'
 // occurs more frequently in Firefox and Chrome than in Safari.)  As a workaround,
 // observe loading of the font used by the graphs (Roboto Condensed 400) so
 // that we can wait for it to be loaded before rendering the app.
-const graphFont = new FontFaceObserver('Roboto Condensed', { weight: 400 })
-let graphFontReady = false
-graphFont.load().then(() => {
-  graphFontReady = true
-})
+// const graphFont = new FontFaceObserver('Roboto Condensed', { weight: 400 })
+// let graphFontReady = false
+// graphFont.load().then(() => {
+//   graphFontReady = true
+// })
+const graphFontReady = true
 
 // Wait for the fonts to be loaded before we render the app
 let viewReady = false

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-row-vm.ts
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-row-vm.ts
@@ -31,7 +31,8 @@ export function row(
   rowClass: string,
   status: CheckStatus,
   content: string,
-  graphBoxViewModel?: CheckSummaryGraphBoxViewModel
+  graphBoxViewModel?: CheckSummaryGraphBoxViewModel,
+  graphVisible = false
 ): CheckSummaryRowViewModel {
   const whitespace = '&ensp;'.repeat(2 + indent * 4)
   const statusChar = charForStatus(status)
@@ -42,6 +43,6 @@ export function row(
     status,
     span,
     graphBoxViewModel,
-    graphVisible: writable(false)
+    graphVisible: writable(graphVisible)
   }
 }

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-test-vm.ts
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-test-vm.ts
@@ -24,6 +24,8 @@ export function createCheckSummaryTestViewModel(
   dataCoordinator: CheckDataCoordinator,
   test: CheckTestReport
 ): CheckSummaryTestViewModel {
+  let expandedFirstGraph = false
+
   const rows: CheckSummaryRowViewModel[] = []
   const testRow = row(0, 'test', test.status, test.name)
   for (const scenario of test.scenarios) {
@@ -32,6 +34,7 @@ export function createCheckSummaryTestViewModel(
       rows.push(row(2, 'dataset', dataset.status, datasetMessage(dataset, bold)))
       for (const predicate of dataset.predicates) {
         let graphBoxViewModel: CheckSummaryGraphBoxViewModel
+        let graphVisible = false
         if (scenario.checkScenario.scenario && dataset.checkDataset.datasetKey) {
           graphBoxViewModel = new CheckSummaryGraphBoxViewModel(
             dataCoordinator,
@@ -39,8 +42,22 @@ export function createCheckSummaryTestViewModel(
             dataset.checkDataset.datasetKey,
             predicate
           )
+          if (!expandedFirstGraph && predicate.result.status === 'failed') {
+            // Expand the graph for the first failing check
+            expandedFirstGraph = true
+            graphVisible = true
+          }
         }
-        rows.push(row(3, 'predicate', predicate.result.status, predicateMessage(predicate, bold), graphBoxViewModel))
+        rows.push(
+          row(
+            3,
+            'predicate',
+            predicate.result.status,
+            predicateMessage(predicate, bold),
+            graphBoxViewModel,
+            graphVisible
+          )
+        )
       }
     }
   }

--- a/packages/check-ui-shell/src/components/header/header-vm.ts
+++ b/packages/check-ui-shell/src/components/header/header-vm.ts
@@ -7,6 +7,8 @@ import type { CompareConfig } from '@sdeverywhere/check-core'
 export interface HeaderViewModel {
   nameL?: string
   nameR?: string
+  bundleNamesL: Writable<string[]>
+  bundleNamesR: Writable<string[]>
   thresholds?: string[]
   simplifyScenarios?: Writable<boolean>
 }
@@ -19,24 +21,26 @@ export function createHeaderViewModel(
 
   // Only include the comparison-related header elements if the compare
   // config is defined
-  if (compareConfig) {
-    const thresholds = compareConfig.thresholds
-    const thresholdStrings: string[] = []
-    thresholdStrings.push('no diff')
-    for (let i = 0; i < 3; i++) {
-      thresholdStrings.push(`diff &lt; ${thresholds[i]}%`)
-    }
-    thresholdStrings.push(`diff &gt;= ${thresholds[2]}%`)
-
-    return {
-      nameL: compareConfig.bundleL.name,
-      nameR: compareConfig.bundleR.name,
-      thresholds: thresholdStrings,
-      simplifyScenarios
-    }
-  } else {
-    return {
-      simplifyScenarios
-    }
+  // if (compareConfig) {
+  const thresholds = compareConfig.thresholds
+  const thresholdStrings: string[] = []
+  thresholdStrings.push('no diff')
+  for (let i = 0; i < 3; i++) {
+    thresholdStrings.push(`diff &lt; ${thresholds[i]}%`)
   }
+  thresholdStrings.push(`diff &gt;= ${thresholds[2]}%`)
+
+  return {
+    nameL: compareConfig.bundleL.name,
+    nameR: compareConfig.bundleR.name,
+    bundleNamesL: writable([compareConfig.bundleL.name, 'Baseline 2']),
+    bundleNamesR: writable([compareConfig.bundleR.name, 'Baseline 2']),
+    thresholds: thresholdStrings,
+    simplifyScenarios
+  }
+  // } else {
+  //   return {
+  //     simplifyScenarios
+  //   }
+  // }
 }

--- a/packages/check-ui-shell/src/components/header/header-vm.ts
+++ b/packages/check-ui-shell/src/components/header/header-vm.ts
@@ -3,6 +3,7 @@
 import type { Writable } from 'svelte/store'
 import { writable } from 'svelte/store'
 import type { CompareConfig } from '@sdeverywhere/check-core'
+import { localStorageWritableBoolean } from '../../_shared/stores'
 
 export interface HeaderViewModel {
   nameL?: string
@@ -17,7 +18,12 @@ export function createHeaderViewModel(
   compareConfig: CompareConfig | undefined,
   includeSimplifyScenarios: boolean
 ): HeaderViewModel {
-  const simplifyScenarios: Writable<boolean> = includeSimplifyScenarios ? writable(true) : undefined
+  let simplifyScenarios: Writable<boolean>
+  if (includeSimplifyScenarios) {
+    simplifyScenarios = localStorageWritableBoolean('sde-check-simplify-scenarios', true)
+  } else {
+    simplifyScenarios = undefined
+  }
 
   // Only include the comparison-related header elements if the compare
   // config is defined

--- a/packages/check-ui-shell/src/components/header/header-vm.ts
+++ b/packages/check-ui-shell/src/components/header/header-vm.ts
@@ -21,26 +21,28 @@ export function createHeaderViewModel(
 
   // Only include the comparison-related header elements if the compare
   // config is defined
-  // if (compareConfig) {
-  const thresholds = compareConfig.thresholds
-  const thresholdStrings: string[] = []
-  thresholdStrings.push('no diff')
-  for (let i = 0; i < 3; i++) {
-    thresholdStrings.push(`diff &lt; ${thresholds[i]}%`)
-  }
-  thresholdStrings.push(`diff &gt;= ${thresholds[2]}%`)
+  if (compareConfig) {
+    const thresholds = compareConfig.thresholds
+    const thresholdStrings: string[] = []
+    thresholdStrings.push('no diff')
+    for (let i = 0; i < 3; i++) {
+      thresholdStrings.push(`diff &lt; ${thresholds[i]}%`)
+    }
+    thresholdStrings.push(`diff &gt;= ${thresholds[2]}%`)
 
-  return {
-    nameL: compareConfig.bundleL.name,
-    nameR: compareConfig.bundleR.name,
-    bundleNamesL: writable([compareConfig.bundleL.name, 'Baseline 2']),
-    bundleNamesR: writable([compareConfig.bundleR.name, 'Baseline 2']),
-    thresholds: thresholdStrings,
-    simplifyScenarios
+    return {
+      nameL: compareConfig.bundleL.name,
+      nameR: compareConfig.bundleR.name,
+      bundleNamesL: writable([compareConfig.bundleL.name]),
+      bundleNamesR: writable([compareConfig.bundleR.name]),
+      thresholds: thresholdStrings,
+      simplifyScenarios
+    }
+  } else {
+    return {
+      bundleNamesL: writable([]),
+      bundleNamesR: writable([]),
+      simplifyScenarios
+    }
   }
-  // } else {
-  //   return {
-  //     simplifyScenarios
-  //   }
-  // }
 }

--- a/packages/check-ui-shell/src/components/header/header.pug
+++ b/packages/check-ui-shell/src/components/header/header.pug
@@ -1,0 +1,13 @@
+//- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
+
+//- Note: These mixins are kept in an external pug file to work around a
+//- Svelte issue related to `each` and TypeScript, see:
+//-   https://github.com/sveltejs/svelte-preprocess/issues/207
+
+mixin optionsL
+  +each(`$bundleNamesL as name`)
+    option { name }
+
+mixin optionsR
+  +each(`$bundleNamesR as name`)
+    option { name }

--- a/packages/check-ui-shell/src/components/header/header.pug
+++ b/packages/check-ui-shell/src/components/header/header.pug
@@ -6,8 +6,8 @@
 
 mixin optionsL
   +each(`$bundleNamesL as name`)
-    option { name }
+    option(selected!='{name === viewModel.nameL}') { name }
 
 mixin optionsR
   +each(`$bundleNamesR as name`)
-    option { name }
+    option(selected!='{name === viewModel.nameR}') { name }

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -20,28 +20,22 @@ function onHome() {
   dispatch('command', { cmd: 'show-summary' })
 }
 
-function onSelectBundleL(e: Event) {
-  const target = e.target as HTMLSelectElement
-  console.log(target.value)
+function onSelectBundle(kind: string, name: string): void {
   const changeEvent = new CustomEvent('sde-check-bundle', {
     detail: {
-      kind: 'left',
-      name: target.value
+      kind,
+      name
     }
   })
   document.dispatchEvent(changeEvent)
 }
 
+function onSelectBundleL(e: Event) {
+  onSelectBundle('left', (e.target as HTMLSelectElement).value)
+}
+
 function onSelectBundleR(e: Event) {
-  const target = e.target as HTMLSelectElement
-  console.log(target.value)
-  const changeEvent = new CustomEvent('sde-check-bundle', {
-    detail: {
-      kind: 'right',
-      name: target.value
-    }
-  })
-  document.dispatchEvent(changeEvent)
+  onSelectBundle('right', (e.target as HTMLSelectElement).value)
 }
 
 </script>

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -11,11 +11,37 @@ import type { HeaderViewModel } from './header-vm'
 export let viewModel: HeaderViewModel
 const simplifyScenarios = viewModel.simplifyScenarios
 const thresholds = viewModel.thresholds
+const bundleNamesL = viewModel.bundleNamesL
+const bundleNamesR = viewModel.bundleNamesR
 
 const dispatch = createEventDispatcher()
 
 function onHome() {
   dispatch('command', { cmd: 'show-summary' })
+}
+
+function onSelectBundleL(e: Event) {
+  const target = e.target as HTMLSelectElement
+  console.log(target.value)
+  const changeEvent = new CustomEvent('sde-check-bundle', {
+    detail: {
+      kind: 'left',
+      name: target.value
+    }
+  })
+  document.dispatchEvent(changeEvent)
+}
+
+function onSelectBundleR(e: Event) {
+  const target = e.target as HTMLSelectElement
+  console.log(target.value)
+  const changeEvent = new CustomEvent('sde-check-bundle', {
+    detail: {
+      kind: 'right',
+      name: target.value
+    }
+  })
+  document.dispatchEvent(changeEvent)
 }
 
 </script>
@@ -26,6 +52,8 @@ function onHome() {
 <!-- TEMPLATE -->
 <template lang='pug'>
 
+include header.pug
+
 .header-container
   .header-content
     .header-group
@@ -35,12 +63,20 @@ function onHome() {
       .header-group
         input.checkbox(type='checkbox' name='simplify-toggle' bind:checked!='{$simplifyScenarios}')
         label(for='simplify-toggle') Simplify Scenarios
-    +if('viewModel.nameL')
+    +if('viewModel.nameL || $bundleNamesL.length > 1')
       .spacer-fixed
       .header-group
         .label Comparing:
-        .label.dataset-color-0 {viewModel.nameL}
-        .label.dataset-color-1 {viewModel.nameR}
+        +if('$bundleNamesL.length > 1')
+          select.selector.dataset-color-0(on:change!='{onSelectBundleL}')
+            +optionsL
+          +else
+            .label.dataset-color-0 {viewModel.nameL}
+        +if('$bundleNamesR.length > 1')
+          select.selector.dataset-color-1(on:change!='{onSelectBundleR}')
+            +optionsR
+          +else
+            .label.dataset-color-1 {viewModel.nameR}
       .spacer-fixed
       .header-group
         .label Thresholds:
@@ -90,6 +126,20 @@ function onHome() {
 
 .label:not(:last-child)
   margin-right: 1rem
+
+// .label.baseline
+//   cursor: pointer
+//   &:hover
+//     font-weight: 700
+//     color: rgb(219, 72, 101)
+
+select
+  margin-right: 1rem
+  font-family: Roboto, sans-serif
+  font-size: 1em
+  background-color: #353535
+  border: none
+  border-radius: .4rem
 
 .line
   min-height: 1px

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -127,12 +127,6 @@ include header.pug
 .label:not(:last-child)
   margin-right: 1rem
 
-// .label.baseline
-//   cursor: pointer
-//   &:hover
-//     font-weight: 700
-//     color: rgb(219, 72, 101)
-
 select
   margin-right: 1rem
   font-family: Roboto, sans-serif
@@ -142,10 +136,10 @@ select
   -webkit-appearance: none
   -moz-appearance: none
   appearance: none
-  padding: .4rem 1.6rem .4rem .4rem
+  padding: .2rem 1.6rem .2rem .4rem
   background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>") no-repeat
   background-size: .8rem
-  background-position: calc(100% - .4rem) 60%
+  background-position: calc(100% - .4rem) 70%
   background-repeat: no-repeat
   background-color: #353535
   border: none

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -137,6 +137,16 @@ select
   margin-right: 1rem
   font-family: Roboto, sans-serif
   font-size: 1em
+  // XXX: Remove browser-provided background, but preserve arrow; based on:
+  //   https://stackoverflow.com/a/57510283
+  -webkit-appearance: none
+  -moz-appearance: none
+  appearance: none
+  padding: .4rem 1.6rem .4rem .4rem
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>") no-repeat
+  background-size: .8rem
+  background-position: calc(100% - .4rem) 60%
+  background-repeat: no-repeat
   background-color: #353535
   border: none
   border-radius: .4rem

--- a/packages/check-ui-shell/src/components/stats/stats-table-vm.ts
+++ b/packages/check-ui-shell/src/components/stats/stats-table-vm.ts
@@ -24,6 +24,14 @@ export function createStatsTableViewModel(
     return n === 0 ? '' : `${signed(n, 1)}%`
   }
 
+  function pctChange(s0: number, s1: number): number {
+    if (s0 !== 0) {
+      return ((s1 - s0) / s0) * 100
+    } else {
+      return 0
+    }
+  }
+
   const modelSpecL = compareConfig.bundleL.model.modelSpec
   const modelSpecR = compareConfig.bundleR.model.modelSpec
 
@@ -38,17 +46,17 @@ export function createStatsTableViewModel(
   const modelSizeL = modelSpecL.modelSizeInBytes
   const modelSizeR = modelSpecR.modelSizeInBytes
   const modelSizeChange = modelSizeR - modelSizeL
-  const modelSizePctChange = ((modelSizeR - modelSizeL) / modelSizeL) * 100
+  const modelSizePctChange = pctChange(modelSizeL, modelSizeR)
 
   const dataSizeL = modelSpecL.dataSizeInBytes
   const dataSizeR = modelSpecR.dataSizeInBytes
   const dataSizeChange = dataSizeR - dataSizeL
-  const dataSizePctChange = ((dataSizeR - dataSizeL) / dataSizeL) * 100
+  const dataSizePctChange = pctChange(dataSizeL, dataSizeR)
 
   const avgTimeL = perfReportL.avgTime || 0
   const avgTimeR = perfReportR.avgTime || 0
   const avgTimeChange = avgTimeR - avgTimeL
-  const avgTimePctChange = avgTimeL > 0 ? ((avgTimeR - avgTimeL) / avgTimeL) * 100 : 0
+  const avgTimePctChange = pctChange(avgTimeL, avgTimeR)
 
   const minTimeL = perfReportL.minTime
   const minTimeR = perfReportR.minTime

--- a/packages/check-ui-shell/src/global.css
+++ b/packages/check-ui-shell/src/global.css
@@ -56,8 +56,8 @@ sub {
  */
 
 :root {
-  --dataset-0: deepskyblue;
-  --dataset-1: crimson;
+  --dataset-0: crimson;
+  --dataset-1: deepskyblue;
   --bucket-0: green;
   --bucket-1: orange;
   --bucket-2: orangered;

--- a/packages/check-ui-shell/types/index.d.ts
+++ b/packages/check-ui-shell/types/index.d.ts
@@ -2,8 +2,10 @@
 
 import type { ConfigOptions, SuiteSummary } from '@sdeverywhere/check-core'
 
-export function initAppShell(
-  configOptions: ConfigOptions,
-  suiteSummary?: SuiteSummary,
-  containerId = 'app-shell-container'
-): unknown
+export interface AppShellOptions {
+  suiteSummary?: SuiteSummary
+  containerId?: string
+  bundleNames?: string[]
+}
+
+export function initAppShell(configOptions: ConfigOptions, appShellOptions?: AppShellOptions): unknown

--- a/packages/plugin-check/bin/sde-check.js
+++ b/packages/plugin-check/bin/sde-check.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/*
+ * This is the entrypoint for the `sde-check` CLI, which provides commands
+ * that work in conjunction with `@sdeverywhere/plugin-check`.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from 'fs'
+import { join as joinPath } from 'path'
+
+function printUsage() {
+  console.log()
+  console.log('Usage:')
+  console.log('  sim-check baseline --save\t\tcopy the latest bundle to the `baselines` directory')
+  // console.log('  sim-check baseline --clear-all\tremove all bundles from the `baselines` directory')
+  console.log()
+}
+
+function timestamp() {
+  const padL = (nr, len = 2, chr = `0`) => `${nr}`.padStart(len, chr)
+
+  const d = new Date()
+  const year = d.getFullYear()
+  const month = padL(d.getMonth() + 1)
+  const day = padL(d.getDate())
+  const hours = padL(d.getHours())
+  const minutes = padL(d.getMinutes())
+  const seconds = padL(d.getSeconds())
+
+  return `${year}-${month}-${day}--${hours}-${minutes}-${seconds}`
+}
+
+const args = process.argv.slice(2)
+if (args.length !== 2 || args[0] !== 'baseline') {
+  printUsage()
+  process.exit(1)
+}
+
+if (args[1] !== '--save') {
+  printUsage()
+  process.exit(1)
+}
+
+// TODO: For now we make a number of assumptions (e.g., that the bundle will be copied to
+// the `baselines` directory under the current working directory, that the bundle filename
+// will contain the current timestamp); should make these configurable
+const prepDir = joinPath(process.cwd(), 'sde-prep')
+const srcBundleFile = joinPath(prepDir, 'check-bundle.js')
+if (!existsSync(srcBundleFile)) {
+  console.error(`ERROR: No 'check-bundle.js' file found in 'sde-prep' directory`)
+  process.exit(1)
+}
+
+const baselinesDir = joinPath(process.cwd(), 'baselines')
+if (!existsSync(baselinesDir)) {
+  mkdirSync(baselinesDir, { recursive: true })
+}
+
+const dstBundleFile = joinPath(baselinesDir, `${timestamp()}.js`)
+copyFileSync(srcBundleFile, dstBundleFile)

--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -33,11 +33,13 @@
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "@sdeverywhere/check-core": "^0.1.0",
     "@sdeverywhere/check-ui-shell": "^0.1.1",
     "@sdeverywhere/runtime": "^0.1.0",
     "@sdeverywhere/runtime-async": "^0.1.0",
     "assert-never": "^1.2.1",
+    "chokidar": "^3.5.3",
     "picocolors": "^1.0.0",
     "rollup": "^2.76.0",
     "vite": "^3.1.3"

--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -2,6 +2,7 @@
   "name": "@sdeverywhere/plugin-check",
   "version": "0.1.5",
   "files": [
+    "bin/**",
     "dist/**",
     "template-bundle/**",
     "template-report/**",
@@ -17,6 +18,9 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
+  },
+  "bin": {
+    "sde-check": "bin/sde-check.js"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/plugin-check/src/vite-config-for-report.ts
+++ b/packages/plugin-check/src/vite-config-for-report.ts
@@ -49,12 +49,6 @@ export function createViteConfigForReport(
   // Convert the suite summary to JSON, which is what the app currently expects
   const suiteSummaryJson = suiteSummary ? JSON.stringify(suiteSummary) : ''
 
-  function localPackage(...subpath: string[]) {
-    const foo = resolvePath(__dirname, '..', '..', ...subpath)
-    console.log(foo)
-    return foo
-  }
-
   const alias = (find: string, replacement: string) => {
     return {
       find,
@@ -156,9 +150,6 @@ export function createViteConfigForReport(
 
         // Make the overlay use the `messages.html` file that is written to the prep directory
         alias('@_prep_', prepDir),
-
-        // alias('@sdeverywhere/check-core', localPackage('check-core', 'src')),
-        // alias('@sdeverywhere/check-ui-shell', localPackage('check-ui-shell', 'src')),
 
         // XXX: Include no-op polyfills for these modules that are used in the Node-specific
         // implementation of threads.js; this allows us to use one bundle that works in both

--- a/packages/plugin-check/src/vite-config-for-report.ts
+++ b/packages/plugin-check/src/vite-config-for-report.ts
@@ -35,7 +35,6 @@ export function createViteConfigForReport(
   const relProjDirPath = relProjDir.replaceAll('\\', '/')
   // TODO: Use baselinesDir from options
   const baselinesPath = `${relProjDirPath}/baselines/*.js`
-  console.log(baselinesPath)
 
   // Calculate output directory relative to the template root
   let reportPath: string
@@ -128,10 +127,6 @@ export function createViteConfigForReport(
         // don't use it at runtime; we need to exclude it here, otherwise Vite will
         // complain about missing dependencies in dev mode
         'moment'
-
-        // XXX: Prevent Vite from prebundling the local packages
-        // '@sdeverywhere/check-core',
-        // '@sdeverywhere/check-ui-shell'
       ]
     },
 

--- a/packages/plugin-check/template-bundle/src/bundle.ts
+++ b/packages/plugin-check/template-bundle/src/bundle.ts
@@ -21,7 +21,7 @@ import type { Input } from './inputs'
 import { getInputVars, setInputsForScenario } from './inputs'
 import { getOutputVars } from './outputs'
 
-import { startTime, endTime, inputSpecs, outputSpecs } from 'virtual:model-spec'
+import { startTime, endTime, inputSpecs, outputSpecs, modelSizeInBytes, dataSizeInBytes } from 'virtual:model-spec'
 
 import modelWorkerJs from '@_model_worker_/worker.js?raw'
 
@@ -30,14 +30,6 @@ import modelWorkerJs from '@_model_worker_/worker.js?raw'
 // The model-check tools can use this value to skip tests if two bundles
 // have different version numbers.
 const VERSION = 1
-
-// The size (in bytes) of the model file(s), injected at build time.
-const __MODEL_SIZE_IN_BYTES__ = 1
-const modelSizeInBytes = __MODEL_SIZE_IN_BYTES__
-
-// The size (in bytes) of the data file(s), injected at build time.
-const __DATA_SIZE_IN_BYTES__ = 1
-const dataSizeInBytes = __DATA_SIZE_IN_BYTES__
 
 export class BundleModel implements CheckBundleModel {
   private readonly inputs: InputValue[]

--- a/packages/plugin-check/template-bundle/src/empty-model-spec.ts
+++ b/packages/plugin-check/template-bundle/src/empty-model-spec.ts
@@ -13,3 +13,5 @@ export const startTime = 0
 export const endTime = 0
 export const inputSpecs: InputSpec[] = []
 export const outputSpecs: OutputSpec[] = []
+export const modelSizeInBytes = 0
+export const dataSizeInBytes = 0

--- a/packages/plugin-check/template-report/index.html
+++ b/packages/plugin-check/template-report/index.html
@@ -13,6 +13,16 @@
       rel="stylesheet"
     />
 
+    <style>
+      /*
+       * TODO: This avoids white flash when page reloads (due to the CSS bundled with
+       * check-ui-shell being loaded asynchronously); should fix this
+       */
+      body {
+        background-color: #272727;
+      }
+    </style>
+
     <script type="module" src="./src/index.ts"></script>
   </head>
 

--- a/packages/plugin-check/template-report/src/env.d.ts
+++ b/packages/plugin-check/template-report/src/env.d.ts
@@ -2,6 +2,7 @@
 
 // These values are injected by Vite at build time, so we need to
 // declare types for them here
+declare const __BASELINE_BUNDLES_PATH__: string
 declare const __BASELINE_NAME__: string
 declare const __CURRENT_NAME__: string
 declare const __SUITE_SUMMARY_JSON__: string

--- a/packages/plugin-check/template-report/src/index.ts
+++ b/packages/plugin-check/template-report/src/index.ts
@@ -14,17 +14,44 @@ import { createBundle as createBaselineBundle } from '@_baseline_bundle_'
 import { createBundle as createCurrentBundle } from '@_current_bundle_'
 import { getConfigOptions } from '@_test_config_'
 
-// For "production" builds, load the summary from a JSON file that
-// was generated as part of the build process.  This makes the
-// report load almost immediately instead of running all the checks
-// in the user's browser.
-const suiteSummaryJson = __SUITE_SUMMARY_JSON__
-let suiteSummary: SuiteSummary
-if (suiteSummaryJson) {
-  suiteSummary = JSON.parse(suiteSummaryJson) as SuiteSummary
+// Initialize the overlay element used to show builder messages/errors
+initOverlay()
+
+// For local development mode, load the list of available baseline bundles
+let baselineBundleNames: string[]
+let currentBundleNames: string[]
+// TODO: Only do this if baseline bundles path is defined
+// TODO: Sort them alphabetically (reversed, so that newer dates are first)
+// TODO: If no bundles, default to current
+// TODO: If no saved bundle name, default to current
+let selectedBaselineBundleName: string
+let selectedCurrentBundleName: string
+const baselinesPath = __BASELINE_BUNDLES_PATH__
+if (import.meta && baselinesPath) {
+  // Get the available bundles
+  const bundlesGlob = import.meta.glob(__BASELINE_BUNDLES_PATH__, {
+    eager: false
+  })
+  // const baselineBundles: string[] = []
+  console.log(`BUNDLE COUNT: ${Object.keys(bundlesGlob).length}`)
+  for (const bundleKey of Object.keys(bundlesGlob)) {
+    const loadBundle = bundlesGlob[bundleKey]
+    console.log(bundleKey)
+    console.log(loadBundle)
+  }
 }
 
-async function init() {
+async function initForProduction(): Promise<void> {
+  // For "production" builds, load the summary from a JSON file that
+  // was generated as part of the build process.  This makes the
+  // report load almost immediately instead of running all the checks
+  // in the user's browser.
+  const suiteSummaryJson = __SUITE_SUMMARY_JSON__
+  let suiteSummary: SuiteSummary
+  if (suiteSummaryJson) {
+    suiteSummary = JSON.parse(suiteSummaryJson) as SuiteSummary
+  }
+
   // Load the bundles used by the model check/compare configuration.  We
   // always initialize the "current" bundle.
   const bundleR: Bundle = createCurrentBundle()
@@ -48,9 +75,52 @@ async function init() {
 
   // Initialize the root Svelte component
   initAppShell(checkOptions, suiteSummary)
-
-  // Initialize the overlay element used to show builder messages/errors
-  initOverlay()
 }
 
+async function initForLocal(): Promise<void> {
+  // Prepare the model check/compare configuration
+  // XXX: For now, use current vs itself
+  const bundleR: Bundle = createCurrentBundle()
+  const bundleL = bundleR
+  const checkOptions = await getConfigOptions(bundleL, bundleR, {
+    nameL: __CURRENT_NAME__,
+    nameR: __CURRENT_NAME__
+  })
+
+  // Initialize the root Svelte component
+  initAppShell(checkOptions)
+}
+
+async function init() {
+  // Prepare options differently if in local development mode
+  if (import.meta) {
+    await initForLocal()
+  } else {
+    await initForProduction()
+  }
+}
+
+// Initialize the bundles and user interface
 init()
+
+// Reload everything when the user chooses a new baseline or current bundle
+document.addEventListener('sde-check-bundle', e => {
+  // Change the selected bundle
+  const info = (e as CustomEvent).detail
+  if (info.kind === 'left') {
+    selectedBaselineBundleName = info.name
+  } else {
+    selectedCurrentBundleName = info.name
+  }
+
+  // Before switching bundles, clear out the app-shell-container element
+  const container = document.getElementById('app-shell-container')
+  while (container.firstChild) {
+    container.removeChild(container.firstChild)
+  }
+
+  // TODO: Release resources associated with active bundles
+
+  // Reinitialize using the chosen bundles
+  init()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,7 @@ importers:
   packages/plugin-check:
     specifiers:
       '@rollup/plugin-node-resolve': ^13.3.0
+      '@rollup/plugin-replace': ^4.0.0
       '@sdeverywhere/build': workspace:*
       '@sdeverywhere/check-core': ^0.1.0
       '@sdeverywhere/check-ui-shell': ^0.1.1
@@ -264,16 +265,19 @@ importers:
       '@sdeverywhere/runtime-async': ^0.1.0
       '@types/node': ^16.11.7
       assert-never: ^1.2.1
+      chokidar: ^3.5.3
       picocolors: ^1.0.0
       rollup: ^2.76.0
       vite: ^3.1.3
     dependencies:
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.76.0
+      '@rollup/plugin-replace': 4.0.0_rollup@2.76.0
       '@sdeverywhere/check-core': link:../check-core
       '@sdeverywhere/check-ui-shell': link:../check-ui-shell
       '@sdeverywhere/runtime': link:../runtime
       '@sdeverywhere/runtime-async': link:../runtime-async
       assert-never: 1.2.1
+      chokidar: 3.5.3
       picocolors: 1.0.0
       rollup: 2.76.0
       vite: 3.1.3
@@ -522,6 +526,19 @@ packages:
       is-builtin-module: 3.1.0
       is-module: 1.0.0
       resolve: 1.22.0
+      rollup: 2.76.0
+    dev: false
+
+  /@rollup/plugin-replace/4.0.0_rollup@2.76.0:
+    resolution: {integrity: sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.76.0
+      magic-string: 0.25.9
       rollup: 2.76.0
     dev: false
 
@@ -2477,7 +2494,6 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: true
 
   /magic-string/0.26.4:
     resolution: {integrity: sha512-e5uXtVJ22aEpK9u1+eQf0fSxHeqwyV19K+uGnlROCxUhzwRip9tBsaMViK/0vC3viyPd5Gtucp3UmEp/Q2cPTQ==}
@@ -3294,7 +3310,6 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    dev: true
 
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}


### PR DESCRIPTION
Fixes #244 

This improves the `check-ui-shell` package and the model-check report template used by `plugin-check` so that it is now possible for the user to save a baseline bundle and select from a list of available bundles in the report header.  See screenshot below.

The `plugin-check` package now exposes an `sde-check` cli tool that currently only contains one command:

```
sde-check baseline --save
```

This will copy the current `sde-prep/check-bundle.js` file to the `baselines` directory and rename it to include a timestamp.

The report created by `plugin-check` will refresh automatically when bundles are added/removed, and the report will also update when the user chooses a new "baseline" or "current" bundle.

As part of this PR, I also made a few usability improvements in the model-check report that I've been wanting to do for some time:
* swapped the dataset colors ("baseline" is now red, "current" is now blue)
* fixed the bundle generated by `plugin-check` so that it correctly reports the size of the model
* the state of the "Simplify Scenarios" checkbox is preserved when the page is reloaded
* the graph for the first failing check is now expanded/displayed automatically

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/438425/192647063-8160eb23-26e0-4b01-8fdd-1cdeeb6fe2f8.png">
