### PR TITLE
fix!: change Series.getValueAtTime to work with non-1 save frequency

### DIFF
--- a/packages/runtime/docs/classes/Outputs.md
+++ b/packages/runtime/docs/classes/Outputs.md
@@ -28,29 +28,36 @@ ___
 
 ___
 
-### timeStart
+### startTime
 
- `Readonly` **timeStart**: `number`
+ `Readonly` **startTime**: `number`
 
 ___
 
-### timeEnd
+### endTime
 
- `Readonly` **timeEnd**: `number`
+ `Readonly` **endTime**: `number`
+
+___
+
+### saveFreq
+
+ `Readonly` **saveFreq**: `number` = `1`
 
 ## Constructors
 
 ### constructor
 
-**new Outputs**(`varIds`, `timeStart`, `timeEnd`)
+**new Outputs**(`varIds`, `startTime`, `endTime`, `saveFreq?`)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `varIds` | `string`[] |
-| `timeStart` | `number` |
-| `timeEnd` | `number` |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `varIds` | `string`[] | `undefined` | The output variable identifiers. |
+| `startTime` | `number` | `undefined` | The start time for the model. |
+| `endTime` | `number` | `undefined` | The end time for the model. |
+| `saveFreq` | `number` | `1` | The frequency with which output values are saved (aka `SAVEPER`). |
 
 ## Methods
 
@@ -71,7 +78,7 @@ the time range in the buffer produced by the model.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `outputsBuffer` | `Float64Array` | The raw outputs buffer produced by the model. |
-| `rowLength` | `number` | The number of elements per row (one element per year or save point). |
+| `rowLength` | `number` | The number of elements per row (one element per save point). |
 
 #### Returns
 

--- a/packages/runtime/docs/classes/Series.md
+++ b/packages/runtime/docs/classes/Series.md
@@ -35,7 +35,9 @@ ___
 
 **getValueAtTime**(`time`): `number`
 
-Return the Y value at the given time.
+Return the Y value at the given time.  Note that this does not attempt to interpolate
+if there is no data point defined for the given time and will return undefined in
+that case.
 
 #### Parameters
 
@@ -46,6 +48,9 @@ Return the Y value at the given time.
 #### Returns
 
 `number`
+
+The y value for the given time, or undefined if there is no data point defined
+for the given time.
 
 ___
 

--- a/packages/runtime/docs/interfaces/Point.md
+++ b/packages/runtime/docs/interfaces/Point.md
@@ -10,7 +10,7 @@ A data point.
 
  **x**: `number`
 
-The x value (typically a year).
+The x value (typically a time value).
 
 ___
 

--- a/packages/runtime/src/model-runner/outputs.spec.ts
+++ b/packages/runtime/src/model-runner/outputs.spec.ts
@@ -3,19 +3,60 @@
 import { describe, expect, it } from 'vitest'
 
 import type { Point } from './outputs'
-import { Outputs } from './outputs'
+import { Outputs, Series } from './outputs'
 
 function p(x: number, y: number): Point {
   return { x, y }
 }
 
-describe('Outputs', () => {
-  it('should be initialized with the correct data', () => {
-    const outputVars = ['_temp_change', '_co2_conc']
-    const outputs = new Outputs(outputVars, 1990, 2100)
+describe('Series', () => {
+  describe('getValueAtTime', () => {
+    it('should work with a save frequency of 1.0', () => {
+      const s = new Series('_x', [p(0, 1), p(1, 2), p(2, 4), p(3, 8), p(4, 16)])
+      expect(s.getValueAtTime(0)).toBe(1)
+      expect(s.getValueAtTime(1)).toBe(2)
+      expect(s.getValueAtTime(2)).toBe(4)
+      expect(s.getValueAtTime(3)).toBe(8)
+      expect(s.getValueAtTime(4)).toBe(16)
+      expect(s.getValueAtTime(-1)).toBeUndefined()
+      expect(s.getValueAtTime(2.5)).toBeUndefined()
+      expect(s.getValueAtTime(5)).toBeUndefined()
+    })
 
-    expect(outputs.timeStart).toBe(1990)
-    expect(outputs.timeEnd).toBe(2100)
+    it('should work with a save frequency of 0.5', () => {
+      const s = new Series('_x', [p(0, 1), p(0.5, 2), p(1, 4), p(1.5, 8), p(2, 16)])
+      expect(s.getValueAtTime(0)).toBe(1)
+      expect(s.getValueAtTime(0.5)).toBe(2)
+      expect(s.getValueAtTime(1)).toBe(4)
+      expect(s.getValueAtTime(1.5)).toBe(8)
+      expect(s.getValueAtTime(2)).toBe(16)
+      expect(s.getValueAtTime(-1)).toBeUndefined()
+      expect(s.getValueAtTime(0.25)).toBeUndefined()
+      expect(s.getValueAtTime(5)).toBeUndefined()
+    })
+
+    it('should work with a save frequency of 2.0', () => {
+      const s = new Series('_x', [p(0, 1), p(2, 2), p(4, 4), p(6, 8), p(8, 16)])
+      expect(s.getValueAtTime(0)).toBe(1)
+      expect(s.getValueAtTime(2)).toBe(2)
+      expect(s.getValueAtTime(4)).toBe(4)
+      expect(s.getValueAtTime(6)).toBe(8)
+      expect(s.getValueAtTime(8)).toBe(16)
+      expect(s.getValueAtTime(-1)).toBeUndefined()
+      expect(s.getValueAtTime(1)).toBeUndefined()
+      expect(s.getValueAtTime(5)).toBeUndefined()
+    })
+  })
+})
+
+describe('Outputs', () => {
+  it('should be initialized with the correct data (with save frequency of 1)', () => {
+    const outputVars = ['_temp_change', '_co2_conc']
+    const outputs = new Outputs(outputVars, 1990, 2100, 1)
+
+    expect(outputs.startTime).toBe(1990)
+    expect(outputs.endTime).toBe(2100)
+    expect(outputs.saveFreq).toBe(1)
     expect(outputs.varIds).toEqual(outputVars)
 
     expect(outputs.varSeries.length).toBe(2)
@@ -33,10 +74,34 @@ describe('Outputs', () => {
     }
   })
 
+  it('should be initialized with the correct data (with save frequency of 0.25)', () => {
+    const outputVars = ['_temp_change', '_co2_conc']
+    const outputs = new Outputs(outputVars, 1990, 2000, 0.25)
+
+    expect(outputs.startTime).toBe(1990)
+    expect(outputs.endTime).toBe(2000)
+    expect(outputs.saveFreq).toBe(0.25)
+    expect(outputs.varIds).toEqual(outputVars)
+
+    expect(outputs.varSeries.length).toBe(2)
+    expect(outputs.varSeries[0].varId).toBe('_temp_change')
+    expect(outputs.varSeries[0].points.length).toBe(41)
+    expect(outputs.varSeries[1].varId).toBe('_co2_conc')
+    expect(outputs.varSeries[1].points.length).toBe(41)
+
+    let i = 0
+    for (let time = 1990; time <= 2000; time += 0.25) {
+      const expectedPoint: Point = { x: time, y: 0 }
+      expect(outputs.varSeries[0].points[i]).toEqual(expectedPoint)
+      expect(outputs.varSeries[1].points[i]).toEqual(expectedPoint)
+      i++
+    }
+  })
+
   describe('updateFromBuffer', () => {
     it('should parse a valid model outputs buffer', () => {
       const outputVars = ['_temp_change', '_co2_conc']
-      const outputs = new Outputs(outputVars, 2000, 2005)
+      const outputs = new Outputs(outputVars, 2000, 2005, 1)
 
       const outputValues = [0.2, 0.4, 1.0, 2.0, 2.2, 2.5, 400, 450, 500, 510, 520, 530]
       const rowLength = 6
@@ -48,8 +113,9 @@ describe('Outputs', () => {
 
       const actual = outputs
 
-      expect(actual.timeStart).toBe(2000)
-      expect(actual.timeEnd).toBe(2005)
+      expect(actual.startTime).toBe(2000)
+      expect(actual.endTime).toBe(2005)
+      expect(actual.saveFreq).toBe(1)
       expect(actual.varIds).toEqual(outputVars)
 
       expect(actual.varSeries.length).toBe(2)
@@ -75,7 +141,7 @@ describe('Outputs', () => {
 
     it('should store invalid values as undefined', () => {
       const outputVars = ['_temp_change']
-      const outputs = new Outputs(outputVars, 2000, 2003)
+      const outputs = new Outputs(outputVars, 2000, 2003, 1)
 
       const outputValues = [Number.NaN, -Number.MAX_VALUE, -2e32, 2.5]
       const rowLength = 4
@@ -87,8 +153,9 @@ describe('Outputs', () => {
 
       const actual = outputs
 
-      expect(actual.timeStart).toBe(2000)
-      expect(actual.timeEnd).toBe(2003)
+      expect(actual.startTime).toBe(2000)
+      expect(actual.endTime).toBe(2003)
+      expect(actual.saveFreq).toBe(1)
       expect(actual.varIds).toEqual(outputVars)
 
       expect(actual.varSeries.length).toBe(1)
@@ -103,7 +170,7 @@ describe('Outputs', () => {
 
     it('should parse buffer with ok result if it contains more data points than the Outputs instance', () => {
       const outputVars = ['_temp_change', '_co2_conc']
-      const outputs = new Outputs(outputVars, 2000, 2002)
+      const outputs = new Outputs(outputVars, 2000, 2002, 1)
 
       const outputValues = [0.2, 0.4, 1.0, 1.5, 400, 450, 500, 600]
       const rowLength = 4
@@ -115,8 +182,9 @@ describe('Outputs', () => {
 
       const actual = outputs
 
-      expect(actual.timeStart).toBe(2000)
-      expect(actual.timeEnd).toBe(2002)
+      expect(actual.startTime).toBe(2000)
+      expect(actual.endTime).toBe(2002)
+      expect(actual.saveFreq).toBe(1)
       expect(actual.varIds).toEqual(outputVars)
 
       expect(actual.varSeries.length).toBe(2)
@@ -126,9 +194,24 @@ describe('Outputs', () => {
       expect(actual.varSeries[1].points).toEqual([p(2000, 400), p(2001, 450), p(2002, 500)])
     })
 
-    it('should return error if buffer contains too few data points', () => {
+    it('should return error if buffer contains too few data points (with save frequency of 1)', () => {
       const outputVars = ['_temp_change', '_co2_conc']
-      const outputs = new Outputs(outputVars, 2000, 2002)
+      const outputs = new Outputs(outputVars, 2000, 2002, 1)
+
+      const outputValues = [0.2, 0.4, 400, 450]
+      const rowLength = 2
+
+      const result = outputs.updateFromBuffer(new Float64Array(outputValues), rowLength)
+      if (result.isOk()) {
+        throw new Error('updateFromBuffer did not return error as expected')
+      }
+
+      expect(result.error).toBe('invalid-point-count')
+    })
+
+    it('should return error if buffer contains too few data points (with save frequency of 0.25)', () => {
+      const outputVars = ['_temp_change', '_co2_conc']
+      const outputs = new Outputs(outputVars, 2000, 2001, 0.25)
 
       const outputValues = [0.2, 0.4, 400, 450]
       const rowLength = 2


### PR DESCRIPTION
Fixes #259

BREAKING-CHANGE: This renames Outputs timeStart/timeEnd to startTime/endTime and adds a saveFreq argument (defaults to 1).

This primarily fixes an issue with `Series.getValueAtTime` where it previously assumed that the output data had a save frequency (`SAVEPER`) of 1.  It now handles arbitrary save frequency values, and does a linear search instead of assuming that it can jump to a particular index.  (Binary search can come later.)

To make this work, I added a `saveFreq` argument to the `Outputs` constructor.  While I was at it, I renamed the `timeStart` and `timeEnd` fields on `Outputs` to be `startTime` and `endTime` to be consistent with other uses.  (These fields aren't typically accessed but will remain public, and thus the breaking change.)

Note that the rest of the runtime and build packages still need more work to handle non-1 `SAVEPER` values.  That work will be completed soon under separate issue #291.