### PR TITLE
fix: allow lowercase cell reference in GET DIRECT function calls

### DIFF
--- a/models/directconst/directconst.mdl
+++ b/models/directconst/directconst.mdl
@@ -18,8 +18,12 @@ b[DimB] =
   GET DIRECT CONSTANTS(
     'data/b.csv',
     ',',
-    'B2*'
-  ) ~~~:SUPPLEMENTARY|
+    'b2*'
+  )
+  ~
+  ~ This one uses a lowercase letter in the cell reference (atypical, but valid in Vensim).
+  ~ :SUPPLEMENTARY
+  |
 
 c[DimB, DimC] =
   GET DIRECT CONSTANTS(

--- a/models/directdata/directdata.mdl
+++ b/models/directdata/directdata.mdl
@@ -8,7 +8,11 @@ SubM: M2, M3 ~~|
 a[DimA] := GET DIRECT DATA('?data', 'A Data', 'A', 'B2') ~~|
 b[DimA] = a[DimA] * 10 ~~~:SUPPLEMENTARY|
 
-c:= GET DIRECT DATA('?data', 'C Data', 'A', 'B2') ~~|
+c:= GET DIRECT DATA('?data', 'C Data', 'a', 'b2')
+  ~
+  ~ This one uses a lowercase letter in the cell references (atypical, but valid in Vensim).
+  ~ :SUPPLEMENTARY
+  |
 d = c * 10 ~~~:SUPPLEMENTARY|
 
 e[DimA] := GET DIRECT DATA('e_data.csv', ',', 'A', 'B2') ~~|

--- a/models/directlookups/directlookups.mdl
+++ b/models/directlookups/directlookups.mdl
@@ -1,9 +1,10 @@
 {UTF-8}
 DimA: A1, A2, A3 ~~|
 
-a[DimA] = GET DIRECT LOOKUPS('lookup_data.csv', ',', '1', 'E2')
+a[DimA] = GET DIRECT LOOKUPS('lookup_data.csv', ',', '1', 'e2')
 	~	
 	~	subscript currently required for GET DIRECT LOOKUPS
+	~	This one uses a lowercase letter in the cell reference (atypical, but valid in Vensim).
   |
 
 b = a[A1](Time)

--- a/models/directsubs/directsubs.mdl
+++ b/models/directsubs/directsubs.mdl
@@ -13,11 +13,14 @@ DimC:
 	GET DIRECT SUBSCRIPT(
 	   'c_subs.csv',
 	   ',',
-	   'A2',
+	   'a2',
 	   '2',
 	   ''
 	)
-  ~~|
+  ~
+  ~ This one uses a lowercase letter in the cell reference (atypical, but valid in Vensim).
+  ~ :SUPPLEMENTARY
+  |
 a[DimA] = 10, 20, 30
   ~~|
 b[DimB] = 1, 2, 3

--- a/packages/compile/src/generate/equation-gen.js
+++ b/packages/compile/src/generate/equation-gen.js
@@ -427,12 +427,17 @@ export default class EquationGen extends ModelReader {
     let dataCol, dataRow, dataValue, timeCol, timeRow, timeValue, nextCell
     let lookupData = ''
     let lookupSize = 0
-    let dataAddress = XLSX.utils.decode_cell(startCell)
+    let dataAddress = XLSX.utils.decode_cell(startCell.toUpperCase())
     dataCol = dataAddress.c
     dataRow = dataAddress.r
+    if (dataCol < 0 || dataRow < 0) {
+      throw new Error(
+        `Failed to parse 'cell' argument for GET DIRECT {DATA,LOOKUPS} call for ${this.lhs}: ${startCell}`
+      )
+    }
     if (isNaN(parseInt(timeRowOrCol))) {
       // Time values are in a column.
-      timeCol = XLSX.utils.decode_col(timeRowOrCol)
+      timeCol = XLSX.utils.decode_col(timeRowOrCol.toUpperCase())
       timeRow = dataRow
       dataCol += indexNum
       nextCell = () => {
@@ -529,9 +534,12 @@ export default class EquationGen extends ModelReader {
       // Read CSV data into an indexed variable for each cell.
       let numericSubscripts = lhsIndexSubscripts.map(idx => idx.map(s => sub(s).value))
       let lhsSubscripts = numericSubscripts.map(s => s.reduce((a, v) => a.concat(`[${v}]`), ''))
-      let dataAddress = XLSX.utils.decode_cell(startCell)
+      let dataAddress = XLSX.utils.decode_cell(startCell.toUpperCase())
       let startCol = dataAddress.c
       let startRow = dataAddress.r
+      if (startCol < 0 || startRow < 0) {
+        throw new Error(`Failed to parse 'cell' argument for GET DIRECT CONSTANTS call for ${this.lhs}: ${startCell}`)
+      }
       for (let i = 0; i < cellOffsets.length; i++) {
         let rowOffset = cellOffsets[i][0] ? cellOffsets[i][0] : 0
         let colOffset = cellOffsets[i][1] ? cellOffsets[i][1] : 0

--- a/packages/compile/src/model/read-equations.spec.ts
+++ b/packages/compile/src/model/read-equations.spec.ts
@@ -3936,8 +3936,8 @@ describe('readEquations', () => {
         refId: '_a',
         varType: 'const'
       }),
-      v('b[DimB]', "GET DIRECT CONSTANTS('data/b.csv',',','B2*')", {
-        directConstArgs: { file: 'data/b.csv', tab: ',', startCell: 'B2*' },
+      v('b[DimB]', "GET DIRECT CONSTANTS('data/b.csv',',','b2*')", {
+        directConstArgs: { file: 'data/b.csv', tab: ',', startCell: 'b2*' },
         refId: '_b',
         subscripts: ['_dimb'],
         varType: 'const'
@@ -4036,8 +4036,8 @@ describe('readEquations', () => {
         references: ['_a[_a1]', '_a[_a2]'],
         subscripts: ['_dima']
       }),
-      v('c', "GET DIRECT DATA('?data','C Data','A','B2')", {
-        directDataArgs: { file: '?data', tab: 'C Data', timeRowOrCol: 'A', startCell: 'B2' },
+      v('c', "GET DIRECT DATA('?data','C Data','a','b2')", {
+        directDataArgs: { file: '?data', tab: 'C Data', timeRowOrCol: 'a', startCell: 'b2' },
         refId: '_c',
         varType: 'data'
       }),
@@ -4210,22 +4210,22 @@ describe('readEquations', () => {
   it('should work for Vensim "directlookups" model', () => {
     const vars = readSubscriptsAndEquations('directlookups')
     expect(vars).toEqual([
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
-        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'E2' },
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
+        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'e2' },
         refId: '_a[_a1]',
         separationDims: ['_dima'],
         subscripts: ['_a1'],
         varType: 'data'
       }),
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
-        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'E2' },
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
+        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'e2' },
         refId: '_a[_a2]',
         separationDims: ['_dima'],
         subscripts: ['_a2'],
         varType: 'data'
       }),
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
-        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'E2' },
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
+        directDataArgs: { file: 'lookup_data.csv', tab: ',', timeRowOrCol: '1', startCell: 'e2' },
         refId: '_a[_a3]',
         separationDims: ['_dima'],
         subscripts: ['_a3'],

--- a/packages/compile/src/model/read-variables.spec.ts
+++ b/packages/compile/src/model/read-variables.spec.ts
@@ -370,7 +370,7 @@ describe('readVariables', () => {
     const vars = readSubscriptsAndVariables('directconst')
     expect(vars).toEqual([
       v('a', "GET DIRECT CONSTANTS('data/a.csv',',','B2')"),
-      v('b[DimB]', "GET DIRECT CONSTANTS('data/b.csv',',','B2*')", { subscripts: ['_dimb'] }),
+      v('b[DimB]', "GET DIRECT CONSTANTS('data/b.csv',',','b2*')", { subscripts: ['_dimb'] }),
       v('c[DimB,DimC]', "GET DIRECT CONSTANTS('data/c.csv',',','B2')", { subscripts: ['_dimb', '_dimc'] }),
       v('d[D1,DimB,DimC]', "GET DIRECT CONSTANTS('data/c.csv',',','B2')", { subscripts: ['_dimb', '_dimc', '_d1'] }),
       v('e[DimC,DimB]', "GET DIRECT CONSTANTS('data/c.csv',',','B2*')", { subscripts: ['_dimb', '_dimc'] }),
@@ -401,7 +401,7 @@ describe('readVariables', () => {
       v('a[DimA]', "GET DIRECT DATA('?data','A Data','A','B2')", { subscripts: ['_a1'], separationDims: ['_dima'] }),
       v('a[DimA]', "GET DIRECT DATA('?data','A Data','A','B2')", { subscripts: ['_a2'], separationDims: ['_dima'] }),
       v('b[DimA]', 'a[DimA]*10', { subscripts: ['_dima'] }),
-      v('c', "GET DIRECT DATA('?data','C Data','A','B2')"),
+      v('c', "GET DIRECT DATA('?data','C Data','a','b2')"),
       v('d', 'c*10'),
       v('e[DimA]', "GET DIRECT DATA('e_data.csv',',','A','B2')", { subscripts: ['_a1'], separationDims: ['_dima'] }),
       v('e[DimA]', "GET DIRECT DATA('e_data.csv',',','A','B2')", { subscripts: ['_a2'], separationDims: ['_dima'] }),
@@ -449,15 +449,15 @@ describe('readVariables', () => {
   it('should work for Vensim "directlookups" model', () => {
     const vars = readSubscriptsAndVariables('directlookups')
     expect(vars).toEqual([
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
         separationDims: ['_dima'],
         subscripts: ['_a1']
       }),
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
         separationDims: ['_dima'],
         subscripts: ['_a2']
       }),
-      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','E2')", {
+      v('a[DimA]', "GET DIRECT LOOKUPS('lookup_data.csv',',','1','e2')", {
         separationDims: ['_dima'],
         subscripts: ['_a3']
       }),

--- a/packages/compile/src/model/subscript-range-reader.js
+++ b/packages/compile/src/model/subscript-range-reader.js
@@ -115,9 +115,12 @@ export default class SubscriptRangeReader extends ModelReader {
     let lastCell = args[3]
     // let prefix = args[4]
     // If lastCell is a column letter, scan the column, else scan the row.
-    let dataAddress = XLSX.utils.decode_cell(firstCell)
+    let dataAddress = XLSX.utils.decode_cell(firstCell.toUpperCase())
     let col = dataAddress.c
     let row = dataAddress.r
+    if (col < 0 || row < 0) {
+      throw new Error(`Failed to parse 'firstcell' argument for GET DIRECT SUBSCRIPT call: ${firstCell}`)
+    }
     let nextCell
     if (isNaN(parseInt(lastCell))) {
       nextCell = () => row++


### PR DESCRIPTION
Fixes #395 

This is a simple fix that allows `GET DIRECT ...` calls to use a cell reference that has lowercase letters instead of the more typical uppercase ones.  Vensim is lenient and allows either form, but the XLSX library we use in SDE is not lenient, so I've added a `toUpperCase()` call in the appropriate places.

I also added some error handling so that users will get a more useful error message in the unlikely case where an invalid cell reference is used (instead of allowing things to pass through).

I updated the existing integration tests and also added some new unit tests to verify this.
