### PR TITLE
fix: upgrade to vite 4.4.9

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "clean": "rm -rf ./sde-prep",
     "build": "sde bundle",
     "dev": "sde dev",
     "save-baseline": "sde-check baseline --save",

--- a/examples/sample-check-app/package.json
+++ b/examples/sample-check-app/package.json
@@ -23,14 +23,14 @@
     "@sdeverywhere/sample-check-tests": "workspace:*"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.4.0",
+    "@sveltejs/vite-plugin-svelte": "^2.4.5",
     "postcss": "^8.2.14",
     "pug": "^3.0.1",
     "sass": "^1.34.1",
     "svelte": "^3.59.2",
     "svelte-check": "^3.5.1",
     "svelte-preprocess": "^5.0.4",
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/sample-check-app/package.json
+++ b/examples/sample-check-app/package.json
@@ -23,7 +23,7 @@
     "@sdeverywhere/sample-check-tests": "workspace:*"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.8",
+    "@sveltejs/vite-plugin-svelte": "^1.4.0",
     "postcss": "^8.2.14",
     "pug": "^3.0.1",
     "sass": "^1.34.1",

--- a/examples/sample-check-app/package.json
+++ b/examples/sample-check-app/package.json
@@ -30,7 +30,7 @@
     "svelte": "^3.59.2",
     "svelte-check": "^3.5.1",
     "svelte-preprocess": "^5.0.4",
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/sample-check-bundle/package.json
+++ b/examples/sample-check-bundle/package.json
@@ -26,7 +26,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/sample-check-bundle/package.json
+++ b/examples/sample-check-bundle/package.json
@@ -26,7 +26,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/sample-check-tests/package.json
+++ b/examples/sample-check-tests/package.json
@@ -24,7 +24,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/sample-check-tests/package.json
+++ b/examples/sample-check-tests/package.json
@@ -24,7 +24,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/examples/template-default/packages/app/package.json
+++ b/examples/template-default/packages/app/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/chart.js": "^2.9.34",
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   }
 }

--- a/examples/template-default/packages/app/package.json
+++ b/examples/template-default/packages/app/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/chart.js": "^2.9.34",
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   }
 }

--- a/examples/template-default/packages/core/package.json
+++ b/examples/template-default/packages/core/package.json
@@ -21,6 +21,6 @@
     "@sdeverywhere/runtime-async": "^0.2.0"
   },
   "devDependencies": {
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   }
 }

--- a/examples/template-default/packages/core/package.json
+++ b/examples/template-default/packages/core/package.json
@@ -21,6 +21,6 @@
     "@sdeverywhere/runtime-async": "^0.2.0"
   },
   "devDependencies": {
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
     "typescript": "^5.2.2",
-    "vitest": "^0.23.4"
+    "vitest": "^0.34.3"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/packages/check-ui-shell/package.json
+++ b/packages/check-ui-shell/package.json
@@ -36,7 +36,7 @@
     "fontfaceobserver": "^2.1.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.8",
+    "@sveltejs/vite-plugin-svelte": "^1.4.0",
     "@types/chart.js": "^2.9.34",
     "@types/fontfaceobserver": "^0.0.6",
     "postcss": "^8.2.14",

--- a/packages/check-ui-shell/package.json
+++ b/packages/check-ui-shell/package.json
@@ -36,7 +36,7 @@
     "fontfaceobserver": "^2.1.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.4.0",
+    "@sveltejs/vite-plugin-svelte": "^2.4.5",
     "@types/chart.js": "^2.9.34",
     "@types/fontfaceobserver": "^0.0.6",
     "postcss": "^8.2.14",
@@ -46,7 +46,7 @@
     "svelte-awesome": "^3.0.0",
     "svelte-check": "^3.5.1",
     "svelte-preprocess": "^5.0.4",
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   },
   "devDependenciesComments": {
     "svelte-awesome": [

--- a/packages/check-ui-shell/package.json
+++ b/packages/check-ui-shell/package.json
@@ -46,7 +46,7 @@
     "svelte-awesome": "^3.0.0",
     "svelte-check": "^3.5.1",
     "svelte-preprocess": "^5.0.4",
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "devDependenciesComments": {
     "svelte-awesome": [

--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@rollup/plugin-replace": "^4.0.0",
+    "@rollup/plugin-replace": "^5.0.2",
     "@sdeverywhere/check-core": "^0.1.1",
     "@sdeverywhere/check-ui-shell": "^0.2.2",
     "@sdeverywhere/runtime": "^0.2.0",
@@ -47,7 +47,7 @@
     "chokidar": "^3.5.3",
     "picocolors": "^1.0.0",
     "rollup": "^2.76.0",
-    "vite": "^3.2.7"
+    "vite": "4.4.9"
   },
   "dependenciesComments": {
     "rollup": [

--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -47,7 +47,7 @@
     "chokidar": "^3.5.3",
     "picocolors": "^1.0.0",
     "rollup": "^2.76.0",
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "dependenciesComments": {
     "rollup": [

--- a/packages/plugin-check/src/vite-config-for-bundle.ts
+++ b/packages/plugin-check/src/vite-config-for-bundle.ts
@@ -177,8 +177,8 @@ export async function createViteConfigForBundle(prepDir: string, modelSpec: Mode
         // in its Node implementation.  This import ensures that threads.js uses
         // the native `worker_threads` implementation when using the bundle in a
         // Node environment.  When importing the bundle for use in the browser,
-        // Vite will transform this import into an empty module (it does not seem
-        // to be necessary to define a polyfill).
+        // Vite will transform this import into an empty module due to the empty
+        // polyfill that is configured in `vite-config-for-report.ts`.
         output: {
           banner: `
 import * as worker_threads from 'worker_threads'

--- a/packages/plugin-check/src/vite-config-for-bundle.ts
+++ b/packages/plugin-check/src/vite-config-for-bundle.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2022 Climate Interactive / New Venture Fund
 
 import { existsSync, statSync } from 'fs'
-import { dirname, join as joinPath, relative, resolve as resolvePath } from 'path'
+import { basename, dirname, join as joinPath, relative, resolve as resolvePath } from 'path'
 import { fileURLToPath } from 'url'
 
-import type { InlineConfig, Plugin as VitePlugin } from 'vite'
+import type { InlineConfig, ResolvedConfig, Plugin as VitePlugin } from 'vite'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 
 import type { ModelSpec } from '@sdeverywhere/build'
@@ -93,6 +93,55 @@ export const dataSizeInBytes = ${dataSizeInBytes};
   }
 }
 
+/**
+ * XXX: This overrides the built-in `vite:resolve` plugin so that we can intercept `resolveId`
+ * calls for the threads package.
+ */
+function overrideViteResolvePlugin(viteConfig: ResolvedConfig) {
+  const resolvePlugin = viteConfig.plugins.find(p => p.name === 'vite:resolve')
+  if (resolvePlugin === undefined) {
+    throw new Error('Failed to locate the built-in vite:resolve plugin')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalResolveId = resolvePlugin.resolveId as any
+  resolvePlugin.resolveId = async function resolveId(id, importer, options) {
+    if (id.startsWith('./implementation') && importer.includes('threads/dist-esm')) {
+      // XXX: The default resolver behavior will look at the `browser` mappings in
+      // `threads/package.json` and try to resolve `implementation.js` to
+      // `implementation.browser.js` because it thinks we're in a browser-only context.
+      // We don't want that.  Instead we want to keep the generic implementation from
+      // threads that chooses between the Node and browser implementations at runtime.
+      //
+      // If we get here, importer will be something like:
+      //   /.../node_modules/.pnpm/threads@1.7.0/node_modules/threads/dist-esm/{worker,master}/index.js
+      // And id will be:
+      //   ./implementation
+      // So resolve the ID to:
+      //   /.../node_modules/.pnpm/threads@1.7.0/node_modules/threads/dist-esm/{worker,master}/implementation.js
+      //
+      // Or, importer will be:
+      //   /.../node_modules/.pnpm/threads@1.7.0/node_modules/threads/dist-esm/{worker,master}/implementation.js
+      // And id will be one of:
+      //   ./implementation.browser
+      //   ./implementation.node
+      //   ./implementation.worker_threads
+      // So resolve the ID to:
+      //   /.../node_modules/.pnpm/threads@1.7.0/node_modules/threads/dist-esm/{worker,master}/implementation.{...}.js
+      const idFileName = id.replace('./', '')
+      const importerFileName = basename(importer)
+      const resolvedId = importer.replace(importerFileName, `${idFileName}.js`)
+      return {
+        id: resolvedId,
+        moduleSideEffects: false
+      }
+    }
+
+    // For all other cases, fall back on the default resolver
+    return originalResolveId.call(this, id, importer, options)
+  }
+}
+
 export async function createViteConfigForBundle(prepDir: string, modelSpec: ModelSpec): Promise<InlineConfig> {
   // Use `template-bundle` as the root directory for the bundle project
   const root = resolvePath(__dirname, '..', 'template-bundle')
@@ -130,8 +179,15 @@ export async function createViteConfigForBundle(prepDir: string, modelSpec: Mode
         // XXX: Prevent Vite from using the `browser` section of `threads/package.json`
         // since we want to force the use of the general module (under dist-esm) that chooses
         // the correct implementation (Web Worker vs worker_threads) at runtime.  Currently
-        // Vite's library mode is browser focused, so using a `customResolver` seems to be
-        // the easiest way to prevent Vite from picking up the `browser` exports.
+        // Vite's library mode is browser focused and generally chooses the right imports,
+        // except in the case of the threads package where we want to use the generic
+        // `implementation.js` that chooses between Web Worker and worker_threads at runtime.
+        // Note that we could in theory set `resolve.browserField` to false, but that would
+        // make Vite not use the browser field for all other packages, and there is not
+        // currently a way to tell Vite to use the browser field on a case-by-case basis.
+        // So for now we need this workaround here to make it resolve to `dist-esm`, and then
+        // a second workaround in `overrideViteResolvePlugin` to prevent the resolver from
+        // using the browser field when resolving the threads package.
         {
           find: 'threads',
           replacement: 'threads',
@@ -153,7 +209,17 @@ export async function createViteConfigForBundle(prepDir: string, modelSpec: Mode
 
     plugins: [
       // Use a virtual module plugin to inject the model spec values
-      injectModelSpec(prepDir, modelSpec)
+      injectModelSpec(prepDir, modelSpec),
+
+      // XXX: Install a wrapper around the built-in `vite:resolve` plugin so that we can
+      // override the default resolver behavior that tries to resolve the `browser` section
+      // of the `package.json` for the threads package.
+      {
+        name: 'vite-plugin-override-resolve',
+        configResolved(viteConfig) {
+          overrideViteResolvePlugin(viteConfig)
+        }
+      }
     ],
 
     build: {
@@ -161,6 +227,9 @@ export async function createViteConfigForBundle(prepDir: string, modelSpec: Mode
       // note that this must be relative to the project `root`
       outDir,
       emptyOutDir: false,
+
+      // Uncomment for debugging purposes
+      // minify: false,
 
       lib: {
         entry: './src/index.ts',

--- a/packages/plugin-check/src/vite-config-for-report.ts
+++ b/packages/plugin-check/src/vite-config-for-report.ts
@@ -105,28 +105,28 @@ export function createViteConfigForReport(
       // As a terrible workaround, explicitly include the direct dependencies so
       // that Vite optimizes them; this works for pnpm, yarn, and npm.  We should
       // find a less fragile solution.
-      include: [
-        // from check-core
-        'assert-never',
-        'ajv',
-        'neverthrow',
-        'yaml',
-        // from check-ui-shell
-        'fontfaceobserver',
-        'copy-text-to-clipboard',
-        'chart.js'
-      ],
+      // include: [
+      //   // from check-core
+      //   'assert-never',
+      //   'ajv',
+      //   'neverthrow',
+      //   'yaml',
+      //   // from check-ui-shell
+      //   'fontfaceobserver',
+      //   'copy-text-to-clipboard',
+      //   'chart.js'
+      // ],
 
       exclude: [
         // XXX: The threads.js implementation references `tiny-worker` as an optional
         // dependency, but it doesn't get used at runtime, so we can just exclude it
         // so that Vite doesn't complain in dev mode
-        'tiny-worker',
+        'tiny-worker'
 
         // XXX: Similarly, chart.js treats `moment` as an optional dependency, but we
         // don't use it at runtime; we need to exclude it here, otherwise Vite will
         // complain about missing dependencies in dev mode
-        'moment'
+        // 'moment'
       ]
     },
 
@@ -152,7 +152,8 @@ export function createViteConfigForReport(
         noopPolyfillAlias('events'),
         noopPolyfillAlias('os'),
         noopPolyfillAlias('path'),
-        noopPolyfillAlias('url')
+        noopPolyfillAlias('url'),
+        noopPolyfillAlias('worker_threads')
       ]
     },
 
@@ -175,11 +176,12 @@ export function createViteConfigForReport(
       // the glob handler (which requires the glob to be injected as a literal)
       replace({
         preventAssignment: true,
+        delimiters: ['', ''],
         values: {
           // Inject the path for baseline bundles
-          __BASELINE_BUNDLES_PATH__: JSON.stringify(baselinesPath)
+          './__BASELINE_BUNDLES_PATH__': baselinesPath
         }
-      }) as PluginOption
+      }) as unknown as PluginOption
     ],
 
     build: {

--- a/packages/plugin-check/src/vite-config-for-report.ts
+++ b/packages/plugin-check/src/vite-config-for-report.ts
@@ -105,17 +105,17 @@ export function createViteConfigForReport(
       // As a terrible workaround, explicitly include the direct dependencies so
       // that Vite optimizes them; this works for pnpm, yarn, and npm.  We should
       // find a less fragile solution.
-      // include: [
-      //   // from check-core
-      //   'assert-never',
-      //   'ajv',
-      //   'neverthrow',
-      //   'yaml',
-      //   // from check-ui-shell
-      //   'fontfaceobserver',
-      //   'copy-text-to-clipboard',
-      //   'chart.js'
-      // ],
+      include: [
+        // from check-core
+        '@sdeverywhere/check-core > assert-never',
+        '@sdeverywhere/check-core > ajv',
+        '@sdeverywhere/check-core > neverthrow',
+        '@sdeverywhere/check-core > yaml',
+        // from check-ui-shell
+        '@sdeverywhere/check-ui-shell > fontfaceobserver',
+        '@sdeverywhere/check-ui-shell > copy-text-to-clipboard',
+        '@sdeverywhere/check-ui-shell > chart.js'
+      ],
 
       exclude: [
         // XXX: The threads.js implementation references `tiny-worker` as an optional

--- a/packages/plugin-check/src/vite-config-for-report.ts
+++ b/packages/plugin-check/src/vite-config-for-report.ts
@@ -150,6 +150,7 @@ export function createViteConfigForReport(
         // implementation of threads.js; this allows us to use one bundle that works in both
         // Node and browser environments
         noopPolyfillAlias('events'),
+        noopPolyfillAlias('fs'),
         noopPolyfillAlias('os'),
         noopPolyfillAlias('path'),
         noopPolyfillAlias('url'),

--- a/packages/plugin-check/src/vite-config-for-tests.ts
+++ b/packages/plugin-check/src/vite-config-for-tests.ts
@@ -3,7 +3,8 @@
 import { dirname, relative, resolve as resolvePath } from 'path'
 import { fileURLToPath } from 'url'
 
-import type { InlineConfig } from 'vite'
+import type { InlineConfig, PluginOption } from 'vite'
+import replace from '@rollup/plugin-replace'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -44,11 +45,20 @@ export function createViteConfigForTests(projDir: string, prepDir: string, mode:
     // TODO: Disable vite output by default?
     // logLevel: 'silent',
 
-    // Inject special values into the generated JS
-    define: {
-      // Inject the glob pattern for matching check yaml files
-      __YAML_PATH__: JSON.stringify(yamlPath)
-    },
+    plugins: [
+      // Inject special values into the generated JS
+      // TODO: We currently have to use `@rollup/plugin-replace` instead of Vite's
+      // built-in `define` feature because the latter does not seem to run before
+      // the glob handler (which requires the glob to be injected as a literal)
+      replace({
+        preventAssignment: true,
+        delimiters: ['', ''],
+        values: {
+          // Inject the glob pattern for matching check yaml files
+          './__YAML_PATH__': yamlPath
+        }
+      }) as unknown as PluginOption
+    ],
 
     build: {
       // Write output files to the configured directory (instead of the default `dist`);

--- a/packages/plugin-check/template-report/src/env.d.ts
+++ b/packages/plugin-check/template-report/src/env.d.ts
@@ -2,7 +2,6 @@
 
 // These values are injected by Vite at build time, so we need to
 // declare types for them here
-declare const __BASELINE_BUNDLES_PATH__: string
 declare const __BASELINE_NAME__: string
 declare const __CURRENT_NAME__: string
 declare const __SUITE_SUMMARY_JSON__: string

--- a/packages/plugin-check/template-report/src/index.ts
+++ b/packages/plugin-check/template-report/src/index.ts
@@ -45,14 +45,18 @@ const availableBundles: { [key: string]: LoadBundle } = {}
 let bundleNames: string[]
 let selectedBaselineBundleName: string
 let selectedCurrentBundleName: string
-const baselinesPath = __BASELINE_BUNDLES_PATH__
+// The following value will be injected by `vite-config-for-report.ts`
+const baselinesPath = './__BASELINE_BUNDLES_PATH__'
 if (import.meta.hot && baselinesPath) {
   // Restore the previously selected bundles (from before the page was reloaded)
   selectedBaselineBundleName = loadBundleName('baseline')
   selectedCurrentBundleName = loadBundleName('current')
 
-  // Get the available baseline bundles
-  const bundlesGlob = import.meta.glob(__BASELINE_BUNDLES_PATH__, {
+  // Get the available baseline bundles.  The `./__BASELINE_BUNDLES_PATH__` part
+  // will be replaced by Vite (see `vite-config-for-report.ts`).  Note that we
+  // provide a placeholder here that looks like a valid glob pattern, since Vite's
+  // dependency resolver will report errors if it is invalid (not a literal).
+  const bundlesGlob = import.meta.glob('./__BASELINE_BUNDLES_PATH__', {
     eager: false
   })
   const baselineBundleNames: string[] = []

--- a/packages/plugin-check/template-tests/src/env.d.ts
+++ b/packages/plugin-check/template-tests/src/env.d.ts
@@ -1,5 +1,0 @@
-// Copyright (c) 2022 Climate Interactive / New Venture Fund
-
-// These values are injected by Vite at build time, so we need to
-// declare types for them here
-declare const __YAML_PATH__: string

--- a/packages/plugin-check/template-tests/src/index.ts
+++ b/packages/plugin-check/template-tests/src/index.ts
@@ -12,8 +12,11 @@ import type {
   InputVar
 } from '@sdeverywhere/check-core'
 
-// Load the yaml test files
-const yamlGlob = import.meta.glob(__YAML_PATH__, {
+// Load the yaml test files.  The `./__YAML_PATH__` part will be replaced by Vite
+// (see `vite-config-for-tests.ts`).  Note that we provide a placeholder here that
+// looks like a valid glob pattern, since Vite's dependency resolver will report
+// errors if it is invalid (not a literal).
+const yamlGlob = import.meta.glob('./__YAML_PATH__', {
   eager: true,
   as: 'raw'
 })

--- a/packages/plugin-vite/docs/interfaces/VitePluginOptions.md
+++ b/packages/plugin-vite/docs/interfaces/VitePluginOptions.md
@@ -30,10 +30,10 @@ Specifies the behavior of the plugin for different `sde` build modes.
 
 | Name | Type |
 | :------ | :------ |
-| `development?` | ``"watch"`` \| ``"serve"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"`` |
+| `development?` | ``"serve"`` \| ``"watch"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"`` |
 | `production?` | ``"skip"`` \| ``"post-generate"`` \| ``"post-build"`` |
 
-**development?**: ``"watch"`` \| ``"serve"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"``
+**development?**: ``"serve"`` \| ``"watch"`` \| ``"skip"`` \| ``"post-generate"`` \| ``"post-build"``
 
 The behavior of the plugin when sde is configured for development mode.
 

--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@sdeverywhere/build": "*",
-    "vite": "3.1.3"
+    "vite": "^3.2.7"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -31,11 +31,11 @@
   },
   "peerDependencies": {
     "@sdeverywhere/build": "^0.3.0",
-    "vite": "^3.0.0"
+    "vite": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@sdeverywhere/build": "*",
-    "vite": "^3.2.7"
+    "vite": "^4.4.9"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/packages/plugin-worker/package.json
+++ b/packages/plugin-worker/package.json
@@ -35,7 +35,7 @@
     "@sdeverywhere/runtime": "^0.2.0",
     "@sdeverywhere/runtime-async": "^0.2.0",
     "rollup": "^2.76.0",
-    "vite": "^3.1.3"
+    "vite": "^3.2.7"
   },
   "dependenciesComments": {
     "rollup": [

--- a/packages/plugin-worker/package.json
+++ b/packages/plugin-worker/package.json
@@ -31,20 +31,9 @@
     "ci:build": "run-s clean lint prettier:check test:ci type-check build docs"
   },
   "dependencies": {
-    "@rollup/plugin-node-resolve": "^13.3.0",
     "@sdeverywhere/runtime": "^0.2.0",
     "@sdeverywhere/runtime-async": "^0.2.0",
-    "rollup": "^2.76.0",
-    "vite": "^3.2.7"
-  },
-  "dependenciesComments": {
-    "rollup": [
-      "XXX: For now, rollup is listed as a dependency even though it is not actually",
-      "needed since we only use the @rollup plugins with vite.  Those @rollup plugins",
-      "don't technically need rollup to function properly, but they list rollup as a",
-      "required peer dependency.  To avoid making consumers worry about this, we list",
-      "it as a dependency here."
-    ]
+    "vite": "4.4.9"
   },
   "peerDependencies": {
     "@sdeverywhere/build": "^0.3.0"

--- a/packages/plugin-worker/src/vite-config.ts
+++ b/packages/plugin-worker/src/vite-config.ts
@@ -3,8 +3,7 @@
 import { dirname, resolve as resolvePath } from 'path'
 import { fileURLToPath } from 'url'
 
-import type { InlineConfig, Plugin as VitePlugin, ResolverObject } from 'vite'
-import { nodeResolve } from '@rollup/plugin-node-resolve'
+import type { InlineConfig, Plugin as VitePlugin } from 'vite'
 
 import type { ModelSpec } from '@sdeverywhere/build'
 
@@ -94,19 +93,18 @@ export function createViteConfig(
         {
           find: '@_wasm_',
           replacement: resolvePath(stagedModelDir, modelJsFile)
-        },
-
-        // XXX: Prevent Vite from using the `browser` section of `threads/package.json`
-        // since we want to force the use of the general module (under dist) that chooses
-        // the correct implementation (Web Worker vs worker_threads) at runtime.  Currently
-        // Vite's library mode is browser focused, so using a `customResolver` seems to be
-        // the easiest way to prevent Vite from picking up the `browser` exports.
-        {
-          find: 'threads',
-          replacement: 'threads',
-          customResolver: nodeResolve({ browser: false }) as ResolverObject
         }
-      ]
+      ],
+
+      // XXX: Prevent Vite from using the `browser` section of `threads/package.json`
+      // since we want to force the use of the general module (under dist) that chooses
+      // the correct implementation (Web Worker vs worker_threads) at runtime.  This
+      // gets the job done, but is fragile because it applies to all dependencies even
+      // though we really only need this workaround for the threads package.  Fortunately
+      // the worker template is very simple (only depends on `@sdeverywhere/runtime-async`,
+      // which in turn only depends on `@sdeverywhere/runtime` and `threads`, so we should
+      // be safe to use this workaround for a while.
+      browserField: false
     },
 
     plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vitest:
-        specifier: ^0.23.4
-        version: 0.23.4
+        specifier: ^0.34.3
+        version: 0.34.3
 
   examples/hello-world:
     dependencies:
@@ -120,7 +120,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.5.7)
+        version: 3.2.7(sass@1.52.3)
 
   examples/sample-check-tests:
     dependencies:
@@ -133,7 +133,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.5.7)
+        version: 3.2.7(sass@1.52.3)
 
   packages/build:
     dependencies:
@@ -438,7 +438,7 @@ importers:
         version: link:../build
       vite:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.5.7)
+        version: 3.2.7(sass@1.52.3)
 
   packages/plugin-wasm:
     dependencies:
@@ -865,6 +865,13 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
@@ -968,6 +975,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
   /@sveltejs/vite-plugin-svelte@1.0.8(svelte@3.59.2)(vite@3.2.7):
     resolution: {integrity: sha512-1xkVTB4pm6zuign858FzVYE9Fdw9MQBOlxrdd85STV0NvTDmcofcRpcrK+zcIyT8SZ2dseHLu8hvDwzssF6RfA==}
     engines: {node: ^14.18.0 || >= 16}
@@ -1002,11 +1013,11 @@ packages:
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.3
+      '@types/chai': 4.3.5
     dev: true
 
-  /@types/chai@4.3.3:
-    resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+  /@types/chai@4.3.5:
+    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: true
 
   /@types/chart.js@2.9.37:
@@ -1053,10 +1064,6 @@ packages:
 
   /@types/marked@4.0.6:
     resolution: {integrity: sha512-ITAVUzsnVbhy5afxhs4PPPbrv2hKVEDH5BhhaQNQlVG0UNu+9A18XSdYr53nBdHZ0ADEQLl+ciOjXbs7eHdiQQ==}
-    dev: true
-
-  /@types/node@17.0.42:
-    resolution: {integrity: sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==}
     dev: true
 
   /@types/node@20.5.7:
@@ -1242,12 +1249,55 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /@vitest/expect@0.34.3:
+    resolution: {integrity: sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==}
+    dependencies:
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
+      chai: 4.3.8
+    dev: true
+
+  /@vitest/runner@0.34.3:
+    resolution: {integrity: sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==}
+    dependencies:
+      '@vitest/utils': 0.34.3
+      p-limit: 4.0.0
+      pathe: 1.1.1
+    dev: true
+
+  /@vitest/snapshot@0.34.3:
+    resolution: {integrity: sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==}
+    dependencies:
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      pretty-format: 29.6.3
+    dev: true
+
+  /@vitest/spy@0.34.3:
+    resolution: {integrity: sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==}
+    dependencies:
+      tinyspy: 2.1.1
+    dev: true
+
+  /@vitest/utils@0.34.3:
+    resolution: {integrity: sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.6
+      pretty-format: 29.6.3
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.10.0
+    dev: true
+
+  /acorn-walk@8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /acorn@7.4.1:
@@ -1258,12 +1308,6 @@ packages:
 
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
-
-  /acorn@8.8.0:
-    resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -1325,6 +1369,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
 
   /antlr4-vensim@0.6.0:
     resolution: {integrity: sha512-bZFRZ5wpzKEa8N2BeExZaE0xlH9hZqGHDYnCmt+sy5bh0u4L0FyI1dNQin/Ao+MH/80eO9ImgDL1yQ/exoKhmA==}
@@ -1462,6 +1511,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1481,13 +1535,13 @@ packages:
       crc-32: 1.2.2
     dev: false
 
-  /chai@4.3.6:
-    resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}
+  /chai@4.3.8:
+    resolution: {integrity: sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
       check-error: 1.0.2
-      deep-eql: 3.0.1
+      deep-eql: 4.1.3
       get-func-name: 2.0.0
       loupe: 2.3.4
       pathval: 1.1.1
@@ -1676,9 +1730,9 @@ packages:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
 
-  /deep-eql@3.0.1:
-    resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
-    engines: {node: '>=0.12'}
+  /deep-eql@4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
     dependencies:
       type-detect: 4.0.8
     dev: true
@@ -1714,6 +1768,11 @@ packages:
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /dir-glob@3.0.1:
@@ -2875,8 +2934,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /local-pkg@0.4.2:
-    resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
     dev: true
 
@@ -2916,6 +2975,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /loupe@2.3.6:
+    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    dependencies:
+      get-func-name: 2.0.0
+    dev: true
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -2945,6 +3010,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
+
+  /magic-string@0.30.3:
+    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /marked@4.3.0:
@@ -3023,6 +3095,15 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.6
+    dev: true
+
+  /mlly@1.4.1:
+    resolution: {integrity: sha512-SCDs78Q2o09jiZiE2WziwVBEqXQ02XkGdUy45cbJf+BpYRIjArXRJ1Wbowxkb+NaM9DWvS3UC9GiO/6eqvQ/pg==}
+    dependencies:
+      acorn: 8.10.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      ufo: 1.3.0
     dev: true
 
   /moment@2.29.3:
@@ -3206,7 +3287,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
-    dev: false
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -3284,6 +3364,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
+
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -3311,6 +3395,14 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.4.1
+      pathe: 1.1.1
+    dev: true
+
   /postcss-load-config@4.0.1:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -3335,15 +3427,6 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /postcss@8.4.16:
-    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.4
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
-
   /postcss@8.4.29:
     resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3361,6 +3444,15 @@ packages:
     resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  /pretty-format@29.6.3:
+    resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
 
   /printj@1.1.2:
     resolution: {integrity: sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==}
@@ -3485,6 +3577,10 @@ packages:
     resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
     dev: false
 
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
+
   /read-pkg@3.0.0:
     resolution: {integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=}
     engines: {node: '>=4'}
@@ -3603,14 +3699,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
-
-  /rollup@2.78.1:
-    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
@@ -3744,6 +3832,10 @@ packages:
       object-inspect: 1.12.2
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3847,6 +3939,14 @@ packages:
       frac: 1.1.2
     dev: false
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@3.4.3:
+    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
+    dev: true
+
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3932,10 +4032,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal@0.4.2:
-    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
-      acorn: 8.8.0
+      acorn: 8.10.0
     dev: true
 
   /sucrase@3.21.0:
@@ -4132,8 +4232,8 @@ packages:
     dev: false
     optional: true
 
-  /tinybench@2.1.5:
-    resolution: {integrity: sha512-ak+PZZEuH3mw6CCFOgf5S90YH0MARnZNhxjhjguAmoJimEMAJuNip/rJRd6/wyylHItomVpKTzZk9zrhTrQCoQ==}
+  /tinybench@2.5.0:
+    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
   /tinydate@1.3.0:
@@ -4141,13 +4241,13 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /tinypool@0.3.0:
-    resolution: {integrity: sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==}
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@1.0.2:
-    resolution: {integrity: sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==}
+  /tinyspy@2.1.1:
+    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -4277,6 +4377,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ufo@1.3.0:
+    resolution: {integrity: sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==}
+    dev: true
+
   /uglify-js@3.16.0:
     resolution: {integrity: sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==}
     engines: {node: '>=0.8.0'}
@@ -4315,31 +4419,25 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite@3.1.3:
-    resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  /vite-node@0.34.3(@types/node@20.5.7):
+    resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      terser:
-        optional: true
     dependencies:
-      esbuild: 0.15.9
-      postcss: 8.4.16
-      resolve: 1.22.1
-      rollup: 2.78.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.1
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 3.2.7(@types/node@20.5.7)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vite@3.2.7(@types/node@20.5.7):
@@ -4409,9 +4507,9 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.23.4:
-    resolution: {integrity: sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==}
-    engines: {node: '>=v14.16.0'}
+  /vitest@0.34.3:
+    resolution: {integrity: sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -4419,6 +4517,9 @@ packages:
       '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4430,22 +4531,42 @@ packages:
         optional: true
       jsdom:
         optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
     dependencies:
-      '@types/chai': 4.3.3
+      '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 17.0.42
-      chai: 4.3.6
+      '@types/node': 20.5.7
+      '@vitest/expect': 0.34.3
+      '@vitest/runner': 0.34.3
+      '@vitest/snapshot': 0.34.3
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.8
       debug: 4.3.4
-      local-pkg: 0.4.2
-      strip-literal: 0.4.2
-      tinybench: 2.1.5
-      tinypool: 0.3.0
-      tinyspy: 1.0.2
-      vite: 3.1.3
+      local-pkg: 0.4.3
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.0
+      tinypool: 0.7.0
+      vite: 3.2.7(@types/node@20.5.7)
+      vite-node: 0.34.3(@types/node@20.5.7)
+      why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
       - sass
       - stylus
+      - sugarss
       - supports-color
       - terser
     dev: true
@@ -4509,6 +4630,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
 
   /with@7.0.2:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
@@ -4604,4 +4734,3 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.8
-        version: 1.0.8(svelte@3.59.2)(vite@3.1.3)
+        version: 1.0.8(svelte@3.59.2)(vite@3.2.7)
       postcss:
         specifier: ^8.2.14
         version: 8.4.14
@@ -106,8 +106,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(postcss@8.4.14)(pug@3.0.2)(sass@1.52.3)(svelte@3.59.2)(typescript@5.2.2)
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(sass@1.52.3)
 
   examples/sample-check-bundle:
     dependencies:
@@ -119,8 +119,8 @@ importers:
         version: 1.2.1
     devDependencies:
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@20.5.7)
 
   examples/sample-check-tests:
     dependencies:
@@ -132,8 +132,8 @@ importers:
         version: 1.2.1
     devDependencies:
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@20.5.7)
 
   packages/build:
     dependencies:
@@ -210,7 +210,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.8
-        version: 1.0.8(svelte@3.59.2)(vite@3.1.3)
+        version: 1.0.8(svelte@3.59.2)(vite@3.2.7)
       '@types/chart.js':
         specifier: ^2.9.34
         version: 2.9.37
@@ -239,8 +239,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(postcss@8.4.14)(pug@3.0.2)(sass@1.52.3)(svelte@3.59.2)(typescript@5.2.2)
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(sass@1.52.3)
 
   packages/cli:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: ^2.76.0
         version: 2.76.0
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@20.5.7)
     devDependencies:
       '@sdeverywhere/build':
         specifier: '*'
@@ -437,8 +437,8 @@ importers:
         specifier: '*'
         version: link:../build
       vite:
-        specifier: 3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@20.5.7)
 
   packages/plugin-wasm:
     dependencies:
@@ -468,8 +468,8 @@ importers:
         specifier: ^2.76.0
         version: 2.76.0
       vite:
-        specifier: ^3.1.3
-        version: 3.1.3(sass@1.52.3)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@20.5.7)
     devDependencies:
       '@sdeverywhere/build':
         specifier: '*'
@@ -968,7 +968,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@1.0.8(svelte@3.59.2)(vite@3.1.3):
+  /@sveltejs/vite-plugin-svelte@1.0.8(svelte@3.59.2)(vite@3.2.7):
     resolution: {integrity: sha512-1xkVTB4pm6zuign858FzVYE9Fdw9MQBOlxrdd85STV0NvTDmcofcRpcrK+zcIyT8SZ2dseHLu8hvDwzssF6RfA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -988,7 +988,7 @@ packages:
       magic-string: 0.26.4
       svelte: 3.59.2
       svelte-hmr: 0.15.0(svelte@3.59.2)
-      vite: 3.1.3(sass@1.52.3)
+      vite: 3.2.7(sass@1.52.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2561,6 +2561,7 @@ packages:
 
   /immutable@4.1.0:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
+    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -3052,6 +3053,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -3076,7 +3082,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.0
+      resolve: 1.22.1
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -3336,6 +3342,15 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /postcss@8.4.29:
+    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3399,7 +3414,7 @@ packages:
       jstransformer: 1.0.0
       pug-error: 2.0.0
       pug-walk: 2.0.0
-      resolve: 1.22.0
+      resolve: 1.22.1
     dev: true
 
   /pug-lexer@5.0.1:
@@ -3498,7 +3513,7 @@ packages:
     resolution: {integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=}
     engines: {node: '>= 0.10'}
     dependencies:
-      resolve: 1.22.0
+      resolve: 1.22.1
     dev: false
 
   /regexp.prototype.flags@1.4.3:
@@ -3537,6 +3552,7 @@ packages:
       is-core-module: 2.9.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /resolve@1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
@@ -3594,6 +3610,14 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /rollup@2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
 
   /rollup@3.28.1:
     resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
@@ -3647,6 +3671,7 @@ packages:
       chokidar: 3.5.3
       immutable: 4.1.0
       source-map-js: 1.0.2
+    dev: true
 
   /semiver@1.1.0:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
@@ -4290,7 +4315,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite@3.1.3(sass@1.52.3):
+  /vite@3.1.3:
     resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -4313,9 +4338,76 @@ packages:
       postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.78.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@3.2.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.5.7
+      esbuild: 0.15.9
+      postcss: 8.4.29
+      resolve: 1.22.1
+      rollup: 2.79.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@3.2.7(sass@1.52.3):
+    resolution: {integrity: sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.15.9
+      postcss: 8.4.29
+      resolve: 1.22.1
+      rollup: 2.79.1
       sass: 1.52.3
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vitest@0.23.4:
     resolution: {integrity: sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==}
@@ -4349,7 +4441,7 @@ packages:
       tinybench: 2.1.5
       tinypool: 0.3.0
       tinyspy: 1.0.2
-      vite: 3.1.3(sass@1.52.3)
+      vite: 3.1.3
     transitivePeerDependencies:
       - less
       - sass

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         version: link:../sample-check-tests
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^1.4.0
-        version: 1.4.0(svelte@3.59.2)(vite@3.2.7)
+        specifier: ^2.4.5
+        version: 2.4.5(svelte@3.59.2)(vite@4.4.9)
       postcss:
         specifier: ^8.2.14
         version: 8.4.14
@@ -106,8 +106,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(postcss@8.4.14)(pug@3.0.2)(sass@1.52.3)(svelte@3.59.2)(typescript@5.2.2)
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(sass@1.52.3)
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   examples/sample-check-bundle:
     dependencies:
@@ -119,8 +119,8 @@ importers:
         version: 1.2.1
     devDependencies:
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(sass@1.52.3)
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   examples/sample-check-tests:
     dependencies:
@@ -132,8 +132,8 @@ importers:
         version: 1.2.1
     devDependencies:
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(sass@1.52.3)
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   packages/build:
     dependencies:
@@ -209,8 +209,8 @@ importers:
         version: 2.3.0
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^1.4.0
-        version: 1.4.0(svelte@3.59.2)(vite@3.2.7)
+        specifier: ^2.4.5
+        version: 2.4.5(svelte@3.59.2)(vite@4.4.9)
       '@types/chart.js':
         specifier: ^2.9.34
         version: 2.9.37
@@ -239,8 +239,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(postcss@8.4.14)(pug@3.0.2)(sass@1.52.3)(svelte@3.59.2)(typescript@5.2.2)
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(sass@1.52.3)
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   packages/cli:
     dependencies:
@@ -354,8 +354,8 @@ importers:
         specifier: ^13.3.0
         version: 13.3.0(rollup@2.76.0)
       '@rollup/plugin-replace':
-        specifier: ^4.0.0
-        version: 4.0.0(rollup@2.76.0)
+        specifier: ^5.0.2
+        version: 5.0.2(rollup@2.76.0)
       '@sdeverywhere/check-core':
         specifier: ^0.1.1
         version: link:../check-core
@@ -381,8 +381,8 @@ importers:
         specifier: ^2.76.0
         version: 2.76.0
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.5.7)
+        specifier: 4.4.9
+        version: 4.4.9(@types/node@20.5.7)
     devDependencies:
       '@sdeverywhere/build':
         specifier: '*'
@@ -437,8 +437,8 @@ importers:
         specifier: '*'
         version: link:../build
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(sass@1.52.3)
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   packages/plugin-wasm:
     dependencies:
@@ -455,21 +455,15 @@ importers:
 
   packages/plugin-worker:
     dependencies:
-      '@rollup/plugin-node-resolve':
-        specifier: ^13.3.0
-        version: 13.3.0(rollup@2.76.0)
       '@sdeverywhere/runtime':
         specifier: ^0.2.0
         version: link:../runtime
       '@sdeverywhere/runtime-async':
         specifier: ^0.2.0
         version: link:../runtime-async
-      rollup:
-        specifier: ^2.76.0
-        version: 2.76.0
       vite:
-        specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.5.7)
+        specifier: 4.4.9
+        version: 4.4.9(@types/node@20.5.7)
     devDependencies:
       '@sdeverywhere/build':
         specifier: '*'
@@ -575,7 +569,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.15.9:
@@ -584,6 +577,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -592,7 +586,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.18.20:
@@ -601,7 +594,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -610,7 +602,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.18.20:
@@ -619,7 +610,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -628,7 +618,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.18.20:
@@ -637,7 +626,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -646,7 +634,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.18.20:
@@ -655,7 +642,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -664,7 +650,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.15.9:
@@ -673,6 +658,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -681,7 +667,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -690,7 +675,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.18.20:
@@ -699,7 +683,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -708,7 +691,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.18.20:
@@ -717,7 +699,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -726,7 +707,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.18.20:
@@ -735,7 +715,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -744,7 +723,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.18.20:
@@ -753,7 +731,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.20:
@@ -762,7 +739,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.18.20:
@@ -771,7 +747,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.18.20:
@@ -780,7 +755,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
@@ -877,13 +851,8 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/sourcemap-codec@1.4.13:
-    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
-    dev: true
-
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.19:
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
@@ -939,16 +908,17 @@ packages:
       rollup: 2.76.0
     dev: false
 
-  /@rollup/plugin-replace@4.0.0(rollup@2.76.0):
-    resolution: {integrity: sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==}
+  /@rollup/plugin-replace@5.0.2(rollup@2.76.0):
+    resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.76.0)
-      magic-string: 0.25.9
+      '@rollup/pluginutils': 5.0.4(rollup@2.76.0)
+      magic-string: 0.27.0
       rollup: 2.76.0
     dev: false
 
@@ -967,28 +937,63 @@ packages:
       rollup: 2.76.0
     dev: false
 
+  /@rollup/pluginutils@5.0.4(rollup@2.76.0):
+    resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 2.76.0
+    dev: false
+
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.59.2)(vite@3.2.7):
-    resolution: {integrity: sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==}
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.5)(svelte@3.59.2)(vite@4.4.9):
+    resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
-      svelte: ^3.44.0
-      vite: ^3.0.0
+      '@sveltejs/vite-plugin-svelte': ^2.2.0
+      svelte: ^3.54.0 || ^4.0.0
+      vite: ^4.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
     dependencies:
+      '@sveltejs/vite-plugin-svelte': 2.4.5(svelte@3.59.2)(vite@4.4.9)
       debug: 4.3.4
-      deepmerge: 4.2.2
+      svelte: 3.59.2
+      vite: 4.4.9(sass@1.52.3)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@sveltejs/vite-plugin-svelte@2.4.5(svelte@3.59.2)(vite@4.4.9):
+    resolution: {integrity: sha512-UJKsFNwhzCVuiZd06jM/psscyNJNDwjQC+qIeb7GBJK9iWeQCcIyfcPWDvbCudfcJggY9jtxJeeaZH7uny93FQ==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      svelte: ^3.54.0 || ^4.0.0
+      vite: ^4.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.5)(svelte@3.59.2)(vite@4.4.9)
+      debug: 4.3.4
+      deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.26.7
+      magic-string: 0.30.3
       svelte: 3.59.2
       svelte-hmr: 0.15.3(svelte@3.59.2)
-      vite: 3.2.7(sass@1.52.3)
-      vitefu: 0.2.4(vite@3.2.7)
+      vite: 4.4.9(sass@1.52.3)
+      vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1031,6 +1036,10 @@ packages:
 
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: false
+
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: false
 
   /@types/folder-hash@4.0.1:
@@ -1733,6 +1742,12 @@ packages:
   /deepmerge@4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /defaults@1.0.3:
     resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
@@ -1866,6 +1881,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64@0.15.9:
@@ -1874,6 +1890,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64@0.15.9:
@@ -1882,6 +1899,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64@0.15.9:
@@ -1890,6 +1908,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64@0.15.9:
@@ -1898,6 +1917,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64@0.15.9:
@@ -1906,6 +1926,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32@0.15.9:
@@ -1914,6 +1935,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64@0.15.9:
@@ -1922,6 +1944,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64@0.15.9:
@@ -1930,6 +1953,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm@0.15.9:
@@ -1938,6 +1962,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le@0.15.9:
@@ -1946,6 +1971,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le@0.15.9:
@@ -1954,6 +1980,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64@0.15.9:
@@ -1962,6 +1989,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x@0.15.9:
@@ -1970,6 +1998,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64@0.15.9:
@@ -1978,6 +2007,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64@0.15.9:
@@ -1986,6 +2016,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64@0.15.9:
@@ -1994,6 +2025,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32@0.15.9:
@@ -2002,6 +2034,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64@0.15.9:
@@ -2010,6 +2043,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64@0.15.9:
@@ -2018,6 +2052,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild@0.15.9:
@@ -2048,6 +2083,7 @@ packages:
       esbuild-windows-32: 0.15.9
       esbuild-windows-64: 0.15.9
       esbuild-windows-arm64: 0.15.9
+    dev: true
 
   /esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2077,7 +2113,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -2235,6 +2270,10 @@ packages:
 
   /estree-walker@1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: false
+
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: false
 
   /esutils@2.0.3:
@@ -2977,25 +3016,11 @@ packages:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
     dev: true
 
-  /magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: false
-
-  /magic-string@0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
-    engines: {node: '>=12'}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: true
-
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.13
-    dev: true
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   /magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
@@ -3691,6 +3716,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup@3.28.1:
     resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
@@ -3698,7 +3724,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3882,10 +3907,6 @@ packages:
     dependencies:
       whatwg-url: 7.1.0
     dev: true
-
-  /sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   /spdx-correct@3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
@@ -4415,10 +4436,11 @@ packages:
       mlly: 1.4.1
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 3.2.7(@types/node@20.5.7)
+      vite: 4.4.9(@types/node@20.5.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -4458,14 +4480,16 @@ packages:
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
-  /vite@3.2.7(sass@1.52.3):
-    resolution: {integrity: sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==}
+  /vite@4.4.9(@types/node@20.5.7):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
+      lightningcss: ^1.21.0
       sass: '*'
       stylus: '*'
       sugarss: '*'
@@ -4474,6 +4498,8 @@ packages:
       '@types/node':
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -4484,16 +4510,50 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.15.9
+      '@types/node': 20.5.7
+      esbuild: 0.18.20
       postcss: 8.4.29
-      resolve: 1.22.1
-      rollup: 2.79.1
+      rollup: 3.28.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@4.4.9(sass@1.52.3):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.29
+      rollup: 3.28.1
       sass: 1.52.3
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu@0.2.4(vite@3.2.7):
+  /vitefu@0.2.4(vite@4.4.9):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -4501,7 +4561,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 3.2.7(sass@1.52.3)
+      vite: 4.4.9(sass@1.52.3)
     dev: true
 
   /vitest@0.34.3:
@@ -4561,6 +4621,7 @@ packages:
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         version: link:../sample-check-tests
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^1.0.8
-        version: 1.0.8(svelte@3.59.2)(vite@3.2.7)
+        specifier: ^1.4.0
+        version: 1.4.0(svelte@3.59.2)(vite@3.2.7)
       postcss:
         specifier: ^8.2.14
         version: 8.4.14
@@ -209,8 +209,8 @@ importers:
         version: 2.3.0
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^1.0.8
-        version: 1.0.8(svelte@3.59.2)(vite@3.2.7)
+        specifier: ^1.4.0
+        version: 1.4.0(svelte@3.59.2)(vite@3.2.7)
       '@types/chart.js':
         specifier: ^2.9.34
         version: 2.9.37
@@ -967,39 +967,28 @@ packages:
       rollup: 2.76.0
     dev: false
 
-  /@rollup/pluginutils@4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@1.0.8(svelte@3.59.2)(vite@3.2.7):
-    resolution: {integrity: sha512-1xkVTB4pm6zuign858FzVYE9Fdw9MQBOlxrdd85STV0NvTDmcofcRpcrK+zcIyT8SZ2dseHLu8hvDwzssF6RfA==}
+  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.59.2)(vite@3.2.7):
+    resolution: {integrity: sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
-      diff-match-patch: ^1.0.5
       svelte: ^3.44.0
       vite: ^3.0.0
     peerDependenciesMeta:
-      diff-match-patch:
-        optional: true
       svelte:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
       deepmerge: 4.2.2
       kleur: 4.1.5
-      magic-string: 0.26.4
+      magic-string: 0.26.7
       svelte: 3.59.2
-      svelte-hmr: 0.15.0(svelte@3.59.2)
+      svelte-hmr: 0.15.3(svelte@3.59.2)
       vite: 3.2.7(sass@1.52.3)
+      vitefu: 0.2.4(vite@3.2.7)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2248,10 +2237,6 @@ packages:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
     dev: false
 
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
-
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2998,8 +2983,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: false
 
-  /magic-string@0.26.4:
-    resolution: {integrity: sha512-e5uXtVJ22aEpK9u1+eQf0fSxHeqwyV19K+uGnlROCxUhzwRip9tBsaMViK/0vC3viyPd5Gtucp3UmEp/Q2cPTQ==}
+  /magic-string@0.26.7:
+    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
@@ -3900,6 +3885,7 @@ packages:
 
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   /spdx-correct@3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
@@ -4110,11 +4096,11 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr@0.15.0(svelte@3.59.2):
-    resolution: {integrity: sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==}
+  /svelte-hmr@0.15.3(svelte@3.59.2):
+    resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
-      svelte: '>=3.19.0'
+      svelte: ^3.19.0 || ^4.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -4505,6 +4491,17 @@ packages:
       sass: 1.52.3
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitefu@0.2.4(vite@3.2.7):
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 3.2.7(sass@1.52.3)
     dev: true
 
   /vitest@0.34.3:


### PR DESCRIPTION
Fixes #351 

This upgrades all uses of vite from 3.x (3.1.3) to the most recent 4.x (4.4.9).  See issue for more details.

All automated tests are passing, and I also tested the hello-world sample in isolation with pnpm, npm, and yarn and all seems OK.  I'll test again after I publish the new packages.