### PR TITLE
build: reduce js integration test time by running more steps in parallel

### DIFF
--- a/scripts/ci-run-js-int-tests
+++ b/scripts/ci-run-js-int-tests
@@ -9,12 +9,18 @@ set -x # include all commands in logs
 cd "$PROJ_DIR"
 
 # Build the subset of packages that are required for running the JS-level
-# integration tests
-pnpm -F build build
-pnpm -F plugin-wasm build
-pnpm -F plugin-worker build
-pnpm -F runtime build
-pnpm -F runtime-async build
+# integration tests.  We use `--workspace-concurrency=0` to use all
+# available CPUs, but let pnpm handle the topological sorting.
+pnpm \
+--aggregate-output \
+--reporter=append-only \
+--workspace-concurrency=0 \
+-F build \
+-F plugin-wasm \
+-F plugin-worker \
+-F runtime \
+-F runtime-async \
+-r build
 
 # Run the JS-level integration tests that exercise the build and runtime packages
 pnpm run test:js-int

--- a/tests/run-js-int-tests
+++ b/tests/run-js-int-tests
@@ -3,5 +3,13 @@
 set -e # fail on error
 set -x # include all commands in logs
 
-# Run "ci:int-test" script for all JS-level integration test packages
-pnpm -r ci:int-test
+# Run "ci:int-test" script for all JS-level integration test packages.  We run
+# the tests in parallel using all available CPUs (`--workspace-concurrency=0`)
+# since there are no dependencies between the tests.
+pnpm \
+--parallel \
+--aggregate-output \
+--reporter=append-only \
+--workspace-concurrency=0 \
+-F "./tests/**" \
+-r ci:int-test


### PR DESCRIPTION
Fixes #347

This follows on the earlier PR #348 to apply similar changes to the `ci-run-js-int-tests` script.  See issue for more details.
