### PR TITLE
fix: make vite a peer dependency for plugin-vite

### DIFF
--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -28,14 +28,13 @@
     "build": "tsup",
     "ci:build": "run-s clean lint prettier:check test:ci type-check build"
   },
-  "dependencies": {
-    "vite": "^3.1.3"
-  },
   "peerDependencies": {
-    "@sdeverywhere/build": "^0.2.0"
+    "@sdeverywhere/build": "^0.2.0",
+    "vite": "^3.0.0"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*"
+    "@sdeverywhere/build": "*",
+    "vite": "3.1.3"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,11 +317,10 @@ importers:
   packages/plugin-vite:
     specifiers:
       '@sdeverywhere/build': '*'
-      vite: ^3.1.3
-    dependencies:
       vite: 3.1.3
     devDependencies:
       '@sdeverywhere/build': link:../build
+      vite: 3.1.3
 
   packages/plugin-wasm:
     specifiers:


### PR DESCRIPTION
Fixes #268 

Simple fix to make vite a peer dependency instead of hard dependency for plugin-vite.
