### PR TITLE
feat: add view option for consistent y-axis limits across a row of comparison graphs

### DIFF
--- a/packages/check-ui-shell/src/_shared/user-prefs.ts
+++ b/packages/check-ui-shell/src/_shared/user-prefs.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2024 Climate Interactive / New Venture Fund
+
+import type { Readable } from 'svelte/store'
+
+export interface UserPrefs {
+  zoom: Readable<number>
+  consistentYRange: Readable<boolean>
+}

--- a/packages/check-ui-shell/src/app-vm.ts
+++ b/packages/check-ui-shell/src/app-vm.ts
@@ -6,6 +6,9 @@ import { get, writable } from 'svelte/store'
 import type { ComparisonSummary, SuiteSummary } from '@sdeverywhere/check-core'
 import { checkReportFromSummary, comparisonSummaryFromReport, runSuite } from '@sdeverywhere/check-core'
 
+import { localStorageWritableBoolean, localStorageWritableNumber } from './_shared/stores'
+import type { UserPrefs } from './_shared/user-prefs'
+
 import type { AppModel } from './model/app-model'
 
 import type { ComparisonGroupingKind } from './components/compare/_shared/comparison-grouping-kind'
@@ -31,6 +34,7 @@ export class AppViewModel {
   public readonly checksInProgress: Readable<boolean>
   private readonly writableProgress: Writable<string>
   public readonly progress: Readable<string>
+  public readonly userPrefs: UserPrefs
   public readonly headerViewModel: HeaderViewModel
   public summaryViewModel: SummaryViewModel
   private cancelRunSuite: () => void
@@ -48,8 +52,23 @@ export class AppViewModel {
     this.progress = this.writableProgress
 
     // Show the "Simplify Scenarios" checkbox if we run checks in the browser
-    const includeSimplifyScenarios = suiteSummary === undefined
-    this.headerViewModel = createHeaderViewModel(appModel.config.comparison, includeSimplifyScenarios)
+    let simplifyScenarios: Writable<boolean>
+    if (suiteSummary === undefined) {
+      simplifyScenarios = localStorageWritableBoolean('sde-check-simplify-scenarios', false)
+    } else {
+      simplifyScenarios = undefined
+    }
+
+    // Create the `UserPrefs` object that is passed down to the component hierarchy
+    const zoom = localStorageWritableNumber('sde-check-graph-zoom', 1)
+    const consistentYRange = localStorageWritableBoolean('sde-check-consistent-y-range', false)
+    this.userPrefs = {
+      zoom,
+      consistentYRange
+    }
+
+    // Create the header view model
+    this.headerViewModel = createHeaderViewModel(appModel.config.comparison, simplifyScenarios, zoom, consistentYRange)
   }
 
   runTestSuite(): void {
@@ -145,6 +164,7 @@ export class AppViewModel {
     return createCompareDetailViewModel(
       this.appModel.config.comparison,
       this.appModel.comparisonDataCoordinator,
+      this.userPrefs,
       groupSummary,
       viewGroup,
       view,

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
@@ -16,6 +16,8 @@ import type {
 } from '@sdeverywhere/check-core'
 import { diffGraphs } from '@sdeverywhere/check-core'
 
+import type { UserPrefs } from '../../../_shared/user-prefs'
+
 import { getAnnotationsForDataset, getAnnotationsForScenario } from '../_shared/annotations'
 import { getBucketIndex } from '../_shared/buckets'
 import type { ComparisonGroupingKind } from '../_shared/comparison-grouping-kind'
@@ -72,6 +74,7 @@ export interface CompareDetailViewModel {
 export function createCompareDetailViewModel(
   comparisonConfig: ComparisonConfig,
   dataCoordinator: ComparisonDataCoordinator,
+  userPrefs: UserPrefs,
   groupSummary: ComparisonGroupSummary,
   viewGroup: ComparisonViewGroup | undefined,
   view: ComparisonView | undefined,
@@ -83,6 +86,7 @@ export function createCompareDetailViewModel(
       return createCompareDetailViewModelForDataset(
         comparisonConfig,
         dataCoordinator,
+        userPrefs,
         groupSummary,
         previousRowIndex,
         nextRowIndex
@@ -91,6 +95,7 @@ export function createCompareDetailViewModel(
       return createCompareDetailViewModelForScenario(
         comparisonConfig,
         dataCoordinator,
+        userPrefs,
         groupSummary,
         viewGroup,
         view,
@@ -105,6 +110,7 @@ export function createCompareDetailViewModel(
 function createCompareDetailViewModelForDataset(
   comparisonConfig: ComparisonConfig,
   dataCoordinator: ComparisonDataCoordinator,
+  userPrefs: UserPrefs,
   groupSummary: ComparisonGroupSummary,
   previousRowIndex: number | undefined,
   nextRowIndex: number | undefined
@@ -157,6 +163,7 @@ function createCompareDetailViewModelForDataset(
     const detailRow = createCompareDetailRowViewModel(
       comparisonConfig,
       dataCoordinator,
+      userPrefs,
       'scenarios',
       group.title,
       undefined, // TODO: Subtitle?
@@ -190,6 +197,7 @@ function createCompareDetailViewModelForDataset(
 function createCompareDetailViewModelForScenario(
   comparisonConfig: ComparisonConfig,
   dataCoordinator: ComparisonDataCoordinator,
+  userPrefs: UserPrefs,
   groupSummary: ComparisonGroupSummary,
   viewGroup: ComparisonViewGroup | undefined,
   view: ComparisonView | undefined,
@@ -263,6 +271,7 @@ function createCompareDetailViewModelForScenario(
     const rowViewModel = createCompareDetailRowViewModel(
       comparisonConfig,
       dataCoordinator,
+      userPrefs,
       'datasets',
       title,
       subtitle,

--- a/packages/check-ui-shell/src/components/graphs/comparison-graph-vm.ts
+++ b/packages/check-ui-shell/src/components/graphs/comparison-graph-vm.ts
@@ -21,6 +21,9 @@ export interface ComparisonGraphViewModel {
   pointsR: Point[]
   xMin?: number
   xMax?: number
+  yMin?: number
+  yMax?: number
+  onUpdated?: () => void
 }
 
 /**

--- a/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
@@ -37,6 +37,11 @@ function initGraphView() {
   // Create the graph view that wraps the canvas element
   previousKey = viewModel.key
   graphView = new ComparisonGraphView(canvas, viewModel)
+
+  // Update the view when the view model is changed
+  viewModel.onUpdated = () => {
+    graphView?.update()
+  }
 }
 
 onMount(() => {

--- a/packages/check-ui-shell/src/components/header/header-vm.ts
+++ b/packages/check-ui-shell/src/components/header/header-vm.ts
@@ -3,7 +3,6 @@
 import type { Writable } from 'svelte/store'
 import { writable } from 'svelte/store'
 import type { ComparisonConfig } from '@sdeverywhere/check-core'
-import { localStorageWritableBoolean, localStorageWritableNumber } from '../../_shared/stores'
 
 export interface HeaderViewModel {
   nameL?: string
@@ -14,21 +13,16 @@ export interface HeaderViewModel {
   simplifyScenarios?: Writable<boolean>
   controlsVisible: Writable<boolean>
   zoom: Writable<number>
+  consistentYRange: Writable<boolean>
 }
 
 export function createHeaderViewModel(
   comparisonConfig: ComparisonConfig | undefined,
-  includeSimplifyScenarios: boolean
+  simplifyScenarios: Writable<boolean> | undefined,
+  zoom: Writable<number>,
+  consistentYRange: Writable<boolean>
 ): HeaderViewModel {
-  let simplifyScenarios: Writable<boolean>
-  if (includeSimplifyScenarios) {
-    simplifyScenarios = localStorageWritableBoolean('sde-check-simplify-scenarios', false)
-  } else {
-    simplifyScenarios = undefined
-  }
-
   const controlsVisible = writable(false)
-  const zoom = localStorageWritableNumber('sde-check-graph-zoom', 1)
 
   // Only include the comparison-related header elements if the comparison
   // config is defined
@@ -49,7 +43,8 @@ export function createHeaderViewModel(
       thresholds: thresholdStrings,
       simplifyScenarios,
       controlsVisible,
-      zoom
+      zoom,
+      consistentYRange
     }
   } else {
     return {
@@ -57,7 +52,8 @@ export function createHeaderViewModel(
       bundleNamesR: writable([]),
       simplifyScenarios,
       controlsVisible,
-      zoom
+      zoom,
+      consistentYRange
     }
   }
 }

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -16,7 +16,7 @@ const bundleNamesL = viewModel.bundleNamesL
 const bundleNamesR = viewModel.bundleNamesR
 const controlsVisible = viewModel.controlsVisible
 const zoom = viewModel.zoom
-
+const consistentYRange = viewModel.consistentYRange
 
 const dispatch = createEventDispatcher()
 
@@ -105,6 +105,9 @@ include header.pug
   +if('$controlsVisible')
     .header-controls
       .spacer-flex
+      input.checkbox(type='checkbox' name='toggle-consistent-y-range' bind:checked!='{$consistentYRange}')
+      label(for='toggle-consistent-y-range') Consistent Y-Axis Ranges
+      .spacer-fixed
       .control-label Graph Zoom:
       input(type="range" min="0.3" max="2.5" step="0.1" bind:value!='{$zoom}')
       .control-label { `${$zoom.toFixed(1)}x` }


### PR DESCRIPTION
Fixes #547 

This improves model-check with a new view option to show all graphs in a row with a consistent y-axis for easier (visual) comparison.  See issue for more details.
