### PR TITLE
fix: update to latest antlr4-vensim with support for Unicode characters in variable names

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "vitest": "^2.0.5"
   },
   "pnpm": {
+    "overrides": {
+      "antlr4-vensim": "climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f"
+    },
     "peerDependencyRules": {
       "ignoreMissing": [
         "eslint",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "vitest": "^2.0.5"
   },
   "pnpm": {
-    "overrides": {
-      "antlr4-vensim": "climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f"
-    },
     "peerDependencyRules": {
       "ignoreMissing": [
         "eslint",

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "antlr4": "4.12.0",
-    "antlr4-vensim": "0.6.2",
+    "antlr4-vensim": "0.6.3",
     "assert-never": "^1.2.1",
     "split-string": "^6.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  antlr4-vensim: climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f
-
 importers:
 
   .:
@@ -406,8 +403,8 @@ importers:
         specifier: 4.12.0
         version: 4.12.0
       antlr4-vensim:
-        specifier: climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f
-        version: github.com/climateinteractive/gitpkg-registry-public/3162ef2eedd46efc3008fdcfc9e54bfcab303aae
+        specifier: 0.6.3
+        version: 0.6.3
       assert-never:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1871,6 +1868,12 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
     dev: true
+
+  /antlr4-vensim@0.6.3:
+    resolution: {integrity: sha512-xDjUXNjeDEj2ahCFIIxOIlA6Jf/YtBMngugH1AyvVeg4qKttTFmof13j7lXvE24hHcW9sa0ACs6JmgR+/x8c+A==}
+    dependencies:
+      antlr4: 4.12.0
+    dev: false
 
   /antlr4@4.12.0:
     resolution: {integrity: sha512-23iB5IzXJZRZeK9TigzUyrNc9pSmNqAerJRBcNq1ETrmttMWRgaYZzC561IgEO3ygKsDJTYDTozABXa4b/fTQQ==}
@@ -5249,12 +5252,4 @@ packages:
     version: 0.20.2
     engines: {node: '>=0.8'}
     hasBin: true
-    dev: false
-
-  github.com/climateinteractive/gitpkg-registry-public/3162ef2eedd46efc3008fdcfc9e54bfcab303aae:
-    resolution: {tarball: https://codeload.github.com/climateinteractive/gitpkg-registry-public/tar.gz/3162ef2eedd46efc3008fdcfc9e54bfcab303aae}
-    name: antlr4-vensim
-    version: 0.6.2
-    dependencies:
-      antlr4: 4.12.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  antlr4-vensim: climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f
+
 importers:
 
   .:
@@ -403,8 +406,8 @@ importers:
         specifier: 4.12.0
         version: 4.12.0
       antlr4-vensim:
-        specifier: 0.6.2
-        version: 0.6.2
+        specifier: climateinteractive/gitpkg-registry-public#antlr4-vensim-d95075f
+        version: github.com/climateinteractive/gitpkg-registry-public/3162ef2eedd46efc3008fdcfc9e54bfcab303aae
       assert-never:
         specifier: ^1.2.1
         version: 1.2.1
@@ -667,6 +670,27 @@ importers:
         version: link:../../../packages/runtime-async
 
   tests/integration/saveper:
+    dependencies:
+      '@sdeverywhere/build':
+        specifier: workspace:*
+        version: link:../../../packages/build
+      '@sdeverywhere/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@sdeverywhere/plugin-wasm':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-wasm
+      '@sdeverywhere/plugin-worker':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-worker
+      '@sdeverywhere/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime
+      '@sdeverywhere/runtime-async':
+        specifier: workspace:*
+        version: link:../../../packages/runtime-async
+
+  tests/integration/unicode:
     dependencies:
       '@sdeverywhere/build':
         specifier: workspace:*
@@ -1847,12 +1871,6 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
     dev: true
-
-  /antlr4-vensim@0.6.2:
-    resolution: {integrity: sha512-NzYwNWUxpiNqIAEgTbSPYkyoXxhe2B3Lbmwd4LtUGCIeHCNPnGYuZVaa0om1zZ1PXilx2c7Xwm74Trin8QqRmg==}
-    dependencies:
-      antlr4: 4.12.0
-    dev: false
 
   /antlr4@4.12.0:
     resolution: {integrity: sha512-23iB5IzXJZRZeK9TigzUyrNc9pSmNqAerJRBcNq1ETrmttMWRgaYZzC561IgEO3ygKsDJTYDTozABXa4b/fTQQ==}
@@ -5231,4 +5249,12 @@ packages:
     version: 0.20.2
     engines: {node: '>=0.8'}
     hasBin: true
+    dev: false
+
+  github.com/climateinteractive/gitpkg-registry-public/3162ef2eedd46efc3008fdcfc9e54bfcab303aae:
+    resolution: {tarball: https://codeload.github.com/climateinteractive/gitpkg-registry-public/tar.gz/3162ef2eedd46efc3008fdcfc9e54bfcab303aae}
+    name: antlr4-vensim
+    version: 0.6.2
+    dependencies:
+      antlr4: 4.12.0
     dev: false

--- a/tests/integration/unicode/package.json
+++ b/tests/integration/unicode/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "unicode",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf sde-prep",
+    "build-js": "GEN_FORMAT=js sde bundle",
+    "build-wasm": "GEN_FORMAT=c sde bundle",
+    "run-tests": "./run-tests.js",
+    "test-js": "run-s build-js run-tests",
+    "test-wasm": "run-s build-wasm run-tests",
+    "ci:int-test": "run-s clean test-js clean test-wasm"
+  },
+  "dependencies": {
+    "@sdeverywhere/build": "workspace:*",
+    "@sdeverywhere/cli": "workspace:*",
+    "@sdeverywhere/plugin-wasm": "workspace:*",
+    "@sdeverywhere/plugin-worker": "workspace:*",
+    "@sdeverywhere/runtime": "workspace:*",
+    "@sdeverywhere/runtime-async": "workspace:*"
+  }
+}

--- a/tests/integration/unicode/run-tests.js
+++ b/tests/integration/unicode/run-tests.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { readFile } from 'fs/promises'
+import { join as joinPath } from 'path'
+
+import { createInputValue, createSynchronousModelRunner } from '@sdeverywhere/runtime'
+import { spawnAsyncModelRunner } from '@sdeverywhere/runtime-async'
+
+import loadGeneratedModel from './sde-prep/generated-model.js'
+
+/*
+ * This is a JS-level integration test that verifies that the compile and runtime
+ * packages work correctly when used with a model that contains Unicode (non-Latin)
+ * variable names.
+ */
+
+function verify(runnerKind, outputs, inputY) {
+  const series = outputs.getSeriesForVar('_中文输出变量_z')
+  for (let time = 2000; time <= 2002; time += 1) {
+    const actualZ = series.getValueAtTime(time)
+    const expectedZ = time + inputY
+    if (actualZ !== expectedZ) {
+      console.error(
+        `Test failed for ${runnerKind} runner at time=${time} with y=${inputY}: expected z=${expectedZ}, got z=${actualZ}`
+      )
+      process.exit(1)
+    }
+  }
+}
+
+async function runTests(runnerKind, modelRunner) {
+  // Create the set of inputs
+  const inputY = createInputValue('_中文变量名_y', 0)
+  const inputs = [inputY]
+
+  // Create the buffer to hold the outputs
+  let outputs = modelRunner.createOutputs()
+
+  // Run the model with input at default (0)
+  outputs = await modelRunner.runModel(inputs, outputs)
+
+  // Verify outputs
+  verify(runnerKind, outputs, 0)
+
+  // Run the model with input at 1
+  inputY.set(1)
+  outputs = await modelRunner.runModel(inputs, outputs)
+
+  // Verify outputs
+  verify(runnerKind, outputs, 1)
+
+  // Terminate the model runner
+  await modelRunner.terminate()
+}
+
+async function createSynchronousRunner() {
+  // TODO: This test app is using ESM-style modules, and `__dirname` is not defined
+  // in an ESM context.  The `generated-model.js` file (if it contains a Wasm model)
+  // may contain a reference to `__dirname`, so we need to define it here.  We should
+  // fix the generated Wasm file so that it works for either ESM or CommonJS.
+  global.__dirname = '.'
+
+  // Initialize the synchronous `ModelRunner` that drives the generated model
+  const generatedModel = await loadGeneratedModel()
+  return createSynchronousModelRunner(generatedModel)
+}
+
+async function createAsynchronousRunner() {
+  // Initialize the aynchronous `ModelRunner` that drives the generated model
+  const modelWorkerJs = await readFile(joinPath('sde-prep', 'worker.js'), 'utf8')
+  return await spawnAsyncModelRunner({ source: modelWorkerJs })
+}
+
+async function main() {
+  // Verify with the synchronous model runner
+  const syncRunner = await createSynchronousRunner()
+  await runTests('synchronous', syncRunner)
+
+  // Verify with the asynchronous model runner
+  const asyncRunner = await createAsynchronousRunner()
+  await runTests('asynchronous', asyncRunner)
+
+  console.log('Tests passed!\n')
+}
+
+main()

--- a/tests/integration/unicode/sde.config.js
+++ b/tests/integration/unicode/sde.config.js
@@ -1,0 +1,27 @@
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+const genFormat = process.env.GEN_FORMAT === 'c' ? 'c' : 'js'
+
+export async function config() {
+  return {
+    genFormat,
+    modelFiles: ['unicode.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: ['中文变量名 Y'],
+        outputs: ['中文输出变量 Z']
+      }
+    },
+
+    plugins: [
+      // If targeting WebAssembly, generate a `generated-model.js` file
+      // containing the Wasm model
+      genFormat === 'c' && wasmPlugin(),
+
+      // Generate a `worker.js` file that runs the generated model in a worker
+      workerPlugin()
+    ]
+  }
+}

--- a/tests/integration/unicode/unicode.mdl
+++ b/tests/integration/unicode/unicode.mdl
@@ -1,0 +1,16 @@
+{UTF-8}
+
+中文变量名 X = TIME ~~|
+
+中文变量名 Y = 0
+  ~ [-10,10,0.1]
+  ~
+  |
+
+中文输出变量 Z = 中文变量名 X + 中文变量名 Y
+  ~~|
+
+INITIAL TIME = 2000 ~~|
+FINAL TIME = 2002 ~~|
+TIME STEP = 1 ~~|
+SAVEPER = TIME STEP ~~|


### PR DESCRIPTION
Fixes #532 

@ToddFincannonEI: This is the companion to the antlr4-vensim PR https://github.com/climateinteractive/antlr4-vensim/pull/14 that I just filed.

This one updates SDE to use the gitpkg (pre-release) version of antlr4-vensim containing the fix and adds an integration test to verify that it no longer chokes on non-Latin characters in variable names.

Once you approve these PRs, I'll publish antlr4-vensim and will update this one before merge to use the latest published version instead of the gitpkg version.
