### PR TITLE
feat: expose accessor functions for control parameters

### DIFF
--- a/packages/cli/src/c/sde.h
+++ b/packages/cli/src/c/sde.h
@@ -50,7 +50,7 @@ EXTERN double _final_time;
 EXTERN double _time_step;
 EXTERN double _saveper;
 
-// API
+// API (defined in model.h)
 char* run_model(const char* inputs);
 void runModelWithBuffers(double* inputs, double* outputs);
 void run(void);
@@ -58,7 +58,12 @@ void startOutput(void);
 void outputVar(double value);
 void finish(void);
 
-// Functions implemented by the model
+// API (defined by the generated model)
+double getInitialTime(void);
+double getFinalTime(void);
+double getSaveper(void);
+
+// Functions implemented by the generated model
 void initConstants(void);
 void initLevels(void);
 void setInputs(const char* inputData);

--- a/packages/compile/src/generate/code-gen.js
+++ b/packages/compile/src/generate/code-gen.js
@@ -42,6 +42,7 @@ let codeGenerator = (parseTree, opts) => {
       } else if (operation === 'generateC') {
         // Generate code for each variable in the proper order.
         let code = emitDeclCode()
+        code += emitGetControlValuesCode()
         code += emitInitLookupsCode()
         code += emitInitConstantsCode()
         code += emitInitLevelsCode()
@@ -78,6 +79,55 @@ ${dimensionMappingsSection()}
 // Lookup data arrays
 ${section(Model.lookupVars())}
 ${section(Model.dataVars())}
+
+`
+  }
+
+  //
+  // Control value getters section
+  //
+  function emitGetControlValuesCode() {
+    function getConstTimeValue(vensimName) {
+      const v = Model.varWithName(Model.cName(vensimName))
+      if (v && v.varType === 'const') {
+        return v.modelFormula
+      } else {
+        throw new Error(`SDE only supports ${vensimName} defined as a constant value`)
+      }
+    }
+
+    function getSaveperValue() {
+      const v = Model.varWithName('_saveper')
+      if (v && v.varType === 'const') {
+        return v.modelFormula
+      } else if (v && v.varType === 'aux' && v.modelFormula === 'TIME STEP') {
+        return getConstTimeValue('TIME STEP')
+      } else {
+        throw new Error(`SDE only supports SAVEPER defined as TIME STEP or a constant value`)
+      }
+    }
+
+    // For now we only allow models that have:
+    //   INITIAL TIME = a constant value
+    //   FINAL TIME = a constant value
+    //   SAVEPER = a constant value or constant `TIME STEP`
+    // If the model does not meet these expectations, we throw an error.
+    // TODO: Loosen this up to allow for certain common constant expressions
+    const initialTimeValue = getConstTimeValue('INITIAL TIME')
+    const finalTimeValue = getConstTimeValue('FINAL TIME')
+    const saveperValue = getSaveperValue('SAVEPER')
+
+    return `
+// Control parameter accessors
+double getInitialTime() {
+  return ${initialTimeValue};
+}
+double getFinalTime() {
+  return ${finalTimeValue};
+}
+double getSaveper() {
+  return ${saveperValue};
+}
 
 `
   }


### PR DESCRIPTION
Fixes #295 

This changes the code gen to emit 3 new accessors that allow the `runtime` and `runtime-async` packages to more easily read the control parameters (`INITIAL TIME`, `FINAL TIME`, and `SAVEPER`) prior to running the model for correctly sizing the allocated buffers that hold output values.  See issue for more details.

There are no tests included here, but I've already verified that this works on my other branch for #291, and that branch also includes automated JS-level integration tests that verify the behavior.

@ToddFincannonEI: It would be great if you could review this change if you've got time.  I decided to split it out from my other changes for #291 (supporting non-1 `SAVEPER` values in the runtime packages) because these 2 files are the only ones that I touched in the `cli` and `compile` packages.  That way you only have to review 2 files, and I'll submit/merge the other build/runtime changes once this PR is merged.  Also, having these changes broken out makes it easier to highlight this as a separate "feature" in the changelog that's independent from the other changes.
