### PR TITLE
build: add separate job to build workflow for running JS-level integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,12 @@ on:
     branches-ignore:
       - main
 
+env:
+  EM_DIR: 'emsdk'
+  EM_VERSION: 2.0.34
+  # This is an additional key that can be used to invalidate the emsdk cache when needed
+  EM_KEY: 'v1'
+
 jobs:
   # The `build` job builds and tests all packages in the monorepo
   build:
@@ -78,10 +84,10 @@ jobs:
         run: |
           ./scripts/ci-build
 
-  # The `test_e2e` job runs the model tests.  This job runs in parallel with the `build`
-  # job (which cuts down on overall time to execute the workflow) because it only needs
-  # to build a subset of the packages in order to run the integration tests.
-  test_e2e:
+  # The `test_c` job runs the C-level integration tests.  This job runs in parallel with
+  # the other jobs (which cuts down on overall time to execute the workflow) because it
+  # only needs to build a subset of the packages in order to run the integration tests.
+  test_c:
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 20
     strategy:
@@ -140,4 +146,78 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: |
-          ./scripts/ci-test-e2e
+          ./scripts/ci-run-c-int-tests
+
+  # The `test_js` job runs the JS-level integration tests.  This job runs in parallel with
+  # the other jobs (which cuts down on overall time to execute the workflow) because it
+  # only needs to build a subset of the packages in order to run the integration tests.
+  test_js:
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        config:
+          - { plat: 'linux', os: 'ubuntu-20.04' }
+          # - { plat: 'mac', os: 'macos-10.15' }
+          # - { plat: 'win', os: 'windows-2019' }
+    steps:
+      # Force Unix-style line endings (otherwise Prettier checks will fail on Windows)
+      - name: Configure git to use Unix-style line endings
+        if: matrix.config.plat == 'win'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Enable Emscripten cache
+        uses: actions/cache@v3
+        with:
+          path: ${{env.EM_DIR}}
+          key: emsdk-app-${{env.EM_VERSION}}-${{env.EM_KEY}}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      # The pnpm caching strategy in the following steps is based on:
+      #   https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7
+
+      - name: Configure pnpm
+        if: matrix.config.plat == 'win'
+        run: |
+          # Force pnpm to use bash shell for running scripts on Windows
+          pnpm config set script-shell bash
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Enable pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          pnpm install
+
+      - name: Install Emscripten
+        run: |
+          ./scripts/install-emsdk
+
+      - name: Run integration tests
+        shell: bash
+        run: |
+          ./scripts/ci-run-js-int-tests

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ removals.txt
 # Logs
 npm-debug.log*
 # Dependency directories
+emsdk
 node_modules

--- a/scripts/ci-run-c-int-tests
+++ b/scripts/ci-run-c-int-tests
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJ_DIR=$SCRIPT_DIR/..
+
+set -e # fail on error
+set -x # include all commands in logs
+
+cd "$PROJ_DIR"
+
+# Build the `@sdeverywhere/build` package, which is the only one that needs to be
+# built prior to running the C-level model tests.  (The model tests do depend on the
+# `compile` and `cli` packages, but those don't currently have a build step since
+# they are pure JavaScript.)
+pnpm -F build build
+
+# Run the C-level model/integration tests
+pnpm run test:c-int
+
+# Fail the build if there are any untracked or modified files.  This usually
+# only occurs if the typedoc-generated docs need updating after any API
+# changes.  (We currently keep the generated API docs as tracked files in
+# the repo, and updating them is a manual step.)
+set +e
+set +x
+if [[ -n "$(git status --porcelain)" ]]; then
+echo
+  echo "ERROR: There are untracked or modified files reported by git"
+  echo
+  git status
+  echo
+  exit 1
+fi

--- a/scripts/ci-run-js-int-tests
+++ b/scripts/ci-run-js-int-tests
@@ -8,16 +8,15 @@ set -x # include all commands in logs
 
 cd "$PROJ_DIR"
 
-# Build the `@sdeverywhere/build` package, which is the only one that needs to be
-# built prior to running the C-level model tests.  (The model tests do depend on the
-# `compile` and `cli` packages, but those don't currently have a build step since
-# they are pure JavaScript.)
+# Build the subset of packages that are required for running the JS-level
+# integration tests
 pnpm -F build build
+pnpm -F plugin-wasm build
+pnpm -F plugin-worker build
+pnpm -F runtime build
+pnpm -F runtime-async build
 
-# Run the C-level model tests
-pnpm run test:c-int
-
-# Run the JS-level integration tests (that exercise the build and runtime packages)
+# Run the JS-level integration tests that exercise the build and runtime packages
 pnpm run test:js-int
 
 # Fail the build if there are any untracked or modified files.  This usually

--- a/scripts/install-emsdk
+++ b/scripts/install-emsdk
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#
+# This script installs the Emscripten SDK to the `emsdk` directory under
+# the current directory (if `emsdk` is not already present), then
+# activates the requested version (specified with EM_VERSION).
+#
+# The implementation is similar to the existing `setup-emsdk` action
+# (https://github.com/mymindstorm/setup-emsdk) except that one has issues
+# with the cache directory on Windows, so having our own script gives us
+# more control over installation and caching behavior.
+#
+
+if [[ -z $EM_VERSION ]]; then
+  echo "ERROR: Must specify EM_VERSION"
+  exit 1
+fi
+
+# If EM_DIR is not specified, use the `emsdk` directory under the current one
+if [[ -z $EM_DIR ]]; then
+  EM_DIR=$PWD/emsdk
+fi
+
+set -e # fail on error
+#set -x # include all commands in logs
+
+echo
+echo "Python info:"
+set +e
+which python3
+python3 --version
+set -e
+
+emsdk_cmd() {
+  # XXX: Workaround for installing locally when python path is not executable
+  # if [[ PLATFORM == "win" ]]; then
+  #   winpty python.exe emsdk.py $@
+  # else
+    python3 emsdk.py $@
+  # fi
+}
+
+# Only download if the emsdk directory wasn't restored from a cache
+echo
+if [[ ! -d "$EM_DIR" ]]; then
+  echo "Downloading Emscripten SDK to $EM_DIR"
+  echo
+  git clone https://github.com/emscripten-core/emsdk.git "$EM_DIR"
+else
+  echo "Found existing Emscripten SDK directory: $EM_DIR"
+fi
+echo
+
+cd "$EM_DIR"
+if [[ $CI == true ]]; then
+  # On GitHub Actions, remove the `.git` directory to keep the cache smaller.
+  # When we update to a new version, the cache key will miss and the emsdk
+  # repo will be redownloaded.
+  echo "CI detected, removing .git directory..."
+  rm -rf .git
+  echo
+else
+  # For local development, pull to get the latest
+  echo "Local development detected, performing git pull..."
+  git pull
+  echo
+fi
+
+echo "Activating Emscripten SDK $EM_VERSION..."
+emsdk_cmd install $EM_VERSION
+emsdk_cmd activate $EM_VERSION
+echo

--- a/tests/run-js-int-tests
+++ b/tests/run-js-int-tests
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-# TODO: Run the JS-level integration tests here.  Before we add this step,
-# we first need to change the ci-test-e2e script to build the minimal set
-# of packages that are required to run the JS-level tests:
-#   build
-#   plugin-wasm
-#   plugin-worker
-# Also, to run this in GitHub Actions, we need to change the workflow to
-# install the Emscripten SDK.
+set -e # fail on error
+set -x # include all commands in logs
+
+# TODO: Run integration tests here


### PR DESCRIPTION
Fixes #275 

This makes the necessary changes to the GitHub Actions `build` workflow to have separate jobs for the C-level and JS-level integration tests.  The new `test_js` installs the Emscripten SDK, which is required for building the wasm models used by the JS-level tests.

I didn't hook it up to an actual test in this PR, but the first one is arriving shortly with the `SAVEPER` fixes.
