### PR TITLE
fix: restore exports of non-public perf functions in runtime package

### DIFF
--- a/packages/runtime/src/index.spec.ts
+++ b/packages/runtime/src/index.spec.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Climate Interactive / New Venture Fund
+
+import { describe, expect, it } from 'vitest'
+
+import { perfNow, perfElapsed } from './index'
+
+describe('non-public perf functions', () => {
+  it('should be exported', () => {
+    // The `perf` functions are not officially part of the public API, but they should be
+    // exported for use in experimental tools, so we verify that they are accessible as
+    // top-level exports
+    const t0 = perfNow()
+    const elapsed = perfElapsed(t0)
+    expect(elapsed).toBeDefined()
+  })
+})

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,3 +7,6 @@ export * from './js-model'
 export * from './wasm-model'
 export * from './model-runner'
 export * from './model-scheduler'
+
+/** @hidden The `perf` module is not part of the public API, but is exposed for use in performance tools. */
+export * from './perf'


### PR DESCRIPTION
Fixes #514 

This restores the exports for two perf-related functions that aren't technically part of the public API for the `runtime` package, but are used in some of our internal tools.
