### PR TITLE
feat: allow for customizing emcc arguments in plugin-wasm

### DIFF
--- a/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
+++ b/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
@@ -6,10 +6,34 @@
 
 ### emsdkDir
 
- `Optional` **emsdkDir**: `string`
+ `Optional` **emsdkDir**: `string` \| () => `string`
 
 The path to the Emscripten SDK.  If undefined, the plugin will walk up the directory
 structure to find the nearest `emsdk` directory.
+
+___
+
+### emccArgs
+
+ `Optional` **emccArgs**: `string`[] \| () => `string`[]
+
+The array of additional arguments to pass to `emcc`.  If undefined, the plugin will
+use the following default set of arguments, which are tuned for (and known to work
+with) Emscripten versions 2.0.34 and 3.1.46, among others.
+```
+  -Wall
+  -Os
+  -s STRICT=1
+  -s MALLOC=emmalloc
+  -s FILESYSTEM=0
+  -s MODULARIZE=1
+  -s SINGLE_FILE=1
+  -s EXPORT_ES6=1
+  -s USE_ES6_IMPORT_META=0
+  -s ENVIRONMENT='web,webview,worker'
+  -s EXPORTED_FUNCTIONS=['_malloc','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
+  -s EXPORTED_RUNTIME_METHODS=['cwrap']
+```
 
 ___
 

--- a/packages/plugin-wasm/src/options.ts
+++ b/packages/plugin-wasm/src/options.ts
@@ -5,7 +5,28 @@ export interface WasmPluginOptions {
    * The path to the Emscripten SDK.  If undefined, the plugin will walk up the directory
    * structure to find the nearest `emsdk` directory.
    */
-  emsdkDir?: string
+  emsdkDir?: string | (() => string)
+
+  /**
+   * The array of additional arguments to pass to `emcc`.  If undefined, the plugin will
+   * use the following default set of arguments, which are tuned for (and known to work
+   * with) Emscripten versions 2.0.34 and 3.1.46, among others.
+   * ```
+   *   -Wall
+   *   -Os
+   *   -s STRICT=1
+   *   -s MALLOC=emmalloc
+   *   -s FILESYSTEM=0
+   *   -s MODULARIZE=1
+   *   -s SINGLE_FILE=1
+   *   -s EXPORT_ES6=1
+   *   -s USE_ES6_IMPORT_META=0
+   *   -s ENVIRONMENT='web,webview,worker'
+   *   -s EXPORTED_FUNCTIONS=['_malloc','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
+   *   -s EXPORTED_RUNTIME_METHODS=['cwrap']
+   * ```
+   */
+  emccArgs?: string[] | (() => string[])
 
   /**
    * The path of the resulting JS file (containing the embedded Wasm model).  If undefined,


### PR DESCRIPTION
Fixes #371 

This adds the ability to override the default arguments that are passed to the `emcc` command in plugin-wasm.

I also made it so that `emsdkDir` and `emccArgs` accept a `() => string` as an alternative to a plain string.  This makes it easier to experiment with arguments (by reading them from a file, for example) while dev mode remains running.
