### PR TITLE
feat: allow for customizing the set of context graphs that are displayed for a given dataset/scenario

### DIFF
--- a/packages/check-core/src/comparison/config/comparison-config.ts
+++ b/packages/check-core/src/comparison/config/comparison-config.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
 import type { DatasetKey } from '../../_shared/types'
-import type { LoadedBundle, ModelSpec, NamedBundle } from '../../bundle/bundle-types'
+import type { BundleGraphId, LoadedBundle, ModelSpec, NamedBundle } from '../../bundle/bundle-types'
 
-import type { ComparisonScenario, ComparisonViewGroup } from '../_shared/comparison-resolved-types'
+import type { ComparisonDataset, ComparisonScenario, ComparisonViewGroup } from '../_shared/comparison-resolved-types'
 
 import type { ComparisonDatasets } from './comparison-datasets'
 import type { ComparisonScenarios } from './comparison-scenarios'
@@ -25,6 +25,14 @@ export interface ComparisonDatasetOptions {
    * datasets (for example, to omit datasets that are not relevant).
    */
   datasetKeysForScenario?: (allDatasetKeys: DatasetKey[], scenario: ComparisonScenario) => DatasetKey[]
+  /**
+   * An optional function that allows for customizing the set of context graphs
+   * that are shown for a given dataset and scenario.  By default, all graphs in
+   * which the dataset appears will be shown, but if a custom function is provided,
+   * it can return a different set of graphs (for example, to omit graphs that are
+   * not relevant under the given scenario).
+   */
+  contextGraphIdsForDataset?: (dataset: ComparisonDataset, scenario: ComparisonScenario) => BundleGraphId[]
 }
 
 export interface ComparisonOptions {

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
@@ -1,13 +1,10 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
 import type {
-  BundleGraphId,
   BundleGraphSpec,
-  BundleModel,
   ComparisonConfig,
   ComparisonDataCoordinator,
-  ComparisonScenario,
-  OutputVar
+  ComparisonScenario
 } from '@sdeverywhere/check-core'
 
 import { ContextGraphViewModel } from '../../graphs/context-graph-vm'
@@ -74,34 +71,20 @@ export function createContextGraphRows(box: CompareDetailBoxViewModel): CompareD
   const bundleModelL = dataCoordinator.bundleModelL
   const bundleModelR = dataCoordinator.bundleModelR
 
-  const contextGraph = (scenario: ComparisonScenario, graphSpec: BundleGraphSpec, bundle: 'left' | 'right') => {
+  function contextGraph(
+    scenario: ComparisonScenario,
+    graphSpec: BundleGraphSpec | undefined,
+    bundle: 'left' | 'right'
+  ): ContextGraphViewModel {
     return new ContextGraphViewModel(comparisonConfig, dataCoordinator, bundle, scenario, graphSpec)
   }
 
   // Get the context graphs that are related to this output variable
-  const relatedGraphIds: Set<BundleGraphId> = new Set()
-  const addGraphs = (outputVar: OutputVar, bundleModel: BundleModel) => {
-    // Use the graph specs advertised by the bundle to determine which
-    // graphs to display
-    if (bundleModel.modelSpec.graphSpecs === undefined) {
-      return
-    }
-    for (const graphSpec of bundleModel.modelSpec.graphSpecs) {
-      for (const graphDatasetSpec of graphSpec.datasets) {
-        if (graphDatasetSpec.datasetKey === outputVar.datasetKey) {
-          relatedGraphIds.add(graphSpec.id)
-          break
-        }
-      }
-    }
-  }
-  const dataset = comparisonConfig.datasets.getDataset(box.datasetKey)
-  addGraphs(dataset.outputVarL, bundleModelL)
-  addGraphs(dataset.outputVarR, bundleModelR)
+  const graphIds = comparisonConfig.datasets.getContextGraphIdsForDataset(box.datasetKey, box.scenario)
 
   // Prepare context graphs for this box
   const contextGraphRows: CompareDetailContextGraphRowViewModel[] = []
-  for (const graphId of relatedGraphIds) {
+  for (const graphId of graphIds) {
     const graphSpecL = bundleModelL.modelSpec.graphSpecs?.find(s => s.id === graphId)
     const graphSpecR = bundleModelR.modelSpec.graphSpecs?.find(s => s.id === graphId)
     contextGraphRows.push({


### PR DESCRIPTION
Fixes #540 

This adds a new optional method to allow for overriding the default logic for choosing which context graphs are displayed below a box in model-check.  See issue for more details.
