### PR TITLE
feat: add support for configuring comparison graph groups and order

### DIFF
--- a/examples/house-game/packages/app/vite.config.js
+++ b/examples/house-game/packages/app/vite.config.js
@@ -1,4 +1,4 @@
-import { dirname, resolve as resolvePath } from 'path'
+import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 
 import { defineConfig } from 'vite'
@@ -10,10 +10,6 @@ const production = process.env.NODE_ENV === 'production'
 // Node will complain ("ERROR: __dirname is not defined in ES module scope") so
 // we use our own special name here
 const appDir = dirname(fileURLToPath(import.meta.url))
-
-function localPackage(...subpath) {
-  return resolvePath(appDir, '..', '..', '..', '..', 'packages', ...subpath)
-}
 
 export default defineConfig({
   // Don't clear the screen in dev mode so that we can see builder output

--- a/examples/sample-check-app/package.json
+++ b/examples/sample-check-app/package.json
@@ -15,6 +15,7 @@
     "type-check": "tsc --noEmit -p tsconfig-test.json",
     "build": "vite build",
     "dev": "vite",
+    "preview": "vite preview",
     "ci:build": "run-s clean lint prettier:check type-check build"
   },
   "dependencies": {

--- a/examples/sample-check-app/src/env.d.ts
+++ b/examples/sample-check-app/src/env.d.ts
@@ -2,6 +2,4 @@
 
 // These values are injected by Vite at build time, so we need to
 // declare types for them here
-declare const __MODEL_SIZE_IN_BYTES__: number
-declare const __DATA_SIZE_IN_BYTES__: number
-declare const __MODEL_VERSION__: number
+declare const __SUITE_SUMMARY_JSON__: string

--- a/examples/sample-check-app/src/index.ts
+++ b/examples/sample-check-app/src/index.ts
@@ -14,7 +14,6 @@ import { createBundle as currentBundle } from '../../sample-check-bundle/dist/sa
 // For "production" builds, load the summary from a JSON file that was generated as
 // part of the build process.  This makes the report load almost immediately instead
 // of running all the checks in the user's browser.
-const __SUITE_SUMMARY_JSON__ = ''
 const suiteSummaryJson = __SUITE_SUMMARY_JSON__
 let suiteSummary: SuiteSummary
 if (suiteSummaryJson) {

--- a/examples/sample-check-bundle/src/bundle.ts
+++ b/examples/sample-check-bundle/src/bundle.ts
@@ -26,16 +26,13 @@ import { getOutputs } from './outputs'
 const VERSION = 1
 
 // The size (in bytes) of the model file(s), injected at build time.
-const __MODEL_SIZE_IN_BYTES__ = 1
 const modelSizeInBytes = __MODEL_SIZE_IN_BYTES__
 
 // The size (in bytes) of the data file(s), injected at build time.
-const __DATA_SIZE_IN_BYTES__ = 1
 const dataSizeInBytes = __DATA_SIZE_IN_BYTES__
 
 // The special model version, injected at build time.  This is only used
 // to determine which variables will be simulated by this sample bundle.
-const __MODEL_VERSION__ = 1
 const modelVersion = __MODEL_VERSION__
 
 export class BundleModel implements CheckBundleModel {

--- a/examples/sample-check-bundle/src/env.d.ts
+++ b/examples/sample-check-bundle/src/env.d.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2024 Climate Interactive / New Venture Fund
+
+// Declare constants that are injected at build time
+declare const __MODEL_SIZE_IN_BYTES__: number
+declare const __DATA_SIZE_IN_BYTES__: number
+declare const __MODEL_VERSION__: number

--- a/examples/sample-check-tests/src/comparisons/comparison-specs.ts
+++ b/examples/sample-check-tests/src/comparisons/comparison-specs.ts
@@ -68,8 +68,6 @@ export function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): Com
   })
 
   return {
-    scenarios,
-    scenarioGroups: [],
-    viewGroups: []
+    scenarios
   }
 }

--- a/examples/sample-check-tests/src/comparisons/comparisons.yaml
+++ b/examples/sample-check-tests/src/comparisons/comparisons.yaml
@@ -35,6 +35,18 @@
       - scenario_ref: input_1_at_min
       - scenario_ref: input_1_at_max
 
+- graph_group:
+    id: GraphGroup1
+    graphs:
+      - '1'
+      - '2'
+
+- graph_group:
+    id: GraphGroup2
+    graphs:
+      - '3'
+      - '4'
+
 - view_group:
     title: Baseline
     views:
@@ -42,6 +54,7 @@
           title: All graphs
           scenario_ref: baseline
           graphs: all
+          graph_order: grouped-by-diffs
 
 - view_group:
     title: Extremes
@@ -66,16 +79,14 @@
           subtitle: Slider 2 at min
           scenario_ref: input_1_at_max
           graphs:
-            - '1'
-            - '2'
+            graph_group_ref: GraphGroup1
 
 - view_group:
     title: Group 2 (showing graphs 3+4 for different scenarios involving Input 1)
     scenarios:
       - scenario_group_ref: G0
     graphs:
-      - '3'
-      - '4'
+      graph_group_ref: GraphGroup2
 #
 # TODO: The following can be uncommented to test edge/error cases
 #

--- a/packages/check-core/schema/comparison.schema.json
+++ b/packages/check-core/schema/comparison.schema.json
@@ -420,7 +420,7 @@
       "type": "string",
       "enum": [
         "default",
-        "group-by-diffs"
+        "grouped-by-diffs"
       ]
     },
     "view_group_array_item": {

--- a/packages/check-core/schema/comparison.schema.json
+++ b/packages/check-core/schema/comparison.schema.json
@@ -16,6 +16,9 @@
           "$ref": "#/$defs/scenario_group_array_item"
         },
         {
+          "$ref": "#/$defs/graph_group_array_item"
+        },
+        {
           "$ref": "#/$defs/view_group_array_item"
         }
       ]
@@ -322,6 +325,59 @@
         "scenario_group_ref"
       ]
     },
+    "graphs_preset": {
+      "type": "string",
+      "enum": [
+        "all"
+      ]
+    },
+    "graphs_array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "graph_group_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "graph_group_ref": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "graph_group_ref"
+      ]
+    },
+    "graph_group_array_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "graph_group": {
+          "$ref": "#/$defs/graph_group"
+        }
+      },
+      "required": [
+        "graph_group"
+      ]
+    },
+    "graph_group": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "graphs": {
+          "$ref": "#/$defs/graphs_array"
+        }
+      },
+      "required": [
+        "id",
+        "graphs"
+      ]
+    },
     "view": {
       "type": "object",
       "additionalProperties": false,
@@ -337,6 +393,9 @@
         },
         "graphs": {
           "$ref": "#/$defs/view_graphs"
+        },
+        "graph_order": {
+          "$ref": "#/$defs/view_graph_order"
         }
       },
       "required": [
@@ -347,25 +406,22 @@
     "view_graphs": {
       "oneOf": [
         {
-          "$ref": "#/$defs/view_graphs_preset"
+          "$ref": "#/$defs/graphs_preset"
         },
         {
-          "$ref": "#/$defs/view_graphs_array"
+          "$ref": "#/$defs/graphs_array"
+        },
+        {
+          "$ref": "#/$defs/graph_group_ref"
         }
       ]
     },
-    "view_graphs_preset": {
+    "view_graph_order": {
       "type": "string",
       "enum": [
-        "all"
+        "default",
+        "group-by-diffs"
       ]
-    },
-    "view_graphs_array": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1
     },
     "view_group_array_item": {
       "type": "object",

--- a/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
@@ -18,9 +18,10 @@ import type {
   ComparisonViewGroup
 } from '../comparison-resolved-types'
 import type {
+  ComparisonGraphId,
   ComparisonScenarioGroupId,
   ComparisonScenarioId,
-  ComparisonViewGraphId
+  ComparisonViewGraphOrder
 } from '../../config/comparison-spec-types'
 
 //
@@ -224,14 +225,16 @@ export function view(
   title: string,
   subtitle: string | undefined,
   scenario: ComparisonScenario,
-  graphs: 'all' | ComparisonViewGraphId[]
+  graphIds: ComparisonGraphId[],
+  graphOrder?: ComparisonViewGraphOrder
 ): ComparisonView {
   return {
     kind: 'view',
     title,
     subtitle,
     scenario,
-    graphs
+    graphIds,
+    graphOrder: graphOrder || 'default'
   }
 }
 

--- a/packages/check-core/src/comparison/_shared/comparison-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/comparison-resolved-types.ts
@@ -4,10 +4,11 @@ import type { DatasetKey } from '../../_shared/types'
 import type { InputPosition, ScenarioSpec } from '../../_shared/scenario-spec-types'
 import type { InputVar, OutputVar } from '../../bundle/var-types'
 import type {
+  ComparisonGraphId,
   ComparisonScenarioGroupId,
   ComparisonScenarioGroupTitle,
   ComparisonScenarioId,
-  ComparisonViewGraphId,
+  ComparisonViewGraphOrder,
   ComparisonViewGroupTitle,
   ComparisonViewSubtitle,
   ComparisonViewTitle
@@ -131,7 +132,7 @@ export interface ComparisonScenarioGroup {
   /** The title of the group. */
   title: ComparisonScenarioGroupTitle
   /**
-   * The scenarios that are included in this group.  This includes scenario that were successfully
+   * The scenarios that are included in this group.  This includes scenarios that were successfully
    * resolved as well as scenario references that could not be resolved.
    */
   scenarios: (ComparisonScenario | ComparisonUnresolvedScenarioRef)[]
@@ -142,6 +143,19 @@ export interface ComparisonUnresolvedScenarioGroupRef {
   kind: 'unresolved-scenario-group-ref'
   /** The ID of the referenced scenario group that could not be resolved. */
   scenarioGroupId: ComparisonScenarioGroupId
+}
+
+//
+// GRAPH GROUPS
+//
+
+/** A resolved group of graphs. */
+export interface ComparisonGraphGroup {
+  kind: 'graph-group'
+  /** The unique identifier for the group. */
+  id: ComparisonScenarioGroupId
+  /** The graphs that are included in this group. */
+  graphIds: ComparisonGraphId[]
 }
 
 //
@@ -158,7 +172,9 @@ export interface ComparisonView {
   /** The resolved scenario to be shown in the view. */
   scenario: ComparisonScenario
   /** The graphs to be shown for each scenario view. */
-  graphs: 'all' | ComparisonViewGraphId[]
+  graphIds: ComparisonGraphId[]
+  /** The order in which the graphs will be displayed. */
+  graphOrder: ComparisonViewGraphOrder
 }
 
 /** An unresolved view. */

--- a/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
+++ b/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
@@ -21,10 +21,8 @@ import type {
   ComparisonScenarioWithAllInputsSpec,
   ComparisonScenarioWithDistinctInputsSpec,
   ComparisonScenarioWithInputsSpec,
-  ComparisonSpecs,
   ComparisonViewGraphOrder,
   ComparisonViewGraphsSpec,
-  ComparisonViewGroupSpec,
   ComparisonViewGroupWithScenariosSpec,
   ComparisonViewGroupWithViewsSpec,
   ComparisonViewSpec
@@ -219,21 +217,5 @@ export function viewGroupWithScenariosSpec(
     scenarios,
     graphs,
     graphOrder
-  }
-}
-
-//
-// TOP-LEVEL TYPES
-//
-
-export function comparisonSpecs(
-  scenarios: ComparisonScenarioSpec[],
-  scenarioGroups: ComparisonScenarioGroupSpec[] = [],
-  viewGroups: ComparisonViewGroupSpec[] = []
-): ComparisonSpecs {
-  return {
-    scenarios,
-    scenarioGroups,
-    viewGroups
   }
 }

--- a/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
+++ b/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
@@ -1,6 +1,12 @@
 // Copyright (c) 2023 Climate Interactive / New Venture Fund
 
 import type {
+  ComparisonGraphGroupId,
+  ComparisonGraphGroupRefSpec,
+  ComparisonGraphGroupSpec,
+  ComparisonGraphId,
+  ComparisonGraphsArraySpec,
+  ComparisonGraphsPresetSpec,
   ComparisonScenarioGroupId,
   ComparisonScenarioGroupRefSpec,
   ComparisonScenarioGroupSpec,
@@ -16,8 +22,7 @@ import type {
   ComparisonScenarioWithDistinctInputsSpec,
   ComparisonScenarioWithInputsSpec,
   ComparisonSpecs,
-  ComparisonViewGraphsArraySpec,
-  ComparisonViewGraphsPresetSpec,
+  ComparisonViewGraphOrder,
   ComparisonViewGraphsSpec,
   ComparisonViewGroupSpec,
   ComparisonViewGroupWithScenariosSpec,
@@ -133,6 +138,43 @@ export function scenarioGroupRefSpec(groupId: ComparisonScenarioGroupId): Compar
 }
 
 //
+// GRAPHS
+//
+
+export function graphsPresetSpec(preset: 'all'): ComparisonGraphsPresetSpec {
+  return {
+    kind: 'graphs-preset',
+    preset
+  }
+}
+
+export function graphsArraySpec(graphIds: ComparisonGraphId[]): ComparisonGraphsArraySpec {
+  return {
+    kind: 'graphs-array',
+    graphIds
+  }
+}
+
+//
+// GRAPH GROUPS
+//
+
+export function graphGroupSpec(id: ComparisonGraphGroupId, graphIds: ComparisonGraphId[]): ComparisonGraphGroupSpec {
+  return {
+    kind: 'graph-group',
+    id,
+    graphIds
+  }
+}
+
+export function graphGroupRefSpec(groupId: ComparisonGraphGroupId): ComparisonGraphGroupRefSpec {
+  return {
+    kind: 'graph-group-ref',
+    groupId
+  }
+}
+
+//
 // VIEWS
 //
 
@@ -140,28 +182,16 @@ export function viewSpec(
   title: string | undefined,
   subtitle: string | undefined,
   scenarioId: ComparisonScenarioId,
-  graphs: ComparisonViewGraphsSpec
+  graphs: ComparisonViewGraphsSpec,
+  graphOrder?: ComparisonViewGraphOrder
 ): ComparisonViewSpec {
   return {
     kind: 'view',
     title,
     subtitle,
     scenarioId,
-    graphs
-  }
-}
-
-export function graphsPresetSpec(preset: 'all'): ComparisonViewGraphsPresetSpec {
-  return {
-    kind: 'graphs-preset',
-    preset
-  }
-}
-
-export function graphsArraySpec(graphIds: string[]): ComparisonViewGraphsArraySpec {
-  return {
-    kind: 'graphs-array',
-    graphIds
+    graphs,
+    graphOrder
   }
 }
 
@@ -180,13 +210,15 @@ export function viewGroupWithViewsSpec(title: string, views: ComparisonViewSpec[
 export function viewGroupWithScenariosSpec(
   title: string,
   scenarios: (ComparisonScenarioRefSpec | ComparisonScenarioGroupRefSpec)[],
-  graphs: ComparisonViewGraphsSpec
+  graphs: ComparisonViewGraphsSpec,
+  graphOrder?: ComparisonViewGraphOrder
 ): ComparisonViewGroupWithScenariosSpec {
   return {
     kind: 'view-group-with-scenarios',
     title,
     scenarios,
-    graphs
+    graphs,
+    graphOrder
   }
 }
 

--- a/packages/check-core/src/comparison/config/comparison-config.ts
+++ b/packages/check-core/src/comparison/config/comparison-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
 import type { DatasetKey } from '../../_shared/types'
-import type { BundleGraphId, LoadedBundle, ModelSpec, NamedBundle } from '../../bundle/bundle-types'
+import type { LoadedBundle, ModelSpec, NamedBundle } from '../../bundle/bundle-types'
 
 import type { ComparisonScenario, ComparisonViewGroup } from '../_shared/comparison-resolved-types'
 
@@ -27,16 +27,6 @@ export interface ComparisonDatasetOptions {
   datasetKeysForScenario?: (allDatasetKeys: DatasetKey[], scenario: ComparisonScenario) => DatasetKey[]
 }
 
-export interface ComparisonGraphOptions {
-  /**
-   * An optional function that allows for limiting the graphs that are compared
-   * for a given scenario.  By default, all graphs are compared for a given
-   * scenario, but if a custom function is provided, it can return a subset of
-   * graphs (for example, to omit graphs that are not relevant under that scenario).
-   */
-  graphIdsForScenario?: (scenario: ComparisonScenario) => BundleGraphId[]
-}
-
 export interface ComparisonOptions {
   /** The left-side ("baseline") bundle being compared. */
   baseline: NamedBundle
@@ -52,8 +42,6 @@ export interface ComparisonOptions {
   specs: (ComparisonSpecs | ComparisonSpecsSource)[]
   /** Optional configuration for the datasets that are compared for different scenarios. */
   datasets?: ComparisonDatasetOptions
-  // /** Optional configuration for the graphs that are compared for different scenarios. */
-  // graphs?: ComparisonGraphOptions
 }
 
 export interface ComparisonConfig {

--- a/packages/check-core/src/comparison/config/comparison-spec-types.ts
+++ b/packages/check-core/src/comparison/config/comparison-spec-types.ts
@@ -151,36 +151,70 @@ export interface ComparisonScenarioGroupRefSpec {
 }
 
 //
+// GRAPHS
+//
+
+export type ComparisonGraphId = string
+
+/**
+ * Specifies a list of graphs to be shown in a view.
+ */
+export interface ComparisonGraphsArraySpec {
+  kind: 'graphs-array'
+  /** The array of IDs for graphs to show. */
+  graphIds: ComparisonGraphId[]
+}
+
+/**
+ * Specifies a preset list of graphs to be shown in a view.
+ */
+export interface ComparisonGraphsPresetSpec {
+  kind: 'graphs-preset'
+  /** The preset (currently only "all" is supported, which shows all available graphs). */
+  preset: 'all'
+}
+
+//
+// GRAPH GROUPS
+//
+
+export type ComparisonGraphGroupId = string
+
+/**
+ * A definition of a group of graphs to be shown in a view.  Multiple graphs can be grouped together
+ * under a single ID, and can later be referenced by group ID in a view definition.
+ */
+export interface ComparisonGraphGroupSpec {
+  kind: 'graph-group'
+  /** The unique identifier for the group. */
+  id: ComparisonGraphGroupId
+  /** The graphs that are included in this group. */
+  graphIds: ComparisonGraphId[]
+}
+
+/** A reference to a graph group definition. */
+export interface ComparisonGraphGroupRefSpec {
+  kind: 'graph-group-ref'
+  /** The ID of the graph group that is referenced. */
+  groupId: ComparisonGraphGroupId
+}
+
+//
 // VIEWS
 //
 
 export type ComparisonViewTitle = string
 export type ComparisonViewSubtitle = string
 
-export type ComparisonViewGraphId = string
-
-/**
- * Specifies a list of graphs to be shown in a view.
- */
-export interface ComparisonViewGraphsArraySpec {
-  kind: 'graphs-array'
-  /** The array of IDs for graphs to show. */
-  graphIds: ComparisonViewGraphId[]
-}
-
-/**
- * Specifies a preset list of graphs to be shown in a view.
- */
-export interface ComparisonViewGraphsPresetSpec {
-  kind: 'graphs-preset'
-  /** The preset (currently only "all" is supported, which shows all available graphs). */
-  preset: 'all'
-}
+export type ComparisonViewGraphOrder = 'default' | 'grouped-by-diffs'
 
 /**
  * Specifies a set of graphs to be shown in a view.
  */
-export type ComparisonViewGraphsSpec = ComparisonViewGraphsArraySpec | ComparisonViewGraphsPresetSpec
+export type ComparisonViewGraphsSpec =
+  | ComparisonGraphsPresetSpec
+  | ComparisonGraphsArraySpec
+  | ComparisonGraphGroupRefSpec
 
 /**
  * A definition of a view.  A view presents a set of graphs for a single input scenario.
@@ -195,6 +229,11 @@ export interface ComparisonViewSpec {
   scenarioId: ComparisonScenarioId
   /** The graphs to be shown for each scenario view. */
   graphs: ComparisonViewGraphsSpec
+  /**
+   * The order in which the graphs will be displayed.  If undefined, the graphs will be
+   * displayed in the "default" order, i.e., in the same order that the IDs were specified.
+   */
+  graphOrder?: ComparisonViewGraphOrder
 }
 
 //
@@ -226,6 +265,11 @@ export interface ComparisonViewGroupWithScenariosSpec {
   scenarios: (ComparisonScenarioRefSpec | ComparisonScenarioGroupRefSpec)[]
   /** The graphs to be shown for each scenario view. */
   graphs: ComparisonViewGraphsSpec
+  /**
+   * The order in which the graphs will be displayed.  If undefined, the graphs will be
+   * displayed in the "default" order, i.e., in the same order that the IDs were specified.
+   */
+  graphOrder?: ComparisonViewGraphOrder
 }
 
 /**
@@ -244,11 +288,13 @@ export type ComparisonViewGroupSpec = ComparisonViewGroupWithViewsSpec | Compari
  */
 export interface ComparisonSpecs {
   /** The requested scenarios. */
-  scenarios: ComparisonScenarioSpec[]
+  scenarios?: ComparisonScenarioSpec[]
   /** The requested scenario groups. */
-  scenarioGroups: ComparisonScenarioGroupSpec[]
+  scenarioGroups?: ComparisonScenarioGroupSpec[]
+  /** The requested graph groups. */
+  graphGroups?: ComparisonGraphGroupSpec[]
   /** The requested view groups. */
-  viewGroups: ComparisonViewGroupSpec[]
+  viewGroups?: ComparisonViewGroupSpec[]
 }
 
 /** A source of comparison scenario and specifications. */

--- a/packages/check-core/src/comparison/config/parse/comparison-parser.spec.ts
+++ b/packages/check-core/src/comparison/config/parse/comparison-parser.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import { parseComparisonSpecs } from './comparison-parser'
 import {
+  graphGroupRefSpec,
+  graphGroupSpec,
   graphsArraySpec,
   graphsPresetSpec,
   inputAtPositionSpec,
@@ -83,6 +85,12 @@ describe('parseComparisonSpecs', () => {
             - input: Input3
               at: max
 
+- graph_group:
+    id: GraphGroup1
+    graphs:
+      - '86'
+      - '87'
+
 - view_group:
     title: Baseline
     views:
@@ -105,8 +113,7 @@ describe('parseComparisonSpecs', () => {
           subtitle: Subtitle goes here
           scenario_ref: S1
           graphs:
-            - '86'
-            - '87'
+            graph_group_ref: GraphGroup1
 
 - view_group:
     title: Temp (shorthand)
@@ -148,11 +155,13 @@ describe('parseComparisonSpecs', () => {
       )
     ])
 
+    expect(comparisonSpecs.graphGroups).toEqual([graphGroupSpec('GraphGroup1', ['86', '87'])])
+
     expect(comparisonSpecs.viewGroups).toEqual([
       viewGroupWithViewsSpec('Baseline', [viewSpec('All graphs', undefined, 'S0', graphsPresetSpec('all'))]),
       viewGroupWithViewsSpec('Temp (explicit views)', [
         viewSpec('Temp for Scenario_0', undefined, 'S0', graphsArraySpec(['86', '87'])),
-        viewSpec('Temp for Scenario_1', 'Subtitle goes here', 'S1', graphsArraySpec(['86', '87']))
+        viewSpec('Temp for Scenario_1', 'Subtitle goes here', 'S1', graphGroupRefSpec('GraphGroup1'))
       ]),
       viewGroupWithScenariosSpec(
         'Temp (shorthand)',

--- a/packages/check-core/src/comparison/config/parse/comparison.schema.js
+++ b/packages/check-core/src/comparison/config/parse/comparison.schema.js
@@ -18,6 +18,7 @@ export default {
       oneOf: [
         { $ref: '#/$defs/scenario_array_item' },
         { $ref: '#/$defs/scenario_group_array_item' },
+        { $ref: '#/$defs/graph_group_array_item' },
         { $ref: '#/$defs/view_group_array_item' }
       ]
     },
@@ -284,6 +285,63 @@ export default {
     },
 
     //
+    // GRAPHS
+    //
+
+    graphs_preset: {
+      type: 'string',
+      enum: ['all']
+    },
+
+    graphs_array: {
+      type: 'array',
+      items: {
+        type: 'string'
+      },
+      minItems: 1
+    },
+
+    graph_group_ref: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        graph_group_ref: {
+          type: 'string'
+        }
+      },
+      required: ['graph_group_ref']
+    },
+
+    //
+    // GRAPH GROUPS
+    //
+
+    graph_group_array_item: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        graph_group: {
+          $ref: '#/$defs/graph_group'
+        }
+      },
+      required: ['graph_group']
+    },
+
+    graph_group: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string'
+        },
+        graphs: {
+          $ref: '#/$defs/graphs_array'
+        }
+      },
+      required: ['id', 'graphs']
+    },
+
+    //
     // VIEWS
     //
 
@@ -302,26 +360,21 @@ export default {
         },
         graphs: {
           $ref: '#/$defs/view_graphs'
+        },
+        graph_order: {
+          $ref: '#/$defs/view_graph_order'
         }
       },
       required: ['scenario_ref', 'graphs']
     },
 
     view_graphs: {
-      oneOf: [{ $ref: '#/$defs/view_graphs_preset' }, { $ref: '#/$defs/view_graphs_array' }]
+      oneOf: [{ $ref: '#/$defs/graphs_preset' }, { $ref: '#/$defs/graphs_array' }, { $ref: '#/$defs/graph_group_ref' }]
     },
 
-    view_graphs_preset: {
+    view_graph_order: {
       type: 'string',
-      enum: ['all']
-    },
-
-    view_graphs_array: {
-      type: 'array',
-      items: {
-        type: 'string'
-      },
-      minItems: 1
+      enum: ['default', 'group-by-diffs']
     },
 
     //

--- a/packages/check-core/src/comparison/config/parse/comparison.schema.js
+++ b/packages/check-core/src/comparison/config/parse/comparison.schema.js
@@ -374,7 +374,7 @@ export default {
 
     view_graph_order: {
       type: 'string',
-      enum: ['default', 'group-by-diffs']
+      enum: ['default', 'grouped-by-diffs']
     },
 
     //

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.spec.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.spec.ts
@@ -31,7 +31,6 @@ import {
 } from '../../_shared/_mocks/mock-resolved-types'
 
 import {
-  comparisonSpecs,
   graphGroupRefSpec,
   graphGroupSpec,
   graphsArraySpec,
@@ -133,20 +132,22 @@ describe('resolveComparisonSpecs', () => {
 
   describe('with scenario specs', () => {
     it('should expand "with: input" at position specs', () => {
-      const specs = comparisonSpecs([
-        // Match by variable name
-        scenarioWithInputsSpec([inputAtPositionSpec('ivarA', 'default')]),
-        // Match by input ID
-        scenarioWithInputsSpec([inputAtPositionSpec('id 2', 'min')]),
-        // Match by alias (slider name)
-        scenarioWithInputsSpec([inputAtPositionSpec('s3', 'max')]),
-        // Error if name can only be resolved on left side
-        scenarioWithInputsSpec([inputAtPositionSpec('ivarB', 'min')]),
-        // Error if name can only be resolved on right side
-        scenarioWithInputsSpec([inputAtPositionSpec('ivarD', 'min')]),
-        // Error if name can't be resolved on either side
-        scenarioWithInputsSpec([inputAtPositionSpec('ivarX', 'min')])
-      ])
+      const specs: ComparisonSpecs = {
+        scenarios: [
+          // Match by variable name
+          scenarioWithInputsSpec([inputAtPositionSpec('ivarA', 'default')]),
+          // Match by input ID
+          scenarioWithInputsSpec([inputAtPositionSpec('id 2', 'min')]),
+          // Match by alias (slider name)
+          scenarioWithInputsSpec([inputAtPositionSpec('s3', 'max')]),
+          // Error if name can only be resolved on left side
+          scenarioWithInputsSpec([inputAtPositionSpec('ivarB', 'min')]),
+          // Error if name can only be resolved on right side
+          scenarioWithInputsSpec([inputAtPositionSpec('ivarD', 'min')]),
+          // Error if name can't be resolved on either side
+          scenarioWithInputsSpec([inputAtPositionSpec('ivarX', 'min')])
+        ]
+      }
 
       const resolved = resolveComparisonSpecs(modelSpecL, modelSpecR, specs)
       expect(resolved).toEqual({
@@ -204,18 +205,20 @@ describe('resolveComparisonSpecs', () => {
     })
 
     it('should expand "with: input" at value specs', () => {
-      const specs = comparisonSpecs([
-        // Match by variable name
-        scenarioWithInputsSpec([inputAtValueSpec('ivarA', 20)]),
-        // Match by input ID
-        scenarioWithInputsSpec([inputAtValueSpec('id 2', 40)]),
-        // Match by alias (slider name)
-        scenarioWithInputsSpec([inputAtValueSpec('S3', 60)]),
-        // Error if value is out of range on both sides
-        scenarioWithInputsSpec([inputAtValueSpec('ivarA', 500)]),
-        // Error if value is out of range on one side
-        scenarioWithInputsSpec([inputAtValueSpec('id 2', 90)])
-      ])
+      const specs: ComparisonSpecs = {
+        scenarios: [
+          // Match by variable name
+          scenarioWithInputsSpec([inputAtValueSpec('ivarA', 20)]),
+          // Match by input ID
+          scenarioWithInputsSpec([inputAtValueSpec('id 2', 40)]),
+          // Match by alias (slider name)
+          scenarioWithInputsSpec([inputAtValueSpec('S3', 60)]),
+          // Error if value is out of range on both sides
+          scenarioWithInputsSpec([inputAtValueSpec('ivarA', 500)]),
+          // Error if value is out of range on one side
+          scenarioWithInputsSpec([inputAtValueSpec('id 2', 90)])
+        ]
+      }
 
       const resolved = resolveComparisonSpecs(modelSpecL, modelSpecR, specs)
       expect(resolved).toEqual({
@@ -284,20 +287,22 @@ describe('resolveComparisonSpecs', () => {
         }
       }
 
-      const specs = comparisonSpecs([
-        // Match by variable name
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 20)], [inputAtValueSpec('ivarA', 30)]),
-        // Match by input ID
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('id 2', 40)], [inputAtValueSpec('id 2', 50)]),
-        // Match by alias (slider name)
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('S3', 60)], [inputAtValueSpec('S3', 70)]),
-        // Error if input is not available on requested side
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 20)], [inputAtValueSpec('unknown', 600)]),
-        // Error if value is out of range on both sides
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 500)], [inputAtValueSpec('ivarA', 600)]),
-        // Error if value is out of range on one side
-        scenarioWithDistinctInputsSpec([inputAtValueSpec('id 2', 90)], [inputAtValueSpec('id 2', 600)])
-      ])
+      const specs: ComparisonSpecs = {
+        scenarios: [
+          // Match by variable name
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 20)], [inputAtValueSpec('ivarA', 30)]),
+          // Match by input ID
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('id 2', 40)], [inputAtValueSpec('id 2', 50)]),
+          // Match by alias (slider name)
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('S3', 60)], [inputAtValueSpec('S3', 70)]),
+          // Error if input is not available on requested side
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 20)], [inputAtValueSpec('unknown', 600)]),
+          // Error if value is out of range on both sides
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('ivarA', 500)], [inputAtValueSpec('ivarA', 600)]),
+          // Error if value is out of range on one side
+          scenarioWithDistinctInputsSpec([inputAtValueSpec('id 2', 90)], [inputAtValueSpec('id 2', 600)])
+        ]
+      }
 
       const resolved = resolveComparisonSpecs(modelSpecL, modelSpecR, specs)
       expect(resolved).toEqual({
@@ -355,11 +360,13 @@ describe('resolveComparisonSpecs', () => {
     // })
 
     it('should expand "with_inputs: all" at position specs', () => {
-      const specs = comparisonSpecs([
-        scenarioWithAllInputsSpec('default'),
-        scenarioWithAllInputsSpec('min'),
-        scenarioWithAllInputsSpec('max')
-      ])
+      const specs: ComparisonSpecs = {
+        scenarios: [
+          scenarioWithAllInputsSpec('default'),
+          scenarioWithAllInputsSpec('min'),
+          scenarioWithAllInputsSpec('max')
+        ]
+      }
 
       const resolved = resolveComparisonSpecs(modelSpecL, modelSpecR, specs)
       expect(resolved).toEqual({
@@ -445,7 +452,9 @@ describe('resolveComparisonSpecs', () => {
         )
       }
 
-      const specs = comparisonSpecs([scenarioMatrixSpec()])
+      const specs: ComparisonSpecs = {
+        scenarios: [scenarioMatrixSpec()]
+      }
 
       const resolved = resolveComparisonSpecs(modelSpecL, modelSpecR, specs)
       expect(resolved).toEqual({
@@ -472,15 +481,15 @@ describe('resolveComparisonSpecs', () => {
 
   describe('with scenario group specs', () => {
     it('should resolve a scenario group with valid scenarios and refs', () => {
-      const specs = comparisonSpecs(
-        [scenarioWithInputsSpec([inputAtPositionSpec('id 1', 'max')], { id: 'id_1_at_max' })],
-        [
+      const specs: ComparisonSpecs = {
+        scenarios: [scenarioWithInputsSpec([inputAtPositionSpec('id 1', 'max')], { id: 'id_1_at_max' })],
+        scenarioGroups: [
           scenarioGroupSpec('Group with two vars at max', [
             scenarioRefSpec('id_1_at_max'),
             scenarioWithInputsSpec([inputAtPositionSpec('id 2', 'max')])
           ])
         ]
-      )
+      }
 
       const expectedId1AtMax = scenarioWithInput(
         '1',
@@ -512,10 +521,10 @@ describe('resolveComparisonSpecs', () => {
     })
 
     it('should resolve a scenario group that refers to an unknown scenario', () => {
-      const specs = comparisonSpecs(
-        [scenarioWithInputsSpec([inputAtPositionSpec('id 1', 'max')])],
-        [scenarioGroupSpec('Group with invalid ref', [scenarioRefSpec('unknown')])]
-      )
+      const specs: ComparisonSpecs = {
+        scenarios: [scenarioWithInputsSpec([inputAtPositionSpec('id 1', 'max')])],
+        scenarioGroups: [scenarioGroupSpec('Group with invalid ref', [scenarioRefSpec('unknown')])]
+      }
 
       const expectedId1AtMax = scenarioWithInput(
         '1',

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
@@ -5,7 +5,7 @@ import { assertNever } from 'assert-never'
 import type { InputPosition, InputSetting, ScenarioSpec } from '../../../_shared/scenario-spec-types'
 import { inputSettingsSpec } from '../../../_shared/scenario-specs'
 
-import type { ModelInputs } from '../../../bundle/model-inputs'
+import { ModelInputs } from '../../../bundle/model-inputs'
 import type { InputId, InputVar } from '../../../bundle/var-types'
 
 import type {
@@ -23,6 +23,9 @@ import type {
 } from '../../_shared/comparison-resolved-types'
 
 import type {
+  ComparisonGraphGroupId,
+  ComparisonGraphGroupSpec,
+  ComparisonGraphId,
   ComparisonScenarioGroupId,
   ComparisonScenarioGroupSpec,
   ComparisonScenarioId,
@@ -33,13 +36,14 @@ import type {
   ComparisonScenarioSubtitle,
   ComparisonScenarioTitle,
   ComparisonSpecs,
-  ComparisonViewGraphId,
+  ComparisonViewGraphOrder,
   ComparisonViewGraphsSpec,
   ComparisonViewGroupSpec,
   ComparisonViewSubtitle,
   ComparisonViewTitle
 } from '../comparison-spec-types'
 import { inputSettingFromResolvedInputState, scenarioSpecsFromSettings } from './comparison-scenario-specs'
+import type { BundleGraphId, ModelSpec } from '../../../bundle/bundle-types'
 
 export interface ComparisonResolvedDefs {
   /** The set of resolved scenarios. */
@@ -57,13 +61,13 @@ type GenKey = () => ComparisonScenarioKey
  * requested specs, resolve references to input variables and scenarios, and then return
  * the definitions for the fully resolved scenarios and views.
  *
- * @param modelInputsL The model inputs for the "left" bundle being compared.
- * @param modelInputsR The model inputs for the "right" bundle being compared.
+ * @param modelSpecL The model spec for the "left" bundle being compared.
+ * @param modelSpecR The model spec for the "right" bundle being compared.
  * @param specs The scenario and view specs that were parsed from YAML/JSON definitions.
  */
 export function resolveComparisonSpecs(
-  modelInputsL: ModelInputs,
-  modelInputsR: ModelInputs,
+  modelSpecL: ModelSpec,
+  modelSpecR: ModelSpec,
   specs: ComparisonSpecs
 ): ComparisonResolvedDefs {
   let key = 1
@@ -71,9 +75,13 @@ export function resolveComparisonSpecs(
     return `${key++}` as ComparisonScenarioKey
   }
 
+  // Create `ModelInputs` instances to make lookups easier
+  const modelInputsL = new ModelInputs(modelSpecL)
+  const modelInputsR = new ModelInputs(modelSpecR)
+
   // Resolve the top-level scenario specs and convert to `ComparisonScenario` instances
   const resolvedScenarios = new ResolvedScenarios()
-  for (const scenarioSpec of specs.scenarios) {
+  for (const scenarioSpec of specs.scenarios || []) {
     resolvedScenarios.add(resolveScenariosFromSpec(modelInputsL, modelInputsR, scenarioSpec, genKey))
   }
 
@@ -85,7 +93,7 @@ export function resolveComparisonSpecs(
     scenarios: (ComparisonScenario | ComparisonScenarioRefSpec)[]
   }
   const partiallyResolvedScenarioGroups: PartiallyResolvedScenarioGroup[] = []
-  for (const scenarioGroupSpec of specs.scenarioGroups) {
+  for (const scenarioGroupSpec of specs.scenarioGroups || []) {
     const scenariosForGroup: (ComparisonScenario | ComparisonScenarioRefSpec)[] = []
     for (const scenarioItem of scenarioGroupSpec.scenarios) {
       if (scenarioItem.kind === 'scenario-ref') {
@@ -143,10 +151,23 @@ export function resolveComparisonSpecs(
     })
   }
 
+  // Resolve the top-level graph group specs
+  const resolvedGraphGroups = new ResolvedGraphGroups()
+  for (const graphGroupSpec of specs.graphGroups || []) {
+    resolvedGraphGroups.add(graphGroupSpec)
+  }
+
   // Resolve the view groups
   const resolvedViewGroups: ComparisonViewGroup[] = []
-  for (const viewGroupSpec of specs.viewGroups) {
-    const resolvedViewGroup = resolveViewGroupFromSpec(resolvedScenarios, resolvedScenarioGroups, viewGroupSpec)
+  for (const viewGroupSpec of specs.viewGroups || []) {
+    const resolvedViewGroup = resolveViewGroupFromSpec(
+      modelSpecL,
+      modelSpecR,
+      resolvedScenarios,
+      resolvedScenarioGroups,
+      resolvedGraphGroups,
+      viewGroupSpec
+    )
     resolvedViewGroups.push(resolvedViewGroup)
   }
 
@@ -633,18 +654,84 @@ class ResolvedScenarioGroups {
 }
 
 //
+// GRAPH GROUPS
+//
+
+// TODO: This doesn't currently check that the referenced graph IDs are available in one or both
+// model specs
+class ResolvedGraphGroups {
+  /** The array of all resolved graph groups. */
+  private readonly resolvedGroups: ComparisonGraphGroupSpec[] = []
+
+  /** The set of resolved graph groups, keyed by ID. */
+  private readonly resolvedGroupsById: Map<ComparisonGraphGroupId, ComparisonGraphGroupSpec> = new Map()
+
+  add(group: ComparisonGraphGroupSpec): void {
+    // Add the group to the general set
+    this.resolvedGroups.push(group)
+
+    // Also add to the map of groups with an ID
+    // TODO: Mark this as an error in the interface rather than throwing
+    if (this.resolvedGroupsById.has(group.id)) {
+      throw new Error(`Multiple graph groups defined with the same id (${group.id})`)
+    }
+    this.resolvedGroupsById.set(group.id, group)
+  }
+
+  getAll(): ComparisonGraphGroupSpec[] {
+    return this.resolvedGroups
+  }
+
+  getGroupForId(id: ComparisonGraphGroupId): ComparisonGraphGroupSpec | undefined {
+    return this.resolvedGroupsById.get(id)
+  }
+}
+
+//
 // VIEWS
 //
 
 /**
  * Return the graphs "all" preset or the graph IDs from a view graphs spec.
  */
-function resolveGraphsFromSpec(graphsSpec: ComparisonViewGraphsSpec): 'all' | ComparisonViewGraphId[] {
+function resolveGraphsFromSpec(
+  modelSpecL: ModelSpec,
+  modelSpecR: ModelSpec,
+  resolvedGraphGroups: ResolvedGraphGroups,
+  graphsSpec: ComparisonViewGraphsSpec
+): ComparisonGraphId[] {
   switch (graphsSpec.kind) {
-    case 'graphs-preset':
-      return 'all'
+    case 'graphs-preset': {
+      switch (graphsSpec.preset) {
+        case 'all': {
+          // Get the union of all graph IDs appearing in either left or right
+          const graphIds: Set<BundleGraphId> = new Set()
+          const addGraphIds = (modelSpec: ModelSpec) => {
+            if (modelSpec.graphSpecs) {
+              for (const graphSpec of modelSpec.graphSpecs) {
+                graphIds.add(graphSpec.id)
+              }
+            }
+          }
+          addGraphIds(modelSpecL)
+          addGraphIds(modelSpecR)
+          return [...graphIds]
+        }
+        default:
+          assertNever(graphsSpec.preset)
+      }
+    }
+    // eslint-disable-next-line no-fallthrough
     case 'graphs-array':
       return graphsSpec.graphIds
+    case 'graph-group-ref': {
+      const groupSpec = resolvedGraphGroups.getGroupForId(graphsSpec.groupId)
+      if (groupSpec === undefined) {
+        // TODO: Mark this as an error in the interface rather than throwing
+        throw new Error(`No graph group found for id ${graphsSpec.groupId}`)
+      }
+      return groupSpec.graphIds
+    }
     default:
       assertNever(graphsSpec)
   }
@@ -655,12 +742,13 @@ function resolveViewForScenarioId(
   viewTitle: ComparisonViewTitle | undefined,
   viewSubtitle: ComparisonViewSubtitle | undefined,
   scenarioId: ComparisonScenarioId,
-  graphs: 'all' | ComparisonViewGraphId[]
+  graphIds: ComparisonGraphId[],
+  graphOrder: ComparisonViewGraphOrder
 ): ComparisonView | ComparisonUnresolvedView {
   const resolvedScenario = resolvedScenarios.getScenarioForId(scenarioId)
   if (resolvedScenario) {
     // Add the resolved view
-    return resolveViewForScenario(viewTitle, viewSubtitle, resolvedScenario, graphs)
+    return resolveViewForScenario(viewTitle, viewSubtitle, resolvedScenario, graphIds, graphOrder)
   } else {
     // Add the unresolved view
     return unresolvedViewForScenarioId(viewTitle, viewSubtitle, scenarioId)
@@ -670,12 +758,13 @@ function resolveViewForScenarioId(
 function resolveViewForScenarioRefSpec(
   resolvedScenarios: ResolvedScenarios,
   refSpec: ComparisonScenarioRefSpec,
-  graphs: 'all' | ComparisonViewGraphId[]
+  graphIds: ComparisonGraphId[],
+  graphOrder: ComparisonViewGraphOrder
 ): ComparisonView | ComparisonUnresolvedView {
   const resolvedScenario = resolvedScenarios.getScenarioForId(refSpec.scenarioId)
   if (resolvedScenario) {
     // Add the resolved view
-    return resolveViewForScenario(refSpec.title, refSpec.subtitle, resolvedScenario, graphs)
+    return resolveViewForScenario(refSpec.title, refSpec.subtitle, resolvedScenario, graphIds, graphOrder)
   } else {
     // Add the unresolved view
     return unresolvedViewForScenarioId(undefined, undefined, refSpec.scenarioId)
@@ -686,7 +775,8 @@ function resolveViewForScenario(
   viewTitle: ComparisonViewTitle | undefined,
   viewSubtitle: ComparisonViewSubtitle | undefined,
   resolvedScenario: ComparisonScenario,
-  graphs: 'all' | ComparisonViewGraphId[]
+  graphIds: ComparisonGraphId[],
+  graphOrder: ComparisonViewGraphOrder
 ): ComparisonView {
   // If explicit title/subtitle were not provided for the view, infer them from the scenario
   // TODO: For now we only infer the subtitle if an explicit title was also not provided; this might
@@ -706,7 +796,8 @@ function resolveViewForScenario(
     title: viewTitle,
     subtitle: viewSubtitle,
     scenario: resolvedScenario,
-    graphs
+    graphIds,
+    graphOrder
   }
 }
 
@@ -744,8 +835,11 @@ function unresolvedViewForScenarioGroupId(
  * Return a resolved `ComparisonViewGroup` instance for the given view group spec.
  */
 function resolveViewGroupFromSpec(
+  modelSpecL: ModelSpec,
+  modelSpecR: ModelSpec,
   resolvedScenarios: ResolvedScenarios,
   resolvedScenarioGroups: ResolvedScenarioGroups,
+  resolvedGraphGroups: ResolvedGraphGroups,
   viewGroupSpec: ComparisonViewGroupSpec
 ): ComparisonViewGroup {
   let views: (ComparisonView | ComparisonUnresolvedView)[]
@@ -754,26 +848,28 @@ function resolveViewGroupFromSpec(
     case 'view-group-with-views': {
       // Resolve each view
       views = viewGroupSpec.views.map(viewSpec => {
-        const graphs = resolveGraphsFromSpec(viewSpec.graphs)
+        const graphIds = resolveGraphsFromSpec(modelSpecL, modelSpecR, resolvedGraphGroups, viewSpec.graphs)
         return resolveViewForScenarioId(
           resolvedScenarios,
           viewSpec.title,
           viewSpec.subtitle,
           viewSpec.scenarioId,
-          graphs
+          graphIds,
+          viewSpec.graphOrder || 'default'
         )
       })
       break
     }
     case 'view-group-with-scenarios': {
       // Resolve to one view for each scenario (with the same set of graphs for each view)
-      const graphs = resolveGraphsFromSpec(viewGroupSpec.graphs)
+      const graphIds = resolveGraphsFromSpec(modelSpecL, modelSpecR, resolvedGraphGroups, viewGroupSpec.graphs)
+      const graphOrder = viewGroupSpec.graphOrder || 'default'
       views = []
       for (const refSpec of viewGroupSpec.scenarios) {
         switch (refSpec.kind) {
           case 'scenario-ref':
             // Add a view for the scenario
-            views.push(resolveViewForScenarioRefSpec(resolvedScenarios, refSpec, graphs))
+            views.push(resolveViewForScenarioRefSpec(resolvedScenarios, refSpec, graphIds, graphOrder))
             break
           case 'scenario-group-ref': {
             const resolvedGroup = resolvedScenarioGroups.getGroupForId(refSpec.groupId)
@@ -785,7 +881,7 @@ function resolveViewGroupFromSpec(
                     views.push(unresolvedViewForScenarioId(undefined, undefined, scenario.scenarioId))
                     break
                   case 'scenario':
-                    views.push(resolveViewForScenario(undefined, undefined, scenario, graphs))
+                    views.push(resolveViewForScenario(undefined, undefined, scenario, graphIds, graphOrder))
                     break
                   default:
                     assertNever(scenario)

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
@@ -660,26 +660,16 @@ class ResolvedScenarioGroups {
 // TODO: This doesn't currently check that the referenced graph IDs are available in one or both
 // model specs
 class ResolvedGraphGroups {
-  /** The array of all resolved graph groups. */
-  private readonly resolvedGroups: ComparisonGraphGroupSpec[] = []
-
   /** The set of resolved graph groups, keyed by ID. */
   private readonly resolvedGroupsById: Map<ComparisonGraphGroupId, ComparisonGraphGroupSpec> = new Map()
 
   add(group: ComparisonGraphGroupSpec): void {
-    // Add the group to the general set
-    this.resolvedGroups.push(group)
-
-    // Also add to the map of groups with an ID
-    // TODO: Mark this as an error in the interface rather than throwing
+    // Add to the map of groups
     if (this.resolvedGroupsById.has(group.id)) {
+      // TODO: Mark this as an error in the interface rather than throwing
       throw new Error(`Multiple graph groups defined with the same id (${group.id})`)
     }
     this.resolvedGroupsById.set(group.id, group)
-  }
-
-  getAll(): ComparisonGraphGroupSpec[] {
-    return this.resolvedGroups
   }
 
   getGroupForId(id: ComparisonGraphGroupId): ComparisonGraphGroupSpec | undefined {

--- a/packages/check-core/src/config/config.ts
+++ b/packages/check-core/src/config/config.ts
@@ -3,7 +3,6 @@
 import type { ScenarioSpec } from '../_shared/scenario-spec-types'
 import type { DatasetKey, DatasetMap } from '../_shared/types'
 import type { BundleModel, LoadedBundle, NamedBundle } from '../bundle/bundle-types'
-import { ModelInputs } from '../bundle/model-inputs'
 
 import type { CheckConfig } from '../check/check-config'
 
@@ -81,9 +80,7 @@ export async function createConfig(options: ConfigOptions): Promise<Config> {
     // Combine and resolve the provided comparison specifications
     const modelSpecL = baselineBundle.model.modelSpec
     const modelSpecR = currentBundle.model.modelSpec
-    const modelInputsL = new ModelInputs(modelSpecL)
-    const modelInputsR = new ModelInputs(modelSpecR)
-    const comparisonDefs = resolveComparisonSpecsFromSources(modelInputsL, modelInputsR, options.comparison.specs)
+    const comparisonDefs = resolveComparisonSpecsFromSources(modelSpecL, modelSpecR, options.comparison.specs)
 
     // Initialize the configuration for comparisons
     comparisonConfig = {

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
@@ -3,17 +3,16 @@
 import assertNever from 'assert-never'
 
 import type {
-  BundleGraphId,
   ComparisonConfig,
   ComparisonDataCoordinator,
   ComparisonDataset,
+  ComparisonGraphId,
   ComparisonGroupSummary,
   ComparisonScenario,
   ComparisonTestSummary,
   ComparisonView,
   ComparisonViewGroup,
-  GraphComparisonReport,
-  LoadedBundle
+  GraphComparisonReport
 } from '@sdeverywhere/check-core'
 import { diffGraphs } from '@sdeverywhere/check-core'
 
@@ -37,7 +36,7 @@ export interface CompareGraphsSectionViewModel {
   rows: CompareGraphsRowViewModel[]
 }
 
-export interface CompareAllGraphsSections {
+export interface CompareGraphsGroupedByDiffs {
   /** The section view models. */
   sections: CompareGraphsSectionViewModel[]
   /** The total number of graphs with changes (non-zero difference). */
@@ -298,7 +297,7 @@ function createCompareDetailViewModelForScenario(
 
   // Add the compared graphs at top, if defined for the given view
   let graphSections: CompareGraphsSectionViewModel[]
-  if (view?.graphs) {
+  if (view) {
     const testSummaries = groupSummary.group.testSummaries
     graphSections = createCompareGraphsSectionViewModels(comparisonConfig, dataCoordinator, view, testSummaries)
   } else {
@@ -326,55 +325,50 @@ function createCompareGraphsSectionViewModels(
   view: ComparisonView,
   testSummaries: ComparisonTestSummary[]
 ): CompareGraphsSectionViewModel[] {
-  if (view.graphs === 'all') {
-    // For the special "all graphs" case, break the list of graphs into sections
-    const allGraphs = getAllGraphsSections(comparisonConfig, dataCoordinator, view.scenario, testSummaries)
-    return allGraphs.sections
-  }
-
   // No sections when there are no graphs
-  if (view.graphs.length === 0) {
+  if (view.graphIds.length === 0) {
     return []
   }
 
-  // When a specific set of graphs is defined, use a single "Featured graphs" section
-  const graphSpecsL = comparisonConfig.bundleL.model.modelSpec.graphSpecs
-  const graphSpecsR = comparisonConfig.bundleR.model.modelSpec.graphSpecs
-  const scenario = view.scenario
-  const rows: CompareGraphsRowViewModel[] = []
-  for (const graphId of view.graphs) {
-    const graphL = graphSpecsL?.find(s => s.id === graphId)
-    const graphR = graphSpecsR?.find(s => s.id === graphId)
-    const graphReport = diffGraphs(graphL, graphR, scenario.key, testSummaries)
-    rows.push(createCompareGraphsRowViewModel(comparisonConfig, dataCoordinator, scenario, graphId, graphReport))
-  }
-
-  return [
-    {
-      title: 'Featured graphs',
-      rows
+  if (view.graphOrder === 'grouped-by-diffs') {
+    // Group the graphs into sections (added, removed, etc) and order by the number/magnitude
+    // of differences
+    const grouped = getGraphsGroupedByDiffs(
+      comparisonConfig,
+      dataCoordinator,
+      view.scenario,
+      testSummaries,
+      view.graphIds
+    )
+    return grouped.sections
+  } else {
+    // Show the graphs in a single "Featured graphs" section
+    const graphSpecsL = comparisonConfig.bundleL.model.modelSpec.graphSpecs
+    const graphSpecsR = comparisonConfig.bundleR.model.modelSpec.graphSpecs
+    const scenario = view.scenario
+    const rows: CompareGraphsRowViewModel[] = []
+    for (const graphId of view.graphIds) {
+      const graphL = graphSpecsL?.find(s => s.id === graphId)
+      const graphR = graphSpecsR?.find(s => s.id === graphId)
+      const graphReport = diffGraphs(graphL, graphR, scenario.key, testSummaries)
+      rows.push(createCompareGraphsRowViewModel(comparisonConfig, dataCoordinator, scenario, graphId, graphReport))
     }
-  ]
+    return [
+      {
+        title: 'Featured graphs',
+        rows
+      }
+    ]
+  }
 }
 
-export function getAllGraphsSections(
+export function getGraphsGroupedByDiffs(
   comparisonConfig: ComparisonConfig,
   dataCoordinator: ComparisonDataCoordinator,
   scenario: ComparisonScenario,
-  testSummaries: ComparisonTestSummary[]
-): CompareAllGraphsSections {
-  // Get the union of all graph IDs appearing in either left or right
-  const graphIds: Set<BundleGraphId> = new Set()
-  function addGraphIds(bundle: LoadedBundle): void {
-    if (bundle.model.modelSpec.graphSpecs) {
-      for (const graphSpec of bundle.model.modelSpec.graphSpecs) {
-        graphIds.add(graphSpec.id)
-      }
-    }
-  }
-  addGraphIds(comparisonConfig.bundleL)
-  addGraphIds(comparisonConfig.bundleR)
-
+  testSummaries: ComparisonTestSummary[],
+  graphIds: ComparisonGraphId[]
+): CompareGraphsGroupedByDiffs {
   // Prepare the groups
   const added: CompareGraphsRowViewModel[] = []
   const removed: CompareGraphsRowViewModel[] = []
@@ -442,7 +436,7 @@ export function getAllGraphsSections(
   }
 
   // Get the percentage of diffs for each bucket relative to the total number of graphs
-  const totalGraphCount = graphIds.size
+  const totalGraphCount = graphIds.length
   const nonZeroDiffCount = totalGraphCount - diffCountByBucket[0]
   const diffPercentByBucket = diffCountByBucket.map(count => (count / totalGraphCount) * 100)
 

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
@@ -10,7 +10,7 @@ import { hasSignificantDiffs } from '../_shared/buckets'
 import type { ComparisonGroupingKind } from '../_shared/comparison-grouping-kind'
 import { datasetSpan } from '../_shared/spans'
 
-import { getAllGraphsSections } from '../detail/compare-detail-vm'
+import { getGraphsGroupedByDiffs } from '../detail/compare-detail-vm'
 
 import type { ComparisonSummaryRowViewModel, ComparisonViewKey } from './comparison-summary-row-vm'
 
@@ -88,15 +88,15 @@ export function createComparisonSummaryViewModels(
           const groupSummary = groupsByScenario.allGroupSummaries.get(scenario.key)
           let diffPercentByBucket: number[]
           let changedGraphCount: number
-          if (view.graphs === 'all') {
-            // For the special "all graphs" case, use the graph differences (instead of the dataset
-            // differences) for the purposes of computing bucket colors for the bar
+          if (view.graphOrder === 'grouped-by-diffs') {
+            // Use the graph differences (instead of the dataset differences) for the purposes of computing
+            // bucket colors for the bar
             // TODO: We should save the result of this comparison; currently we do it once here,
             // and then again when the detail view is shown
             const testSummaries = groupSummary.group.testSummaries
-            const allGraphs = getAllGraphsSections(comparisonConfig, undefined, scenario, testSummaries)
-            diffPercentByBucket = allGraphs.diffPercentByBucket
-            changedGraphCount = allGraphs.nonZeroDiffCount
+            const grouped = getGraphsGroupedByDiffs(comparisonConfig, undefined, scenario, testSummaries, view.graphIds)
+            diffPercentByBucket = grouped.diffPercentByBucket
+            changedGraphCount = grouped.nonZeroDiffCount
           } else {
             // Otherwise, use the dataset differences
             // TODO: We should only look at datasets that appear in the specified graphs, not all datasets

--- a/packages/check-ui-shell/src/components/summary/summary-vm.ts
+++ b/packages/check-ui-shell/src/components/summary/summary-vm.ts
@@ -91,12 +91,19 @@ export function createSummaryViewModel(
     if (comparisonSummaries.views) {
       comparisonViewsSummaryViewModel = comparisonSummaries.views
 
-      // For now, if we have an "all graphs" view, report the number of changed graphs.  If no graph differences, report
-      // the number of views (scenarios) with differences.
+      // For now, if we have one or more views that show graphs grouped by diffs, report the
+      // number of changed graphs.  If no graph differences, report the number of views
+      // (scenarios) with differences.
       let viewsTabInfo: TabInfo
-      const allViewRows = comparisonSummaries.views.allRows
-      const allGraphsRow = allViewRows.find(row => row.viewMetadata?.view.graphs === 'all')
-      const changedGraphCount = allGraphsRow?.viewMetadata?.changedGraphCount || 0
+      let changedGraphCount = 0
+      for (const row of comparisonSummaries.views.allRows) {
+        // TODO: We may end up counting the same graph here multiple times if there are multiple
+        // views that use "grouped-by-diffs" mode and display the same subset of graphs in each.
+        // Ideally we would get the number of unique graphs with changes here instead.
+        if (row.viewMetadata?.view.graphOrder === 'grouped-by-diffs') {
+          changedGraphCount += row?.viewMetadata?.changedGraphCount || 0
+        }
+      }
       if (changedGraphCount > 0) {
         viewsTabInfo = getTabInfo(changedGraphCount, 'graph')
       } else {


### PR DESCRIPTION
Fixes #539 

This updates the model-check packages to allow for more control over which graphs are displayed in a comparison view and in which order.  See issue for more details.
