### PR TITLE
docs: add API docs for all plugin packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
     "tsup": "^6.2.3",
-    "typedoc": "^0.22.17",
-    "typedoc-plugin-markdown": "^3.12.1",
+    "typedoc": "0.23.28",
+    "typedoc-plugin-markdown": "3.14.0",
     "typescript": "^4.7.3",
     "vitest": "^0.23.4"
   },

--- a/packages/build/docs/classes/BuildContext.md
+++ b/packages/build/docs/classes/BuildContext.md
@@ -11,6 +11,8 @@ This is passed to most plugin functions.
 
  `Readonly` **config**: [`ResolvedConfig`](../interfaces/ResolvedConfig.md)
 
+The resolved configuration.
+
 ## Methods
 
 ### log

--- a/packages/build/docs/interfaces/UserConfig.md
+++ b/packages/build/docs/interfaces/UserConfig.md
@@ -60,24 +60,28 @@ ___
 The array of plugins that are used to customize the build process.  These will be
 executed in the order defined here.
 
-## Methods
+___
 
 ### modelSpec
 
-**modelSpec**(`context`): `Promise`<[`ModelSpec`](ModelSpec.md)\>
+ **modelSpec**: (`context`: [`BuildContext`](../classes/BuildContext.md)) => `Promise`<[`ModelSpec`](ModelSpec.md)\>
+
+#### Type declaration
+
+(`context`): `Promise`<[`ModelSpec`](ModelSpec.md)\>
 
 Called before the "generate model" steps are performed.
 
 You must implement this function so that the generated model is
 configured with the desired inputs and outputs.
 
-#### Parameters
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `context` | [`BuildContext`](../classes/BuildContext.md) |
 
-#### Returns
+##### Returns
 
 `Promise`<[`ModelSpec`](ModelSpec.md)\>
 

--- a/packages/build/src/plugin/plugin.ts
+++ b/packages/build/src/plugin/plugin.ts
@@ -37,7 +37,7 @@ export interface Plugin {
    * @param context The build context (for logging, etc).
    * @param modelSpec The spec that controls how the model is generated.
    */
-  preGenerate?: (context: BuildContext, modelSpec: ModelSpec) => Promise<void>
+  preGenerate?(context: BuildContext, modelSpec: ModelSpec): Promise<void>
 
   /**
    * Called before SDE preprocesses the mdl file (in the case of one mdl file),
@@ -45,7 +45,7 @@ export interface Plugin {
    *
    * @param context The build context (for logging, etc).
    */
-  preProcessMdl?: (context: BuildContext) => Promise<void>
+  preProcessMdl?(context: BuildContext): Promise<void>
 
   /**
    * Called after SDE preprocesses the mdl file (in the case of one mdl file),
@@ -55,14 +55,14 @@ export interface Plugin {
    * @param mdlContent The resulting mdl file content.
    * @return The modified mdl file content (if postprocessing was needed).
    */
-  postProcessMdl?: (context: BuildContext, mdlContent: string) => Promise<string>
+  postProcessMdl?(context: BuildContext, mdlContent: string): Promise<string>
 
   /**
    * Called before SDE generates a C file from the mdl file.
    *
    * @param context The build context (for logging, etc).
    */
-  preGenerateC?: (context: BuildContext) => Promise<void>
+  preGenerateC?(context: BuildContext): Promise<void>
 
   /**
    * Called after SDE generates a C file from the mdl file.
@@ -71,7 +71,7 @@ export interface Plugin {
    * @param cContent The resulting C file content.
    * @return The modified C file content (if postprocessing was needed).
    */
-  postGenerateC?: (context: BuildContext, cContent: string) => Promise<string>
+  postGenerateC?(context: BuildContext, cContent: string): Promise<string>
 
   /**
    * Called after the "generate model" process has completed (but before the staged
@@ -82,7 +82,7 @@ export interface Plugin {
    * @return Whether the plugin succeeded (for example, a plugin that runs tests can
    * return false to indicate that one or more tests failed).
    */
-  postGenerate?: (context: BuildContext, modelSpec: ModelSpec) => Promise<boolean>
+  postGenerate?(context: BuildContext, modelSpec: ModelSpec): Promise<boolean>
 
   /**
    * Called after the model has been generated and after the staged files

--- a/packages/check-ui-shell/.gitignore
+++ b/packages/check-ui-shell/.gitignore
@@ -1,1 +1,3 @@
 dist
+docs/*
+!docs/index.md

--- a/packages/check-ui-shell/.prettierignore
+++ b/packages/check-ui-shell/.prettierignore
@@ -1,3 +1,4 @@
 dist
+docs
 **/*.svelte
 CHANGELOG.md

--- a/packages/check-ui-shell/docs/index.md
+++ b/packages/check-ui-shell/docs/index.md
@@ -1,4 +1,4 @@
-# @sdeverywhere/check-core
+# @sdeverywhere/check-ui-shell
 
-Note: The `check-core` API has not yet stabilized, so documentation is not provided at this time.
+Note: The `check-ui-shell` API has not yet stabilized, so documentation is not provided at this time.
 If you would like to help with this task, please get in touch on the [discussion board](https://github.com/climateinteractive/SDEverywhere/discussions).

--- a/packages/check-ui-shell/package.json
+++ b/packages/check-ui-shell/package.json
@@ -21,7 +21,8 @@
     "test:ci": "vitest run",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "vite build",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
     "@sdeverywhere/check-core": "^0.1.0",

--- a/packages/plugin-check/docs/functions/checkPlugin.md
+++ b/packages/plugin-check/docs/functions/checkPlugin.md
@@ -1,0 +1,15 @@
+[@sdeverywhere/plugin-check](../index.md) / checkPlugin
+
+# Function: checkPlugin
+
+**checkPlugin**(`options?`): `Plugin`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | [`CheckPluginOptions`](../interfaces/CheckPluginOptions.md) |
+
+#### Returns
+
+`Plugin`

--- a/packages/plugin-check/docs/index.md
+++ b/packages/plugin-check/docs/index.md
@@ -1,0 +1,48 @@
+# @sdeverywhere/plugin-check
+
+## Example
+
+Example `sde.config.js` file:
+
+```js
+import { checkPlugin } from '@sdeverywhere/plugin-check'
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+export async function config() {
+  return {
+    modelFiles: ['example.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
+        outputs: [{ varName: 'Z' }],
+        datFiles: []
+      }
+    },
+
+    plugins: [
+      // Generate a `wasm-model.js` file containing the Wasm model
+      wasmPlugin(),
+
+      // Generate a `worker.js` file that runs the Wasm model in a worker
+      workerPlugin(),
+
+      // Run checks and comparison tests against the generated Wasm model
+      checkPlugin({
+        // There are no required properties; see `CheckPluginOptions` below
+        // for optional configuration
+      })
+    ]
+  }
+}
+```
+
+## Initialization
+
+- [checkPlugin](functions/checkPlugin.md)
+
+## Options
+
+- [CheckPluginOptions](interfaces/CheckPluginOptions.md)
+- [CheckBundle](interfaces/CheckBundle.md)

--- a/packages/plugin-check/docs/interfaces/CheckBundle.md
+++ b/packages/plugin-check/docs/interfaces/CheckBundle.md
@@ -1,0 +1,19 @@
+[@sdeverywhere/plugin-check](../index.md) / CheckBundle
+
+# Interface: CheckBundle
+
+## Properties
+
+### name
+
+ **name**: `string`
+
+The name of the bundle as displayed in the report (this is typically a branch name).
+
+___
+
+### path
+
+ **path**: `string`
+
+The absolute path to the JS bundle file.

--- a/packages/plugin-check/docs/interfaces/CheckPluginOptions.md
+++ b/packages/plugin-check/docs/interfaces/CheckPluginOptions.md
@@ -1,0 +1,45 @@
+[@sdeverywhere/plugin-check](../index.md) / CheckPluginOptions
+
+# Interface: CheckPluginOptions
+
+## Properties
+
+### baseline
+
+ `Optional` **baseline**: [`CheckBundle`](CheckBundle.md)
+
+The baseline bundle.  If undefined, no comparison tests will be run.
+
+___
+
+### current
+
+ `Optional` **current**: [`CheckBundle`](CheckBundle.md)
+
+The current bundle, i.e., the bundle that is being developed and checked.
+
+___
+
+### testConfigPath
+
+ `Optional` **testConfigPath**: `string`
+
+The absolute path to the JS file containing the test configuration.  If undefined,
+a default test configuration will be used.
+
+___
+
+### reportPath
+
+ `Optional` **reportPath**: `string`
+
+The absolute path to the directory where the report will be written.  If undefined,
+the report will be written to the configured `prepDir`.
+
+___
+
+### serverPort
+
+ `Optional` **serverPort**: `number`
+
+The port used for the local dev server (defaults to 8081).

--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -33,7 +33,8 @@
     "test:ci": "echo No tests yet",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/plugin-config/README.md
+++ b/packages/plugin-config/README.md
@@ -38,12 +38,12 @@ import { configProcessor } from '@sdeverywhere/plugin-config'
 export async function config() {
   return {
     // Specify the Vensim model to read
-    modelFiles: ['sample.mdl'],
+    modelFiles: ['example.mdl'],
 
-    // Read csv files from `config` directory and write to the `generated` directory
+    // Read csv files from `config` directory and write to the recommended output
+    // directory structure.  See `ConfigProcessorOptions` for more details.
     modelSpec: configProcessor({
-      config: configDir,
-      out: genDir
+      config: 'config'
     }),
 
     plugins: [

--- a/packages/plugin-config/docs/functions/configProcessor.md
+++ b/packages/plugin-config/docs/functions/configProcessor.md
@@ -1,0 +1,33 @@
+[@sdeverywhere/plugin-config](../index.md) / configProcessor
+
+# Function: configProcessor
+
+**configProcessor**(`options`): (`buildContext`: `BuildContext`) => `Promise`<`ModelSpec`\>
+
+Returns a function that can be passed as the `modelSpec` function for the SDEverywhere
+`UserConfig`.  The returned function:
+  - reads CSV files from a `config` directory
+  - writes JS files to the configured output directories
+  - returns a `ModelSpec` that guides the rest of the `sde` build process
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | [`ConfigProcessorOptions`](../interfaces/ConfigProcessorOptions.md) |
+
+#### Returns
+
+`fn`
+
+(`buildContext`): `Promise`<`ModelSpec`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `buildContext` | `BuildContext` |
+
+##### Returns
+
+`Promise`<`ModelSpec`\>

--- a/packages/plugin-config/docs/index.md
+++ b/packages/plugin-config/docs/index.md
@@ -1,0 +1,35 @@
+# @sdeverywhere/plugin-config
+
+## Example
+
+Example `sde.config.js` file:
+
+```js
+import { configProcessor } from '@sdeverywhere/plugin-config'
+
+export async function config() {
+  return {
+    // Specify the Vensim model to read
+    modelFiles: ['example.mdl'],
+
+    // Read csv files from `config` directory and write to the recommended output
+    // directory structure.  See `ConfigProcessorOptions` for more details.
+    modelSpec: configProcessor({
+      config: 'config'
+    }),
+
+    plugins: [
+      // ...
+    ]
+  }
+}
+```
+
+## Initialization
+
+- [configProcessor](functions/configProcessor.md)
+
+## Options
+
+- [ConfigProcessorOptions](interfaces/ConfigProcessorOptions.md)
+- [ConfigProcessorOutputPaths](interfaces/ConfigProcessorOutputPaths.md)

--- a/packages/plugin-config/docs/interfaces/ConfigProcessorOptions.md
+++ b/packages/plugin-config/docs/interfaces/ConfigProcessorOptions.md
@@ -19,6 +19,7 @@ ___
 Either a single path to a base output directory (in which case, the recommended
 directory structure will be used) or a `ConfigProcessorOutputPaths` containing specific paths.
 If a single string is provided, the following subdirectories will be used:
+```
   <out-dir>/
     src/
       config/
@@ -26,3 +27,4 @@ If a single string is provided, the following subdirectories will be used:
       model/
         generated/
     strings/
+```

--- a/packages/plugin-config/docs/interfaces/ConfigProcessorOptions.md
+++ b/packages/plugin-config/docs/interfaces/ConfigProcessorOptions.md
@@ -1,0 +1,28 @@
+[@sdeverywhere/plugin-config](../index.md) / ConfigProcessorOptions
+
+# Interface: ConfigProcessorOptions
+
+## Properties
+
+### config
+
+ **config**: `string`
+
+The absolute path to the directory containing the CSV config files.
+
+___
+
+### out
+
+ `Optional` **out**: `string` \| [`ConfigProcessorOutputPaths`](ConfigProcessorOutputPaths.md)
+
+Either a single path to a base output directory (in which case, the recommended
+directory structure will be used) or a `ConfigProcessorOutputPaths` containing specific paths.
+If a single string is provided, the following subdirectories will be used:
+  <out-dir>/
+    src/
+      config/
+        generated/
+      model/
+        generated/
+    strings/

--- a/packages/plugin-config/docs/interfaces/ConfigProcessorOutputPaths.md
+++ b/packages/plugin-config/docs/interfaces/ConfigProcessorOutputPaths.md
@@ -1,0 +1,27 @@
+[@sdeverywhere/plugin-config](../index.md) / ConfigProcessorOutputPaths
+
+# Interface: ConfigProcessorOutputPaths
+
+## Properties
+
+### modelSpecsDir
+
+ `Optional` **modelSpecsDir**: `string`
+
+The absolute path to the directory where model spec files will be written.
+
+___
+
+### configSpecsDir
+
+ `Optional` **configSpecsDir**: `string`
+
+The absolute path to the directory where config spec files will be written.
+
+___
+
+### stringsDir
+
+ `Optional` **stringsDir**: `string`
+
+The absolute path to the directory where translated strings will be written.

--- a/packages/plugin-config/package.json
+++ b/packages/plugin-config/package.json
@@ -29,7 +29,8 @@
     "bundle": "tsup",
     "copy-types": "cp src/spec-types.ts dist",
     "build": "run-s bundle copy-types",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
     "byline": "^5.0.0",

--- a/packages/plugin-config/src/index.ts
+++ b/packages/plugin-config/src/index.ts
@@ -1,3 +1,4 @@
 // Copyright (c) 2022 Climate Interactive / New Venture Fund
 
+export type { ConfigProcessorOptions, ConfigProcessorOutputPaths } from './processor'
 export { configProcessor } from './processor'

--- a/packages/plugin-config/src/processor.spec.ts
+++ b/packages/plugin-config/src/processor.spec.ts
@@ -11,7 +11,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import type { BuildOptions, ModelSpec, Plugin, UserConfig } from '@sdeverywhere/build'
 import { build } from '@sdeverywhere/build'
 
-import type { ConfigOptions } from './processor'
+import type { ConfigProcessorOptions } from './processor'
 import { configProcessor } from './processor'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -23,7 +23,7 @@ interface TestEnv {
 }
 
 async function prepareForBuild(
-  optionsFunc: (corePkgDir: string) => ConfigOptions,
+  optionsFunc: (corePkgDir: string) => ConfigProcessorOptions,
   plugins: Plugin[] = []
 ): Promise<TestEnv> {
   const baseTmpDir = await temp.mkdir('sde-plugin-config')

--- a/packages/plugin-config/src/processor.ts
+++ b/packages/plugin-config/src/processor.ts
@@ -30,6 +30,7 @@ export interface ConfigProcessorOptions {
    * Either a single path to a base output directory (in which case, the recommended
    * directory structure will be used) or a `ConfigProcessorOutputPaths` containing specific paths.
    * If a single string is provided, the following subdirectories will be used:
+   * ```
    *   <out-dir>/
    *     src/
    *       config/
@@ -37,6 +38,7 @@ export interface ConfigProcessorOptions {
    *       model/
    *         generated/
    *     strings/
+   * ```
    */
   out?: string | ConfigProcessorOutputPaths
 }

--- a/packages/plugin-config/src/processor.ts
+++ b/packages/plugin-config/src/processor.ts
@@ -9,7 +9,7 @@ import { createConfigContext } from './context'
 import { writeModelSpec } from './gen-model-spec'
 import { generateConfigSpecs, writeConfigSpecs, writeSpecTypes } from './gen-config-specs'
 
-export interface ConfigOutputPaths {
+export interface ConfigProcessorOutputPaths {
   /** The absolute path to the directory where model spec files will be written. */
   modelSpecsDir?: string
 
@@ -20,7 +20,7 @@ export interface ConfigOutputPaths {
   stringsDir?: string
 }
 
-export interface ConfigOptions {
+export interface ConfigProcessorOptions {
   /**
    * The absolute path to the directory containing the CSV config files.
    */
@@ -28,7 +28,7 @@ export interface ConfigOptions {
 
   /**
    * Either a single path to a base output directory (in which case, the recommended
-   * directory structure will be used) or a `ConfigOutputPaths` containing specific paths.
+   * directory structure will be used) or a `ConfigProcessorOutputPaths` containing specific paths.
    * If a single string is provided, the following subdirectories will be used:
    *   <out-dir>/
    *     src/
@@ -38,7 +38,7 @@ export interface ConfigOptions {
    *         generated/
    *     strings/
    */
-  out?: string | ConfigOutputPaths
+  out?: string | ConfigProcessorOutputPaths
 }
 
 /**
@@ -48,13 +48,13 @@ export interface ConfigOptions {
  *   - writes JS files to the configured output directories
  *   - returns a `ModelSpec` that guides the rest of the `sde` build process
  */
-export function configProcessor(options: ConfigOptions): (buildContext: BuildContext) => Promise<ModelSpec> {
+export function configProcessor(options: ConfigProcessorOptions): (buildContext: BuildContext) => Promise<ModelSpec> {
   return buildContext => {
     return processModelConfig(buildContext, options)
   }
 }
 
-async function processModelConfig(buildContext: BuildContext, options: ConfigOptions): Promise<ModelSpec> {
+async function processModelConfig(buildContext: BuildContext, options: ConfigProcessorOptions): Promise<ModelSpec> {
   const t0 = performance.now()
 
   // Resolve source (config) directory

--- a/packages/plugin-vite/docs/functions/vitePlugin.md
+++ b/packages/plugin-vite/docs/functions/vitePlugin.md
@@ -1,0 +1,15 @@
+[@sdeverywhere/plugin-vite](../index.md) / vitePlugin
+
+# Function: vitePlugin
+
+**vitePlugin**(`options`): `Plugin`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | [`VitePluginOptions`](../interfaces/VitePluginOptions.md) |
+
+#### Returns
+
+`Plugin`

--- a/packages/plugin-vite/docs/index.md
+++ b/packages/plugin-vite/docs/index.md
@@ -1,0 +1,53 @@
+# @sdeverywhere/plugin-vite
+
+## Example
+
+Example `sde.config.js` file:
+
+```js
+import { vitePlugin } from '@sdeverywhere/plugin-vite'
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+export async function config() {
+  return {
+    modelFiles: ['example.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
+        outputs: [{ varName: 'Z' }],
+        datFiles: []
+      }
+    },
+
+    plugins: [
+      // Generate a `wasm-model.js` file containing the Wasm model
+      wasmPlugin(),
+
+      // Generate a `worker.js` file that runs the Wasm model in a worker
+      workerPlugin(),
+
+      // Build or serve a web application using a provided Vite config file.
+      // See `VitePluginOptions` for the full set of configuration options.
+      vitePlugin({
+        name: 'app',
+        apply: {
+          development: 'serve'
+        },
+        config: {
+          configFile: 'app/vite.config.js'
+        }
+      })
+    ]
+  }
+}
+```
+
+## Initialization
+
+- [vitePlugin](functions/vitePlugin.md)
+
+## Options
+
+- [VitePluginOptions](interfaces/VitePluginOptions.md)

--- a/packages/plugin-vite/docs/interfaces/VitePluginOptions.md
+++ b/packages/plugin-vite/docs/interfaces/VitePluginOptions.md
@@ -1,0 +1,62 @@
+[@sdeverywhere/plugin-vite](../index.md) / VitePluginOptions
+
+# Interface: VitePluginOptions
+
+## Properties
+
+### name
+
+ **name**: `string`
+
+The name to include in log messages.
+
+___
+
+### config
+
+ **config**: `InlineConfig`
+
+The Vite config to use.
+
+___
+
+### apply
+
+ `Optional` **apply**: `Object`
+
+Specifies the behavior of the plugin for different `sde` build modes.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `development?` | ``"watch"`` \| ``"serve"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"`` |
+| `production?` | ``"skip"`` \| ``"post-generate"`` \| ``"post-build"`` |
+
+**development?**: ``"watch"`` \| ``"serve"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"``
+
+The behavior of the plugin when sde is configured for development mode.
+
+If left undefined, defaults to 'post-build'.
+
+- `skip`: Don't run the plugin.
+- `post-generate`: Run `vite build` in the `postGenerate` phase.
+- `post-build`: Run `vite build` in the `postBuild` phase.
+- `watch`: Run `vite build` in the `watch` callback (rebuilds the library when
+  changes are detected in source files); useful for libraries.
+- `serve`: Run `vite dev` (sets up local server and refreshes the app
+  automatically when changes are detected); useful for applications.
+
+-----
+
+**production?**: ``"skip"`` \| ``"post-generate"`` \| ``"post-build"``
+
+The behavior of the plugin when sde is configured for production mode.
+
+If left undefined, defaults to 'post-build'.
+
+- `skip`: Don't run the plugin.
+- `post-generate`: Run `vite build` in the `postGenerate` phase.
+- `post-build`: Run `vite build` in the `postBuild` phase.
+
+-----

--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -26,7 +26,8 @@
     "test:ci": "echo No tests yet",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "peerDependencies": {
     "@sdeverywhere/build": "^0.3.0",

--- a/packages/plugin-vite/src/options.ts
+++ b/packages/plugin-vite/src/options.ts
@@ -16,20 +16,13 @@ export interface VitePluginOptions {
      *
      * If left undefined, defaults to 'post-build'.
      *
-     * ```
-     * 'skip':
-     *   Don't run the plugin.
-     * 'post-generate':
-     *   Run "vite build" in the `postGenerate` phase.
-     * 'post-build':
-     *   Run "vite build" in the `postBuild` phase.
-     * 'watch':
-     *   Run "vite build" in the `watch` callback (rebuilds the library when
+     * - `skip`: Don't run the plugin.
+     * - `post-generate`: Run `vite build` in the `postGenerate` phase.
+     * - `post-build`: Run `vite build` in the `postBuild` phase.
+     * - `watch`: Run `vite build` in the `watch` callback (rebuilds the library when
      *   changes are detected in source files); useful for libraries.
-     * 'serve':
-     *   Run "vite dev" (sets up local server and refreshes the app
+     * - `serve`: Run `vite dev` (sets up local server and refreshes the app
      *   automatically when changes are detected); useful for applications.
-     * ```
      */
     development?: 'skip' | 'post-generate' | 'post-build' | 'watch' | 'serve'
 
@@ -38,14 +31,9 @@ export interface VitePluginOptions {
      *
      * If left undefined, defaults to 'post-build'.
      *
-     * ```
-     * 'skip':
-     *   Don't run the plugin.
-     * 'post-generate':
-     *   Run "vite build" in the `postGenerate` phase.
-     * 'post-build':
-     *   Run "vite build" in the `postBuild` phase.
-     * ```
+     * - `skip`: Don't run the plugin.
+     * - `post-generate`: Run `vite build` in the `postGenerate` phase.
+     * - `post-build`: Run `vite build` in the `postBuild` phase.
      */
     production?: 'skip' | 'post-generate' | 'post-build'
   }

--- a/packages/plugin-wasm/docs/functions/wasmPlugin.md
+++ b/packages/plugin-wasm/docs/functions/wasmPlugin.md
@@ -1,0 +1,15 @@
+[@sdeverywhere/plugin-wasm](../index.md) / wasmPlugin
+
+# Function: wasmPlugin
+
+**wasmPlugin**(`options?`): `Plugin`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | [`WasmPluginOptions`](../interfaces/WasmPluginOptions.md) |
+
+#### Returns
+
+`Plugin`

--- a/packages/plugin-wasm/docs/index.md
+++ b/packages/plugin-wasm/docs/index.md
@@ -1,0 +1,39 @@
+# @sdeverywhere/plugin-wasm
+
+## Example
+
+Example `sde.config.js` file:
+
+```js
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+
+export async function config() {
+  return {
+    modelFiles: ['example.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
+        outputs: [{ varName: 'Z' }],
+        datFiles: []
+      }
+    },
+
+    plugins: [
+      // Generate a `wasm-model.js` file containing the Wasm model
+      wasmPlugin({
+        // There are no required properties; see `WasmPluginOptions` below
+        // for optional configuration
+      })
+    ]
+  }
+}
+```
+
+## Initialization
+
+- [wasmPlugin](functions/wasmPlugin.md)
+
+## Options
+
+- [WasmPluginOptions](interfaces/WasmPluginOptions.md)

--- a/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
+++ b/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
@@ -1,0 +1,21 @@
+[@sdeverywhere/plugin-wasm](../index.md) / WasmPluginOptions
+
+# Interface: WasmPluginOptions
+
+## Properties
+
+### emsdkDir
+
+ `Optional` **emsdkDir**: `string`
+
+The path to the Emscripten SDK.  If undefined, the plugin will walk up the directory
+structure to find the nearest `emsdk` directory.
+
+___
+
+### outputJsPath
+
+ `Optional` **outputJsPath**: `string`
+
+The path of the resulting JS file (containing the embedded Wasm model).  If undefined,
+the plugin will write `wasm-model.js` to the configured `prepDir`.

--- a/packages/plugin-wasm/package.json
+++ b/packages/plugin-wasm/package.json
@@ -26,7 +26,8 @@
     "test:ci": "echo No tests yet",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
     "find-up": "^6.3.0"

--- a/packages/plugin-worker/docs/functions/workerPlugin.md
+++ b/packages/plugin-worker/docs/functions/workerPlugin.md
@@ -1,0 +1,15 @@
+[@sdeverywhere/plugin-worker](../index.md) / workerPlugin
+
+# Function: workerPlugin
+
+**workerPlugin**(`options?`): `Plugin`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | [`WorkerPluginOptions`](../interfaces/WorkerPluginOptions.md) |
+
+#### Returns
+
+`Plugin`

--- a/packages/plugin-worker/docs/index.md
+++ b/packages/plugin-worker/docs/index.md
@@ -1,0 +1,43 @@
+# @sdeverywhere/plugin-worker
+
+## Example
+
+Example `sde.config.js` file:
+
+```js
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+export async function config() {
+  return {
+    modelFiles: ['example.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
+        outputs: [{ varName: 'Z' }],
+        datFiles: []
+      }
+    },
+
+    plugins: [
+      // Generate a `wasm-model.js` file containing the Wasm model
+      wasmPlugin(),
+
+      // Generate a `worker.js` file that runs the Wasm model in a worker
+      workerPlugin({
+        // There are no required properties; see `WorkerPluginOptions` below
+        // for optional configuration
+      })
+    ]
+  }
+}
+```
+
+## Initialization
+
+- [workerPlugin](functions/workerPlugin.md)
+
+## Options
+
+- [WorkerPluginOptions](interfaces/WorkerPluginOptions.md)

--- a/packages/plugin-worker/docs/interfaces/WorkerPluginOptions.md
+++ b/packages/plugin-worker/docs/interfaces/WorkerPluginOptions.md
@@ -1,0 +1,12 @@
+[@sdeverywhere/plugin-worker](../index.md) / WorkerPluginOptions
+
+# Interface: WorkerPluginOptions
+
+## Properties
+
+### outputPaths
+
+ `Optional` **outputPaths**: `string`[]
+
+The destination paths for the generated worker JS files.  If undefined,
+a `worker.js` file will be written to the configured `prepDir`.

--- a/packages/plugin-worker/package.json
+++ b/packages/plugin-worker/package.json
@@ -27,7 +27,8 @@
     "test:ci": "echo No tests yet",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
-    "ci:build": "run-s clean lint prettier:check test:ci type-check build"
+    "docs": "../../scripts/gen-docs.js",
+    "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/runtime/docs/classes/Outputs.md
+++ b/packages/runtime/docs/classes/Outputs.md
@@ -26,11 +26,15 @@ ___
 
  `Readonly` **varIds**: `string`[]
 
+The output variable identifiers.
+
 ___
 
 ### startTime
 
  `Readonly` **startTime**: `number`
+
+The start time for the model.
 
 ___
 
@@ -38,11 +42,15 @@ ___
 
  `Readonly` **endTime**: `number`
 
+The end time for the model.
+
 ___
 
 ### saveFreq
 
  `Readonly` **saveFreq**: `number` = `1`
+
+The frequency with which output values are saved (aka `SAVEPER`).
 
 ## Constructors
 

--- a/packages/runtime/docs/classes/Series.md
+++ b/packages/runtime/docs/classes/Series.md
@@ -23,11 +23,15 @@ A time series of data points for an output variable.
 
  `Readonly` **varId**: `string`
 
+The ID for the output variable (as used by SDEverywhere).
+
 ___
 
 ### points
 
  `Readonly` **points**: [`Point`](../interfaces/Point.md)[]
+
+The data points for the variable, one point per time increment.
 
 ## Methods
 

--- a/packages/runtime/docs/interfaces/InputCallbacks.md
+++ b/packages/runtime/docs/interfaces/InputCallbacks.md
@@ -4,14 +4,18 @@
 
 Callback functions that are called when the input value is changed.
 
-## Methods
+## Properties
 
 ### onSet
 
-`Optional` **onSet**(): `void`
+ `Optional` **onSet**: () => `void`
+
+#### Type declaration
+
+(): `void`
 
 Called after a new value is set.
 
-#### Returns
+##### Returns
 
 `void`

--- a/packages/runtime/docs/interfaces/InputValue.md
+++ b/packages/runtime/docs/interfaces/InputValue.md
@@ -14,21 +14,17 @@ The ID of the associated input variable, as used in SDEverywhere.
 
 ___
 
-### callbacks
-
- **callbacks**: [`InputCallbacks`](InputCallbacks.md)
-
-Callback functions that are called when the input value is changed.
-
-## Methods
-
 ### get
 
-**get**(): `number`
+ **get**: () => `number`
+
+#### Type declaration
+
+(): `number`
 
 Get the current value of the input.
 
-#### Returns
+##### Returns
 
 `number`
 
@@ -36,17 +32,21 @@ ___
 
 ### set
 
-**set**(`value`): `void`
+ **set**: (`value`: `number`) => `void`
+
+#### Type declaration
+
+(`value`): `void`
 
 Set the input to the given value.
 
-#### Parameters
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `value` | `number` |
 
-#### Returns
+##### Returns
 
 `void`
 
@@ -54,10 +54,22 @@ ___
 
 ### reset
 
-**reset**(): `void`
+ **reset**: () => `void`
+
+#### Type declaration
+
+(): `void`
 
 Reset the input to its default value.
 
-#### Returns
+##### Returns
 
 `void`
+
+___
+
+### callbacks
+
+ **callbacks**: [`InputCallbacks`](InputCallbacks.md)
+
+Callback functions that are called when the input value is changed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
       npm-run-all: ^4.1.5
       prettier: ^2.6.2
       tsup: ^6.2.3
-      typedoc: ^0.22.17
-      typedoc-plugin-markdown: ^3.12.1
+      typedoc: 0.23.28
+      typedoc-plugin-markdown: 3.14.0
       typescript: ^4.7.3
       vitest: ^0.23.4
     devDependencies:
@@ -29,8 +29,8 @@ importers:
       npm-run-all: 4.1.5
       prettier: 2.6.2
       tsup: 6.2.3_typescript@4.7.3
-      typedoc: 0.22.17_typescript@4.7.3
-      typedoc-plugin-markdown: 3.12.1_typedoc@0.22.17
+      typedoc: 0.23.28_typescript@4.7.3
+      typedoc-plugin-markdown: 3.14.0_typedoc@0.23.28
       typescript: 4.7.3
       vitest: 0.23.4
 
@@ -933,6 +933,10 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
     dev: false
+
+  /ansi-sequence-parser/1.1.0:
+    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
+    dev: true
 
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2406,8 +2410,8 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /jsonc-parser/3.0.0:
-    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
+  /jsonc-parser/3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
   /jsonfile/6.1.0:
@@ -2533,8 +2537,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /marked/4.0.16:
-    resolution: {integrity: sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==}
+  /marked/4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
     engines: {node: '>= 12'}
     hasBin: true
     dev: true
@@ -2588,6 +2592,13 @@ packages:
 
   /minimatch/5.1.0:
     resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
+  /minimatch/7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
@@ -3261,12 +3272,13 @@ packages:
       rechoir: 0.6.2
     dev: false
 
-  /shiki/0.10.1:
-    resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
+  /shiki/0.14.2:
+    resolution: {integrity: sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==}
     dependencies:
-      jsonc-parser: 3.0.0
-      vscode-oniguruma: 1.6.2
-      vscode-textmate: 5.2.0
+      ansi-sequence-parser: 1.1.0
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
     dev: true
 
   /side-channel/1.0.4:
@@ -3846,27 +3858,26 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typedoc-plugin-markdown/3.12.1_typedoc@0.22.17:
-    resolution: {integrity: sha512-gMntJq7+JlGJZ5sVjrkzO/rG2dsmNBbWk5ZkcKvYu6QOeBwGcK5tzEyS0aqnFTJj9GCHCB+brAnTuKtAyotNwA==}
+  /typedoc-plugin-markdown/3.14.0_typedoc@0.23.28:
+    resolution: {integrity: sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==}
     peerDependencies:
-      typedoc: '>=0.22.0'
+      typedoc: '>=0.23.0'
     dependencies:
       handlebars: 4.7.7
-      typedoc: 0.22.17_typescript@4.7.3
+      typedoc: 0.23.28_typescript@4.7.3
     dev: true
 
-  /typedoc/0.22.17_typescript@4.7.3:
-    resolution: {integrity: sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==}
-    engines: {node: '>= 12.10.0'}
+  /typedoc/0.23.28_typescript@4.7.3:
+    resolution: {integrity: sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==}
+    engines: {node: '>= 14.14'}
     hasBin: true
     peerDependencies:
-      typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
     dependencies:
-      glob: 8.0.3
       lunr: 2.3.9
-      marked: 4.0.16
-      minimatch: 5.1.0
-      shiki: 0.10.1
+      marked: 4.3.0
+      minimatch: 7.4.6
+      shiki: 0.14.2
       typescript: 4.7.3
     dev: true
 
@@ -4018,12 +4029,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vscode-oniguruma/1.6.2:
-    resolution: {integrity: sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==}
+  /vscode-oniguruma/1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
     dev: true
 
-  /vscode-textmate/5.2.0:
-    resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
+  /vscode-textmate/8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
 
   /wcwidth/1.0.1:
@@ -4099,7 +4110,7 @@ packages:
     dev: false
 
   /wordwrap/1.0.0:
-    resolution: {integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=}
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
   /wrap-ansi/7.0.0:

--- a/scripts/gen-docs.js
+++ b/scripts/gen-docs.js
@@ -58,6 +58,7 @@ function main() {
 --hideInPageTOC \
 --hideMembersSymbol \
 --allReflectionsHaveOwnDocument \
+--objectLiteralTypeDeclarationStyle list \
 --out docs \
 --cleanOutputDir false \
 src/index.ts`


### PR DESCRIPTION
Fixes #328 

This upgrades to newer versions of typedoc and typedoc-plugin-markdown, which include fixes that improve our generated API docs.

I updated the build to include API docs for all plugin packages and added custom `index.md` files for each.

I included a couple non-breaking changes to interfaces to help improve how they look in the API docs, specifically:
- In the `plugin-config` package, changed `ConfigOptions` to `ConfigProcessorOptions` and made it an exported type (previously it wasn't exported, so this isn't a breaking change)
- In the `build` package, changed `Plugin` to use consistent method-style syntax for optional methods (previously they were a mix of method-style and property-style, which caused them to be grouped differently in newer versions of typedoc); this is not a breaking change because the two styles are interchangeable
