### PR TITLE
fix: code generation with spec and model using GET DIRECT DATA and/or GET DIRECT LOOKUPS

### DIFF
--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -361,8 +361,9 @@ function removeUnusedVariables(spec) {
     }
   }
 
-  // Filter out unneeded variables so we're left with the minimal set of variables to emit
-  variables = R.filter(v => referencedVarNames.includes(v.varName), variables)
+  // Keep vars with directDatArgs (GET DIRECT DATA and GET DIRECT LOOKUPS) 
+  // and filter out unneeded variables so we're left with the minimal set of variables to emit
+  variables = R.filter(v => !R.isEmpty(v.directDataArgs) || referencedVarNames.includes(v.varName), variables)
 
   // Rebuild the variables-by-name map
   variablesByName.clear()


### PR DESCRIPTION
Issue: if a model has direct lookups, like the following:
`sample value = GET DIRECT LOOKUPS( 'sample.csv' , ',' , 'A', 'C2' )`
then when generating the code with a spec the variable is removed (no code generated).

