### PR TITLE
fix: include new columns in generated model.csv file

### DIFF
--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -43,15 +43,14 @@ export async function main(): Promise<void> {
 
   // Prompt the user to select a code generation format
   const genFormat = await chooseCodeFormat()
-  console.log()
 
   // Update the `sde.config.js` file to use the chosen mdl file and
   // generate a sample `.check.yaml` file
   if (!args.dryRun) {
     await updateSdeConfig(projDir, mdlPath, genFormat)
     await generateCheckYaml(projDir, mdlPath)
-    console.log()
   }
+  console.log()
 
   // If the user chose the default template, offer to set up CSV files
   if (templateName === 'template-default' && !args.dryRun) {

--- a/packages/create/src/step-config.ts
+++ b/packages/create/src/step-config.ts
@@ -154,8 +154,13 @@ export async function chooseGenConfig(projDir: string, mdlPath: string): Promise
   const origModelCsvContent = await readFile(modelCsvFile, 'utf8')
   const modelCsvHeader = origModelCsvContent.split('\n')[0]
 
+  // Disable bundled listing and customization features by default
+  const bundleListing = 'false'
+  const customLookups = 'false'
+  const customOutputs = 'false'
+
   // Add line and write out updated `model.csv`
-  const modelCsvLine = `${initialTime},${finalTime},${datPart}`
+  const modelCsvLine = `${initialTime},${finalTime},${datPart},${bundleListing},${customLookups},${customOutputs}`
   const newModelCsvContent = `${modelCsvHeader}\n${modelCsvLine}\n`
   await writeFile(modelCsvFile, newModelCsvContent)
 


### PR DESCRIPTION
Fixes #510 

This addresses an issue with the `create` package (used in the Quick Start instructions).  See issue for more details.  I'll merge this and will publish the fixed `create` package shortly.
