### PR TITLE
build: update ci-build script so that it includes all available example packages

### DIFF
--- a/examples/house-game/package.json
+++ b/examples/house-game/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "clean": "rm -rf ./sde-prep",
     "dev": "sde dev",
     "build": "sde bundle"
   },

--- a/examples/house-game/packages/app/.eslintignore
+++ b/examples/house-game/packages/app/.eslintignore
@@ -1,1 +1,2 @@
 public
+src/model/generated

--- a/examples/house-game/packages/app/.eslintrc.cjs
+++ b/examples/house-game/packages/app/.eslintrc.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['../../../.eslintrc-svelte-common.cjs']
+  extends: ['../../../../.eslintrc-svelte-common.cjs']
 }

--- a/examples/house-game/packages/app/.prettierignore
+++ b/examples/house-game/packages/app/.prettierignore
@@ -1,2 +1,3 @@
 public
+src/model/generated
 **/*.svelte

--- a/examples/house-game/packages/app/package.json
+++ b/examples/house-game/packages/app/package.json
@@ -13,9 +13,9 @@
     "precommit": "../../scripts/precommit",
     "test": "echo No tests yet",
     "type-check": "tsc --noEmit",
-    "build": "vite build",
+    "bundle": "vite build",
     "dev": "vite",
-    "ci:build": "run-s clean lint prettier:check type-check build"
+    "ci:build": "run-s clean lint prettier:check type-check bundle"
   },
   "dependencies": {
     "@sdeverywhere/runtime": "^0.2.2",

--- a/examples/house-game/packages/app/src/app-vm.ts
+++ b/examples/house-game/packages/app/src/app-vm.ts
@@ -1,8 +1,8 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store'
 
-import { AppModel, createAppModel } from './model/app-model'
+import { type AppModel, createAppModel } from './model/app-model'
 
-import { AssumptionsViewModel, createAssumptionsViewModel } from './components/assumptions/assumptions-vm'
+import { type AssumptionsViewModel, createAssumptionsViewModel } from './components/assumptions/assumptions-vm'
 import type { GraphViewModel } from './components/graph/graph-vm'
 
 export async function createAppViewModel(): Promise<AppViewModel> {

--- a/examples/house-game/packages/app/src/components/assumptions/assumptions-vm.ts
+++ b/examples/house-game/packages/app/src/components/assumptions/assumptions-vm.ts
@@ -1,4 +1,4 @@
-import { ModelInputs } from '../../model/app-state'
+import type { ModelInputs } from '../../model/app-state'
 
 export interface AssumptionRow {
   label: string

--- a/examples/house-game/packages/app/src/model/app-model.ts
+++ b/examples/house-game/packages/app/src/model/app-model.ts
@@ -1,12 +1,15 @@
-import { Readable, Writable, get, writable } from 'svelte/store'
+import type { Readable, Writable } from 'svelte/store'
+import { get, writable } from 'svelte/store'
 
-import type { ModelRunner, Point } from '@sdeverywhere/runtime'
-import { Outputs, createLookupDef } from '@sdeverywhere/runtime'
+import type { ModelRunner, Outputs, Point } from '@sdeverywhere/runtime'
+import { createLookupDef } from '@sdeverywhere/runtime'
 
 import { spawnAsyncModelRunner } from '@sdeverywhere/runtime-async'
 
+import type { AppState } from './app-state'
+import { inputValuesForState, stateForIndex } from './app-state'
+
 import modelWorkerJs from './generated/worker.js?raw'
-import { AppState, inputValuesForState, stateForIndex } from './app-state'
 
 /**
  * Create an `AppModel` instance.

--- a/scripts/ci-build
+++ b/scripts/ci-build
@@ -31,8 +31,8 @@ function run_in_workspaces {
   --aggregate-output \
   --reporter=append-only \
   --workspace-concurrency=0 \
-  --filter=./packages/** \
-  --filter=./examples/sample-* \
+  --filter="./packages/*" \
+  --filter="./examples/**" \
   -r $cmd \
   ) 2>&1
 


### PR DESCRIPTION
Fixes #508 

This fixes the `ci-build` script, which wasn't previously building the house-game and hello-world examples (accidental oversight).  This uncovered an incorrect path in the eslint config file for the house-game project.  Once that was fixed, it uncovered some minor lint warnings in the house-game project, which I fixed here as well.
