### PR TITLE
fix: prevent error when model outputs buffer is larger than the RunModelParams internal buffer

### DIFF
--- a/packages/runtime/src/runnable-model/buffered-run-model-params.ts
+++ b/packages/runtime/src/runnable-model/buffered-run-model-params.ts
@@ -183,8 +183,21 @@ export class BufferedRunModelParams implements RunModelParams {
 
   // from RunModelParams interface
   storeOutputs(array: Float64Array): void {
-    // Copy from the given array to the internal buffer
-    this.outputs.view?.set(array)
+    if (this.outputs.view === undefined) {
+      return
+    }
+
+    // Copy from the given array to the internal buffer.  Note that the given array
+    // can be longer than the internal buffer.  This can happen in the case where the
+    // model has an outputs buffer already allocated that was sized to accommodate a
+    // certain amount of outputs, and then a later model run used a smaller amount of
+    // outputs.  In this case, the model may choose to keep the reuse the buffer
+    // rather than reallocate/shrink the buffer, so we need to copy a subset here.
+    if (array.length > this.outputs.view.length) {
+      this.outputs.view.set(array.subarray(0, this.outputs.view.length))
+    } else {
+      this.outputs.view.set(array)
+    }
   }
 
   // from RunModelParams interface

--- a/packages/runtime/src/runnable-model/referenced-run-model-params.spec.ts
+++ b/packages/runtime/src/runnable-model/referenced-run-model-params.spec.ts
@@ -173,7 +173,7 @@ describe('ReferencedRunModelParams', () => {
     )
   })
 
-  it('should store output values from the model run', () => {
+  it('should store output values from the model run (when model outputs buffer length is same as outputs instance length)', () => {
     const inputs = [1, 2, 3]
     const outputs = new Outputs(['_x', '_y'], 2000, 2002, 1)
 
@@ -183,6 +183,33 @@ describe('ReferencedRunModelParams', () => {
     // Pretend that the model writes the following values to its buffer then
     // calls the `store` methods
     const outputsArray = new Float64Array([1, 2, 3, 4, 5, 6])
+    params.storeElapsedTime(42)
+    params.storeOutputs(outputsArray)
+
+    // Verify that the elapsed time can be accessed
+    expect(params.getElapsedTime()).toBe(42)
+
+    // Verify that the `Outputs` instance is updated with the correct values
+    expect(outputs.varIds).toEqual(['_x', '_y'])
+    expect(outputs.getSeriesForVar('_x').points).toEqual([p(2000, 1), p(2001, 2), p(2002, 3)])
+    expect(outputs.getSeriesForVar('_y').points).toEqual([p(2000, 4), p(2001, 5), p(2002, 6)])
+  })
+
+  it('should store output values from the model run (when model outputs buffer is longer than outputs instance)', () => {
+    const inputs = [1, 2, 3]
+    const outputs = new Outputs(['_x', '_y'], 2000, 2002, 1)
+
+    const params = new ReferencedRunModelParams()
+    params.updateFromParams(inputs, outputs)
+
+    // Pretend that the model writes the following values to its buffer then
+    // calls the `store` methods
+    const outputsArray = new Float64Array([
+      // actual outputs
+      1, 2, 3, 4, 5, 6,
+      // extra values (should be ignored)
+      9, 9, 9
+    ])
     params.storeElapsedTime(42)
     params.storeOutputs(outputsArray)
 

--- a/tests/integration/impl-var-access/sde.config.js
+++ b/tests/integration/impl-var-access/sde.config.js
@@ -11,7 +11,7 @@ export async function config() {
     modelSpec: async () => {
       return {
         inputs: ['X'],
-        outputs: ['Z', 'D[A1]', 'E[A2,B1]'],
+        outputs: ['Y', 'Z', 'D[A1]', 'E[A2,B1]'],
         customOutputs: true
       }
     },


### PR DESCRIPTION
Fixes #524 

See issue for more details.  I added new unit tests to verify this case (for both `RunModelParams` implementations) and also updated the existing `impl-var-access` integration test so that it verifies this case as well (previously it used the same number of outputs in two different runs, so the bug was masked, but now it is covered better).
