### PR TITLE
feat: preserve Vensim group names during preprocessing and parsing

### DIFF
--- a/packages/parse/src/ast/ast-builders.ts
+++ b/packages/parse/src/ast/ast-builders.ts
@@ -61,7 +61,8 @@ export function dimDef(
   familyName: DimName,
   dimOrSubNames: SubName[],
   subscriptMappings: SubscriptMapping[] = [],
-  comment = ''
+  comment = '',
+  group?: string
 ): DimensionDef {
   return {
     dimName,
@@ -70,7 +71,8 @@ export function dimDef(
     familyId: canonicalName(familyName),
     subscriptRefs: dimOrSubNames.map(subRef),
     subscriptMappings,
-    comment
+    comment,
+    ...(group ? { group } : {})
   }
 }
 
@@ -176,7 +178,7 @@ export function varDef(
   }
 }
 
-export function exprEqn(varDef: VariableDef, expr: Expr, units = '', comment = ''): Equation {
+export function exprEqn(varDef: VariableDef, expr: Expr, units = '', comment = '', group?: string): Equation {
   return {
     lhs: {
       varDef
@@ -186,7 +188,8 @@ export function exprEqn(varDef: VariableDef, expr: Expr, units = '', comment = '
       expr
     },
     units,
-    comment
+    comment,
+    ...(group ? { group } : {})
   }
 }
 

--- a/packages/parse/src/ast/ast-types.ts
+++ b/packages/parse/src/ast/ast-types.ts
@@ -114,6 +114,10 @@ export interface DimensionDef {
    * The optional comment text that accompanies the dimension definition in the model.
    */
   comment?: string
+  /**
+   * The optional group name, if this dimension definition is contained within a group.
+   */
+  group?: string
 }
 
 //
@@ -375,6 +379,10 @@ export interface Equation {
    * The optional comment text that accompanies the equation definition in the model.
    */
   comment?: string
+  /**
+   * The optional group name, if this equation definition is contained within a group.
+   */
+  group?: string
 }
 
 //

--- a/packages/parse/src/vensim/parse-vensim-model.spec.ts
+++ b/packages/parse/src/vensim/parse-vensim-model.spec.ts
@@ -115,4 +115,45 @@ x = 1
       )
     )
   })
+
+  it('should preserve group names', () => {
+    const mdl = `\
+{UTF-8}
+
+DimA: A1, A2 ~~|
+x = 1 ~~|
+
+********************************************************
+  .Group name 1
+********************************************************~
+  Group comment here.
+  |
+
+y[DimA] = 1 ~~|
+
+********************************************************
+  .Group name 2
+********************************************************~
+  Group comment here.
+  |
+
+DimB: B1, B2 ~~|
+
+z[DimB] = 1 ~~|
+
+\\\\\\---/// Sketch information - do not modify anything except names
+V301  Do not put anything below this section - it will be ignored
+*XYZ
+`
+    expect(parseVensimModel(mdl)).toEqual(
+      model(
+        [dimDef('DimA', 'DimA', ['A1', 'A2']), dimDef('DimB', 'DimB', ['B1', 'B2'], [], '', 'Group name 2')],
+        [
+          exprEqn(varDef('x'), num(1)),
+          exprEqn(varDef('y', ['DimA']), num(1), '', '', 'Group name 1'),
+          exprEqn(varDef('z', ['DimB']), num(1), '', '', 'Group name 2')
+        ]
+      )
+    )
+  })
 })

--- a/packages/parse/src/vensim/parse-vensim-model.ts
+++ b/packages/parse/src/vensim/parse-vensim-model.ts
@@ -55,19 +55,23 @@ export function parseVensimModel(input: string, context?: VensimParseContext, so
     }
 
     for (const dimensionDef of parsedModel.dimensions) {
-      // Fold in the comment string that was extracted during preprocessing
+      // Fold in the other strings that were extracted during preprocessing
+      const group = def.group
       dimensions.push({
         ...dimensionDef,
-        comment: def.comment
+        comment: def.comment,
+        ...(group ? { group } : {})
       })
     }
 
     for (const equation of parsedModel.equations) {
-      // Fold in the units and comment strings that were extracted during preprocessing
+      // Fold in the other strings that were extracted during preprocessing
+      const group = def.group
       equations.push({
         ...equation,
         units: def.units,
-        comment: def.comment
+        comment: def.comment,
+        ...(group ? { group } : {})
       })
     }
   }

--- a/packages/parse/src/vensim/preprocess-vensim.spec.ts
+++ b/packages/parse/src/vensim/preprocess-vensim.spec.ts
@@ -79,7 +79,8 @@ $192-192-192,0,Arial|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,5,0
         def: 'W[A,B] :EXCEPT: [A1,B1] = 1 ~~|',
         line: 23,
         units: '',
-        comment: ''
+        comment: '',
+        group: 'Group name'
       }
     ])
   })


### PR DESCRIPTION
Fixes #417

This is a low-risk change in the new `parse` package and tests are passing, so I will merge it shortly.  The group names are not useful in the `compile` package at this time, so they will be ignored at that level, but they are helpful for an internal tool I'm working on.
