### PR TITLE
build: use --threads=false and increase default timeout for build package tests

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -23,7 +23,7 @@
     "precommit": "../../scripts/precommit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ci": "vitest --threads=false run",
+    "test:ci": "vitest --threads=false --test-timeout=10000 run",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
     "docs": "../../scripts/gen-docs.js",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -23,7 +23,7 @@
     "precommit": "../../scripts/precommit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ci": "vitest run",
+    "test:ci": "vitest --threads=false run",
     "type-check": "tsc --noEmit -p tsconfig-build.json",
     "build": "tsup",
     "docs": "../../scripts/gen-docs.js",


### PR DESCRIPTION
This is an attempt to address the sporadic test failures that started occurring in the build package tests this week.  I'm not sure of the underlying cause or why it started happening suddenly, but running sequentially with a higher timeout seems to help so far.
