### PR TITLE
fix: allow `--genc` and `--list` arguments to be used in the same `sde generate` command

### DIFF
--- a/packages/build/src/build/impl/gen-model.ts
+++ b/packages/build/src/build/impl/gen-model.ts
@@ -163,19 +163,15 @@ async function flattenMdls(
 async function generateC(context: BuildContext, sdeDir: string, sdeCmdPath: string, prepDir: string): Promise<void> {
   log('verbose', '  Generating C code')
 
-  // Use SDE to generate a C version of the model
+  // Use SDE to generate both a C version of the model (`--genc`) AND a JSON list of all model
+  // dimensions and variables (`--list`)
   const command = sdeCmdPath
-  const gencArgs = ['generate', '--genc', '--spec', 'spec.json', 'processed']
+  const gencArgs = ['generate', '--genc', '--list', '--spec', 'spec.json', 'processed']
   await context.spawnChild(prepDir, command, gencArgs, {
     // By default, ignore lines that start with "WARNING: Data for" since these are often harmless
     // TODO: Don't filter by default, but make it configurable
     // ignoredMessageFilter: 'WARNING: Data for'
   })
-
-  // Use SDE to generate a JSON list of all model dimensions and variables
-  // TODO: Allow --genc and --list in same command so that we only need to process once
-  const listArgs = ['generate', '--list', '--spec', 'spec.json', 'processed']
-  await context.spawnChild(prepDir, command, listArgs, {})
 
   // Copy SDE's supporting C files into the build directory
   const buildDir = joinPath(prepDir, 'build')

--- a/packages/cli/src/sde-causes.js
+++ b/packages/cli/src/sde-causes.js
@@ -24,8 +24,8 @@ let causes = (model, varname, opts) => {
   let input = preprocessModel(modelPathname, spec)
   // Parse the model to get variable and subscript information.
   let parseTree = parseModel(input)
-  let operation = 'printRefGraph'
-  generateCode(parseTree, { spec, operation, extData, directData, modelDirname, varname })
+  let operations = ['printRefGraph']
+  generateCode(parseTree, { spec, operations, extData, directData, modelDirname, varname })
 }
 export default {
   command,

--- a/packages/cli/src/sde-generate.js
+++ b/packages/cli/src/sde-generate.js
@@ -66,15 +66,17 @@ export let generate = async (model, opts) => {
   }
   // Parse the model and generate code. If no operation is specified, the code generator will
   // read the model and do nothing else. This is required for the list operation.
-  let operation = ''
+  let operations = []
   if (opts.genc) {
-    operation = 'generateC'
-  } else if (opts.list) {
-    operation = 'printVarList'
-  } else if (opts.refidtest) {
-    operation = 'printRefIdTest'
+    operations.push('generateC')
   }
-  await parseAndGenerate(input, spec, operation, modelDirname, modelName, buildDirname)
+  if (opts.list) {
+    operations.push('printVarList')
+  }
+  if (opts.refidtest) {
+    operations.push('printRefIdTest')
+  }
+  await parseAndGenerate(input, spec, operations, modelDirname, modelName, buildDirname)
 }
 
 export default {

--- a/packages/cli/src/sde-names.js
+++ b/packages/cli/src/sde-names.js
@@ -29,7 +29,7 @@ let names = async (model, namesPathname, opts) => {
   // Preprocess model text into parser input.
   let input = preprocessModel(modelPathname, spec)
   // Parse the model to get variable and subscript information.
-  await parseAndGenerate(input, spec, 'convertNames', modelDirname, modelName, '')
+  await parseAndGenerate(input, spec, ['convertNames'], modelDirname, modelName, '')
   // Read each variable name from the names file and convert it.
   printNames(namesPathname, opts.toc ? 'to-c' : 'to-vensim')
 }

--- a/packages/compile/src/generate/code-gen.js
+++ b/packages/compile/src/generate/code-gen.js
@@ -13,7 +13,7 @@ export function generateCode(parsedModel, opts) {
 }
 
 let codeGenerator = (parsedModel, opts) => {
-  const { spec, operation, extData, directData, modelDirname } = opts
+  const { spec, operations, extData, directData, modelDirname } = opts
   // Set to 'decl', 'init-lookups', 'eval', etc depending on the section being generated.
   let mode = ''
   // Set to true to output all variables when there is no model run spec.
@@ -40,13 +40,16 @@ let codeGenerator = (parsedModel, opts) => {
     try {
       Model.read(parsedModel, spec, extData, directData, modelDirname)
       // In list mode, print variables to the console instead of generating code.
-      if (operation === 'printRefIdTest') {
+      if (operations.includes('printRefIdTest')) {
         Model.printRefIdTest()
-      } else if (operation === 'printRefGraph') {
+      }
+      if (operations.includes('printRefGraph')) {
         Model.printRefGraph(opts.varname)
-      } else if (operation === 'convertNames') {
+      }
+      if (operations.includes('convertNames')) {
         // Do not generate output, but leave the results of model analysis.
-      } else if (operation === 'generateC') {
+      }
+      if (operations.includes('generateC')) {
         // Generate code for each variable in the proper order.
         let code = emitDeclCode()
         code += emitInitLookupsCode()

--- a/packages/compile/src/parse-and-generate.js
+++ b/packages/compile/src/parse-and-generate.js
@@ -18,24 +18,25 @@ import { generateCode } from './generate/code-gen.js'
  *
  * This is the primary entrypoint for the `sde generate` command.
  *
- * - If `operation` is 'generateC', the generated C code will be written to `buildDir`.
- * - If `operation` is 'printVarList', variables and subscripts will be written to
+ * - If `operations` has 'generateC', the generated C code will be written to `buildDir`.
+ * - If `operations` has 'printVarList', variables and subscripts will be written to
  *   txt, yaml, and json files under `buildDir`.
- * - If `operation` is 'printRefIdTest', reference identifiers will be printed to the console.
- * - If `operation` is 'convertNames', no output will be generated, but the results of model
+ * - If `operation` has 'printRefIdTest', reference identifiers will be printed to the console.
+ * - If `operation` has 'convertNames', no output will be generated, but the results of model
  *   analysis will be available.
  *
  * @param input The preprocessed Vensim model text.
  * @param spec The model spec (from the JSON file).
- * @param operation Either 'generateC', 'printVarList', 'printRefIdTest', 'convertNames',
- * or empty string.
+ * @param operations The set of operations to perform; can include 'generateC', 'printVarList',
+ * 'printRefIdTest', 'convertNames'.  If the array is empty, the model will be read but no
+ * operation will be performed.
  * @param modelDirname The absolute path to the directory containing the mdl file.
  * The dat and xlsx files referenced by the spec will be relative to this directory.
  * @param modelName The model name (without the mdl extension).
  * @param buildDir The output directory where the C or list files will be written.
  * @return A string containing the generated C code.
  */
-export async function parseAndGenerate(input, spec, operation, modelDirname, modelName, buildDir) {
+export async function parseAndGenerate(input, spec, operations, modelDirname, modelName, buildDir) {
   // Read time series from external DAT files into a single object.
   // externalDatfiles is an array of either filenames or objects
   // giving a variable name prefix as the key and a filename as the value.
@@ -67,19 +68,19 @@ export async function parseAndGenerate(input, spec, operation, modelDirname, mod
 
   // Parse the model and generate code.
   let parsedModel = parseModel(input, modelDirname)
-  let code = generateCode(parsedModel, { spec, operation, extData, directData, modelDirname })
+  let code = generateCode(parsedModel, { spec, operations, extData, directData, modelDirname })
 
   function writeOutput(filename, text) {
     let outputPathname = path.join(buildDir, filename)
     B.write(text, outputPathname)
   }
 
-  if (operation === 'generateC') {
+  if (operations.includes('generateC')) {
     // Write the generated C to a file
     writeOutput(`${modelName}.c`, code)
   }
 
-  if (operation === 'printVarList') {
+  if (operations.includes('printVarList')) {
     // Write variables to a text file.
     writeOutput(`${modelName}_vars.txt`, Model.printVarList())
     // Write subscripts to a text file.

--- a/packages/create/src/step-config.ts
+++ b/packages/create/src/step-config.ts
@@ -424,7 +424,7 @@ async function readModelVars(projDir: string, mdlPath: string): Promise<MdlVaria
   // Parse the model and generate the variable list
   const mdlDir = dirname(mdlFile)
   const mdlName = parsePath(mdlFile).name
-  await parseAndGenerate(preprocessed, spec, 'printVarList', mdlDir, mdlName, buildDir)
+  await parseAndGenerate(preprocessed, spec, ['printVarList'], mdlDir, mdlName, buildDir)
 
   // Read `build/{mdl}_vars.yaml`
   // TODO: For now the printVarList code only outputs txt and yaml files; we'll use the


### PR DESCRIPTION
Fixes #424

See issue for more details.  This helps improve build performance by quite a bit when using the `sde bundle` or `sde dev` commands.
