### PR TITLE
fix: add trivial changes to correct previous publish failures and force re-publish

### DIFF
--- a/packages/plugin-config/CHANGELOG.md
+++ b/packages/plugin-config/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.2.1](https://github.com/climateinteractive/SDEverywhere/compare/plugin-config-v0.2.0...plugin-config-v0.2.1) (2023-05-03)
 
-
 ### Bug Fixes
 
 * add inputId property to InputSpec interface ([#321](https://github.com/climateinteractive/SDEverywhere/issues/321)) ([f461433](https://github.com/climateinteractive/SDEverywhere/commit/f461433df9ae013e73a76a1103c9cb8a5d22ab52)), closes [#320](https://github.com/climateinteractive/SDEverywhere/issues/320)

--- a/packages/plugin-vite/CHANGELOG.md
+++ b/packages/plugin-vite/CHANGELOG.md
@@ -20,7 +20,6 @@ of whether your project is configured to use Vite 3 or Vite 4.
 
 ## [0.1.4](https://github.com/climateinteractive/SDEverywhere/compare/plugin-vite-v0.1.3...plugin-vite-v0.1.4) (2022-10-25)
 
-
 ### Bug Fixes
 
 * make vite a peer dependency for plugin-vite ([#269](https://github.com/climateinteractive/SDEverywhere/issues/269)) ([eaa02fc](https://github.com/climateinteractive/SDEverywhere/commit/eaa02fcb160735ea591f6074cecb662d1b24289c)), closes [#268](https://github.com/climateinteractive/SDEverywhere/issues/268)

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.2.1](https://github.com/climateinteractive/SDEverywhere/compare/runtime-v0.2.0...runtime-v0.2.1) (2023-09-28)
 
-
 ### Features
 
 * add support for capturing data for any variable at runtime ([#355](https://github.com/climateinteractive/SDEverywhere/issues/355)) ([5d12836](https://github.com/climateinteractive/SDEverywhere/commit/5d1283657ba99f6c7f8e30f8053f1906ac872af3)), closes [#105](https://github.com/climateinteractive/SDEverywhere/issues/105)


### PR DESCRIPTION
Fixes #361 

No behavior changes, just going through the motions to hopefully get `npm publish` to work the next time.