### PR TITLE
fix: update plugin-wasm to export `_free` function

### DIFF
--- a/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
+++ b/packages/plugin-wasm/docs/interfaces/WasmPluginOptions.md
@@ -31,7 +31,7 @@ with) Emscripten versions 2.0.34 and 3.1.46, among others.
   -s EXPORT_ES6=1
   -s USE_ES6_IMPORT_META=0
   -s ENVIRONMENT='web,webview,worker'
-  -s EXPORTED_FUNCTIONS=['_malloc','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
+  -s EXPORTED_FUNCTIONS=['_malloc','_free','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
   -s EXPORTED_RUNTIME_METHODS=['cwrap']
 ```
 

--- a/packages/plugin-wasm/src/options.ts
+++ b/packages/plugin-wasm/src/options.ts
@@ -22,7 +22,7 @@ export interface WasmPluginOptions {
    *   -s EXPORT_ES6=1
    *   -s USE_ES6_IMPORT_META=0
    *   -s ENVIRONMENT='web,webview,worker'
-   *   -s EXPORTED_FUNCTIONS=['_malloc','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
+   *   -s EXPORTED_FUNCTIONS=['_malloc','_free','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']
    *   -s EXPORTED_RUNTIME_METHODS=['cwrap']
    * ```
    */

--- a/packages/plugin-wasm/src/plugin.ts
+++ b/packages/plugin-wasm/src/plugin.ts
@@ -128,7 +128,7 @@ async function buildWasm(
     // and Node.js contexts (tested in Emscripten 2.0.34 and 3.1.46).
     addFlag(`ENVIRONMENT='web,webview,worker'`)
     addFlag(
-      `EXPORTED_FUNCTIONS=['_malloc','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']`
+      `EXPORTED_FUNCTIONS=['_malloc','_free','_getMaxOutputIndices','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']`
     )
     addFlag(`EXPORTED_RUNTIME_METHODS=['cwrap']`)
   }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -128,13 +128,14 @@ $ emcc \
 build/<mymodel>.c build/macros.c build/model.c build/vensim.c \
 -Ibuild -o ./output/<mymodel>.js -Wall -Os \
 -s STRICT=1 -s MALLOC=emmalloc -s FILESYSTEM=0 -s MODULARIZE=1 \
--s EXPORTED_FUNCTIONS="['_malloc','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']" \
+-s EXPORTED_FUNCTIONS="['_malloc','_free','_getInitialTime','_getFinalTime','_getSaveper','_runModelWithBuffers']" \
 -s EXPORTED_RUNTIME_METHODS="['cwrap']"
 ```
 
 Note that the generated module must export the following functions at minimum:
 
 - `_malloc`
+- `_free`
 - `_getInitialTime`
 - `_getFinalTime`
 - `_getSaveper`


### PR DESCRIPTION
Fixes #474 

This adds `_free` to the list of functions that are expected by the runtime.  It was already declared in `WasmModule` and used in the implementation of `WasmBuffer.dispose`, but the latter isn't currently called (though it soon will be), so it's important that we update plugin-wasm and its documentation to correct this oversight.
