### PR TITLE
feat: add support for comparison scenarios that have different input settings in the two models

### DIFF
--- a/examples/sample-check-tests/src/comparisons/comparison-specs.ts
+++ b/examples/sample-check-tests/src/comparisons/comparison-specs.ts
@@ -56,6 +56,17 @@ export function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): Com
     addScenario(inputId, 'max')
   }
 
+  // Create a special scenario that controls a different set of inputs in the "left" model
+  // than in the "right" model
+  scenarios.push({
+    kind: 'scenario-with-distinct-inputs',
+    id: 'extreme_main_sliders_at_best_case',
+    title: 'Main sliders',
+    subtitle: 'at best case',
+    inputsL: [{ kind: 'input-at-value', inputName: 'Input A', value: 75 }],
+    inputsR: [{ kind: 'input-at-value', inputName: 'Input B prime', value: 25 }]
+  })
+
   return {
     scenarios,
     scenarioGroups: [],

--- a/examples/sample-check-tests/src/comparisons/comparisons.yaml
+++ b/examples/sample-check-tests/src/comparisons/comparisons.yaml
@@ -44,6 +44,14 @@
           graphs: all
 
 - view_group:
+    title: Extremes
+    views:
+      - view:
+          scenario_ref: extreme_main_sliders_at_best_case
+          graphs:
+            - '1'
+
+- view_group:
     title: Group 1 (showing graphs 1+2 for different scenarios involving Input 1)
     views:
       - view:

--- a/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
+++ b/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
@@ -13,6 +13,7 @@ import type {
   ComparisonScenarioRefSpec,
   ComparisonScenarioSpec,
   ComparisonScenarioWithAllInputsSpec,
+  ComparisonScenarioWithDistinctInputsSpec,
   ComparisonScenarioWithInputsSpec,
   ComparisonSpecs,
   ComparisonViewGraphsArraySpec,
@@ -57,6 +58,21 @@ export function scenarioWithInputsSpec(
     title: opts?.title,
     subtitle: opts?.subtitle,
     inputs
+  }
+}
+
+export function scenarioWithDistinctInputsSpec(
+  inputsL: ComparisonScenarioInputSpec[],
+  inputsR: ComparisonScenarioInputSpec[],
+  opts?: { id?: string; title?: string; subtitle?: string }
+): ComparisonScenarioWithDistinctInputsSpec {
+  return {
+    kind: 'scenario-with-distinct-inputs',
+    id: opts?.id,
+    title: opts?.title,
+    subtitle: opts?.subtitle,
+    inputsL,
+    inputsR
   }
 }
 

--- a/packages/check-core/src/comparison/config/comparison-spec-types.ts
+++ b/packages/check-core/src/comparison/config/comparison-spec-types.ts
@@ -57,6 +57,24 @@ export interface ComparisonScenarioWithInputsSpec {
 }
 
 /**
+ * Specifies a single scenario that configures inputs differently for the two
+ * model instances.
+ */
+export interface ComparisonScenarioWithDistinctInputsSpec {
+  kind: 'scenario-with-distinct-inputs'
+  /** The unique identifier for the scenario. */
+  id?: ComparisonScenarioId
+  /** The title of the scenario. */
+  title?: ComparisonScenarioTitle
+  /** The subtitle of the scenario. */
+  subtitle?: ComparisonScenarioSubtitle
+  /** The input settings for this scenario when run with the "left" model. */
+  inputsL: ComparisonScenarioInputSpec[]
+  /** The input settings for this scenario when run with the "right" model. */
+  inputsR: ComparisonScenarioInputSpec[]
+}
+
+/**
  * Specifies a single scenario that sets all available inputs to position.
  */
 export interface ComparisonScenarioWithAllInputsSpec {
@@ -88,6 +106,7 @@ export interface ComparisonScenarioPresetMatrixSpec {
  */
 export type ComparisonScenarioSpec =
   | ComparisonScenarioWithInputsSpec
+  | ComparisonScenarioWithDistinctInputsSpec
   | ComparisonScenarioWithAllInputsSpec
   | ComparisonScenarioPresetMatrixSpec
 

--- a/packages/check-core/src/comparison/config/resolve/comparison-scenario-specs.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-scenario-specs.ts
@@ -10,7 +10,11 @@ import {
   valueSetting
 } from '../../../_shared/scenario-specs'
 
-import type { ComparisonScenarioInput, ComparisonScenarioSettings } from '../../_shared/comparison-resolved-types'
+import type {
+  ComparisonScenarioInput,
+  ComparisonScenarioInputState,
+  ComparisonScenarioSettings
+} from '../../_shared/comparison-resolved-types'
 
 /**
  * Create a pair of `ScenarioSpec` instances that can be used to run each model given a
@@ -37,6 +41,10 @@ export function scenarioSpecsFromSettings(
   }
 }
 
+/**
+ * Create a `ScenarioSpec` instance that can be used to run a specific model for the
+ * given input settings.
+ */
 function scenarioSpecFromInputs(inputs: ComparisonScenarioInput[], side: 'left' | 'right'): ScenarioSpec | undefined {
   const settings: InputSetting[] = []
 
@@ -51,13 +59,21 @@ function scenarioSpecFromInputs(inputs: ComparisonScenarioInput[], side: 'left' 
     }
 
     // Create a scenario setting for this input
-    const varId = state.inputVar.varId
-    if (state.position) {
-      settings.push(positionSetting(varId, state.position))
-    } else {
-      settings.push(valueSetting(varId, state.value as number))
-    }
+    settings.push(inputSettingFromResolvedInputState(state))
   }
 
   return inputSettingsSpec(settings)
+}
+
+/**
+ * Create an `InputSetting` instance for the given resolved input that can be used to
+ * build a `ScenarioSpec`.
+ */
+export function inputSettingFromResolvedInputState(state: ComparisonScenarioInputState): InputSetting {
+  const varId = state.inputVar.varId
+  if (state.position) {
+    return positionSetting(varId, state.position)
+  } else {
+    return valueSetting(varId, state.value as number)
+  }
 }


### PR DESCRIPTION
Fixes #453 

This makes it possible to define a comparison scenario that involves a set of inputs for the "left" model that is different from the set of inputs for the "right" model.  See issue for more details.