### PR TITLE
fix: prevent subscripted input variables from being pruned

### DIFF
--- a/packages/compile/src/generate/gen-equation-c.spec.ts
+++ b/packages/compile/src/generate/gen-equation-c.spec.ts
@@ -743,6 +743,24 @@ describe('generateEquation (Vensim -> C)', () => {
     expect(genC(vars.get('_b'), 'init-constants')).toEqual(['_b = 30.0;'])
   })
 
+  it('should work when valid input variable name with subscript is provided in spec file', () => {
+    const vars = readInlineModel(
+      `
+        DimA: A1, A2 ~~|
+        A[DimA] = 10, 20 ~~|
+        B[DimA] = A[DimA] + 1 ~~|
+      `,
+      {
+        inputVarNames: ['A[A1]'],
+        outputVarNames: ['B[A1]', 'B[A2]']
+      }
+    )
+    expect(vars.size).toBe(3)
+    expect(genC(vars.get('_a[_a1]'), 'init-constants')).toEqual(['_a[0] = 10.0;'])
+    expect(genC(vars.get('_a[_a2]'), 'init-constants')).toEqual(['_a[1] = 20.0;'])
+    expect(genC(vars.get('_b'), 'eval')).toEqual(['for (size_t i = 0; i < 2; i++) {', '_b[i] = _a[i] + 1.0;', '}'])
+  })
+
   it('should throw error when unknown input variable name is provided in spec file', () => {
     expect(() =>
       readInlineModel(

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -468,7 +468,11 @@ function removeUnusedVariables(spec) {
 
   // Keep all input variables
   for (const inputVarName of spec.inputVars) {
-    for (const v of varsWithName(inputVarName)) {
+    // The inputVars can include a raw index, e.g. `_input_var[0]`,
+    // which isn't an actual "ref id", so we'll just derive the
+    // var name by chopping off the index part.
+    const inputVarBaseName = inputVarName.split('[')[0]
+    for (const v of varsWithName(inputVarBaseName)) {
       recordUsedVariable(v)
     }
   }


### PR DESCRIPTION
Fixes #438 

@ToddFincannonEI: Here's a fix for an issue that a newcomer to SDE encountered today.  It's kind of an edge case that doesn't matter much once you get a project up and running, but can be a source of confusion when starting a new project.  See issue for more details.

Here's the diff with expanded scope to make it easier to see that the only change is to apply the same handling for input variables that we use for output variables (chop off the subscript part):

<img width="1189" alt="image" src="https://github.com/climateinteractive/SDEverywhere/assets/438425/d35714ea-3d73-47bb-b7e5-757d69bde4b9">
