### PR TITLE
fix: upgrade csv-parse to 5.3.3 and update option names

### DIFF
--- a/packages/compile/src/_shared/helpers.js
+++ b/packages/compile/src/_shared/helpers.js
@@ -225,7 +225,7 @@ export let readCsv = (pathname, delimiter = ',') => {
       columns: false,
       trim: true,
       skip_empty_lines: true,
-      skip_lines_with_empty_values: true
+      skip_records_with_empty_values: true
     }
     try {
       let data = B.read(pathname)

--- a/packages/plugin-config/package.json
+++ b/packages/plugin-config/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "byline": "^5.0.0",
-    "csv-parse": "^4.15.4",
+    "csv-parse": "^5.3.3",
     "sanitize-html": "^2.7.1"
   },
   "peerDependencies": {

--- a/packages/plugin-config/src/context.ts
+++ b/packages/plugin-config/src/context.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from 'fs'
 import { join as joinPath, relative } from 'path'
 
-import parseCsv from 'csv-parse/lib/sync.js'
+import { parse as parseCsv } from 'csv-parse/sync'
 
 import type { BuildContext, InputSpec, LogLevel, OutputSpec } from '@sdeverywhere/build'
 

--- a/packages/plugin-config/src/context.ts
+++ b/packages/plugin-config/src/context.ts
@@ -174,7 +174,7 @@ function readCsvFile(path: string): CsvRow[] {
     columns: true,
     trim: true,
     skip_empty_lines: true,
-    skip_lines_with_empty_values: true
+    skip_records_with_empty_values: true
   })
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,13 +295,13 @@ importers:
       '@types/sanitize-html': ^2.6.2
       '@types/temp': ^0.9.1
       byline: ^5.0.0
-      csv-parse: ^4.15.4
+      csv-parse: ^5.3.3
       dedent: ^0.7.0
       sanitize-html: ^2.7.1
       temp: ^0.9.4
     dependencies:
       byline: 5.0.0
-      csv-parse: 4.16.3
+      csv-parse: 5.3.3
       sanitize-html: 2.7.1
     devDependencies:
       '@sdeverywhere/build': link:../build
@@ -1261,10 +1261,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  /csv-parse/4.16.3:
-    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
-    dev: false
 
   /csv-parse/5.3.3:
     resolution: {integrity: sha512-kEWkAPleNEdhFNkHQpFHu9RYPogsFj3dx6bCxL847fsiLgidzWg0z/O0B1kVWMJUc5ky64zGp18LX2T3DQrOfw==}


### PR DESCRIPTION
Fixes #299 

This upgrades `csv-parse` to the latest 5.3.3 in the `plugin-config` package.  I also had to update both uses of this package in the `plugin-config` and `compile` packages to use the new name for one option that was renamed in 5.x (use `skip_records_with_empty_values` instead of `skip_lines_with_empty_values`).

Tests are all passing; I will merge this right away so that I can publish new versions of these and other packages.

/cc @ToddFincannonEI 
