### PR TITLE
build: use vite preview in examples + update SDE dependencies in templates

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -53,7 +53,7 @@ pnpm dev
 pnpm build
 
 # Open the generated report in a browser
-pnpm serve
+pnpm preview
 ```
 
 ## License

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf ./sde-prep",
-    "build": "sde bundle",
     "dev": "sde dev",
-    "save-baseline": "sde-check baseline --save",
-    "serve": "sirv ./sde-prep/check-report"
+    "build": "sde bundle",
+    "vite": "vite",
+    "preview": "vite preview --open --outDir ./sde-prep/check-report",
+    "save-baseline": "sde-check baseline --save"
   },
   "dependencies": {
     "@sdeverywhere/build": "^0.3.0",
@@ -16,6 +17,6 @@
     "@sdeverywhere/plugin-check": "^0.3.0",
     "@sdeverywhere/plugin-wasm": "^0.2.0",
     "@sdeverywhere/plugin-worker": "^0.2.0",
-    "sirv-cli": "^2.0.2"
+    "vite": "^4.4.9"
   }
 }

--- a/examples/template-default/package.json
+++ b/examples/template-default/package.json
@@ -13,13 +13,13 @@
     "packages/app"
   ],
   "dependencies": {
-    "@sdeverywhere/build": "^0.3.0",
-    "@sdeverywhere/check-core": "^0.1.0",
-    "@sdeverywhere/cli": "^0.7.6",
-    "@sdeverywhere/plugin-check": "^0.3.0",
-    "@sdeverywhere/plugin-config": "^0.2.0",
-    "@sdeverywhere/plugin-vite": "^0.1.5",
-    "@sdeverywhere/plugin-wasm": "^0.2.0",
-    "@sdeverywhere/plugin-worker": "^0.2.0"
+    "@sdeverywhere/build": "^0.3.2",
+    "@sdeverywhere/check-core": "^0.1.1",
+    "@sdeverywhere/cli": "^0.7.12",
+    "@sdeverywhere/plugin-check": "^0.3.4",
+    "@sdeverywhere/plugin-config": "^0.2.3",
+    "@sdeverywhere/plugin-vite": "^0.1.8",
+    "@sdeverywhere/plugin-wasm": "^0.2.1",
+    "@sdeverywhere/plugin-worker": "^0.2.3"
   }
 }

--- a/examples/template-default/package.json
+++ b/examples/template-default/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "sde bundle",
     "dev": "sde dev",
+    "build": "sde bundle",
     "save-baseline": "sde-check baseline --save"
   },
   "workspaces": [

--- a/examples/template-default/packages/app/package.json
+++ b/examples/template-default/packages/app/package.json
@@ -9,8 +9,9 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "precommit": "../scripts/precommit",
+    "dev": "vite",
     "build": "vite build",
-    "dev": "vite"
+    "preview": "vite preview"
   },
   "dependencies": {
     "bootstrap-slider": "10.6.2",

--- a/examples/template-default/packages/core/package.json
+++ b/examples/template-default/packages/core/package.json
@@ -11,16 +11,14 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "eslint src --max-warnings 0",
-    "prettier:check": "prettier --check .",
-    "prettier:fix": "prettier --write .",
-    "precommit": "../scripts/precommit"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@sdeverywhere/runtime": "^0.2.0",
     "@sdeverywhere/runtime-async": "^0.2.0"
   },
   "devDependencies": {
+    "typescript": "^5.2.2",
     "vite": "^4.4.9"
   }
 }

--- a/examples/template-default/packages/core/package.json
+++ b/examples/template-default/packages/core/package.json
@@ -14,8 +14,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@sdeverywhere/runtime": "^0.2.0",
-    "@sdeverywhere/runtime-async": "^0.2.0"
+    "@sdeverywhere/runtime": "^0.2.2",
+    "@sdeverywhere/runtime-async": "^0.2.2"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/examples/template-minimal/package.json
+++ b/examples/template-minimal/package.json
@@ -9,11 +9,11 @@
     "save-baseline": "sde-check baseline --save"
   },
   "dependencies": {
-    "@sdeverywhere/build": "^0.3.0",
-    "@sdeverywhere/check-core": "^0.1.0",
-    "@sdeverywhere/cli": "^0.7.6",
-    "@sdeverywhere/plugin-check": "^0.3.0",
-    "@sdeverywhere/plugin-wasm": "^0.2.0",
-    "@sdeverywhere/plugin-worker": "^0.2.0"
+    "@sdeverywhere/build": "^0.3.2",
+    "@sdeverywhere/check-core": "^0.1.1",
+    "@sdeverywhere/cli": "^0.7.12",
+    "@sdeverywhere/plugin-check": "^0.3.4",
+    "@sdeverywhere/plugin-wasm": "^0.2.1",
+    "@sdeverywhere/plugin-worker": "^0.2.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       '@sdeverywhere/plugin-worker':
         specifier: ^0.2.0
         version: link:../../packages/plugin-worker
-      sirv-cli:
-        specifier: ^2.0.2
-        version: 2.0.2
+      vite:
+        specifier: ^4.4.9
+        version: 4.4.9(sass@1.52.3)
 
   examples/sample-check-app:
     dependencies:
@@ -928,10 +928,6 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@polka/url@1.0.0-next.21:
-    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
-    dev: false
-
   /@rollup/plugin-node-resolve@13.3.0(rollup@2.76.0):
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
     engines: {node: '>= 10.0.0'}
@@ -1708,11 +1704,6 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-
-  /console-clear@1.1.1:
-    resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
-    engines: {node: '>=4'}
-    dev: false
 
   /constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
@@ -2501,11 +2492,6 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /get-port@3.2.0:
-    resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
-    engines: {node: '>=4'}
-    dev: false
-
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -2686,7 +2672,6 @@ packages:
 
   /immutable@4.1.0:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
-    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -2954,11 +2939,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /kleur@4.1.4:
-    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -2994,11 +2974,6 @@ packages:
     resolution: {integrity: sha512-iyT2MXws+dc2Wi6o3grCFtGXpeMvHmJqS27sMPGtV2eUu4PeFnG+33I8BlFK1t1NWMjOpcx9bridn5yxLDX2gQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
-
-  /local-access@1.1.0:
-    resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
-    engines: {node: '>=6'}
-    dev: false
 
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
@@ -3164,11 +3139,7 @@ packages:
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
-    dev: false
+    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -3778,6 +3749,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mri: 1.2.0
+    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3811,12 +3783,6 @@ packages:
       chokidar: 3.5.3
       immutable: 4.1.0
       source-map-js: 1.0.2
-    dev: true
-
-  /semiver@1.1.0:
-    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
-    engines: {node: '>=6'}
-    dev: false
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -3890,30 +3856,6 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  /sirv-cli@2.0.2:
-    resolution: {integrity: sha512-OtSJDwxsF1NWHc7ps3Sa0s+dPtP15iQNJzfKVz+MxkEo3z72mCD+yu30ct79rPr0CaV1HXSOBp+MIY5uIhHZ1A==}
-    engines: {node: '>= 10'}
-    hasBin: true
-    dependencies:
-      console-clear: 1.1.1
-      get-port: 3.2.0
-      kleur: 4.1.4
-      local-access: 1.1.0
-      sade: 1.8.1
-      semiver: 1.1.0
-      sirv: 2.0.2
-      tinydate: 1.3.0
-    dev: false
-
-  /sirv@2.0.2:
-    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
-      totalist: 3.0.0
-    dev: false
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -4285,11 +4227,6 @@ packages:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
-  /tinydate@1.3.0:
-    resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
-    engines: {node: '>=4'}
-    dev: false
-
   /tinypool@0.7.0:
     resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
@@ -4314,11 +4251,6 @@ packages:
   /token-stream@1.0.0:
     resolution: {integrity: sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=}
     dev: true
-
-  /totalist@3.0.0:
-    resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
-    engines: {node: '>=6'}
-    dev: false
 
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -4593,7 +4525,6 @@ packages:
       sass: 1.52.3
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.4(vite@4.4.9):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}


### PR DESCRIPTION
Fixes #272 

This is a minor change to the example apps and the templates used by the `create` package.  No impact on published packages.

The removal of `sirv-cli` helps reduce the number of overall dev dependencies for the SDE repo.
