### PR TITLE
fix: replace hardcoded title in app template

### DIFF
--- a/examples/template-default/packages/app/index.html
+++ b/examples/template-default/packages/app/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>SIR</title>
+    <title>Model Explorer</title>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Fixes #236 

This changes the hardcoded "SIR" that I accidentally left in place when I migrated the old sir app to become the new `template-default`; it now uses the generic "Model Explorer" as the title.
