### PR TITLE
feat: allow for adding reference plots to a comparison graph

### DIFF
--- a/examples/sample-check-tests/src/index.ts
+++ b/examples/sample-check-tests/src/index.ts
@@ -56,7 +56,20 @@ export function getConfigOptions(bundleL: Bundle, bundleR: Bundle, opts?: Config
       thresholds: [1, 5, 10],
       specs: comparisonSpecs,
       datasets: {
-        renamedDatasetKeys
+        renamedDatasetKeys,
+        referencePlotsForDataset: (dataset, scenario) => {
+          if (dataset.key === 'Model__output_x' && scenario.title.startsWith('Input A')) {
+            return [
+              {
+                datasetKey: 'StaticData__static_s',
+                color: 'orange',
+                style: 'dashed',
+                lineWidth: 2
+              }
+            ]
+          }
+          return []
+        }
       }
     }
   }

--- a/packages/check-core/src/comparison/config/comparison-config.ts
+++ b/packages/check-core/src/comparison/config/comparison-config.ts
@@ -12,6 +12,20 @@ import { parseComparisonSpecs } from './parse/comparison-parser'
 import type { ComparisonResolvedDefs } from './resolve/comparison-resolver'
 import { resolveComparisonSpecs } from './resolve/comparison-resolver'
 
+/**
+ * Describes an extra plot to be shown in a comparison graph.
+ */
+export interface ComparisonPlot {
+  /** The dataset key for the plot. */
+  datasetKey: DatasetKey
+  /** The plot color. */
+  color: string
+  /** The plot style.  If undefined, defaults to 'normal'. */
+  style?: 'normal' | 'dashed'
+  /** The plot line width, in px units.  If undefined, a default width will be used. */
+  lineWidth?: number
+}
+
 export interface ComparisonDatasetOptions {
   /**
    * The mapping of renamed dataset keys (old or "left" name as the map key,
@@ -25,6 +39,13 @@ export interface ComparisonDatasetOptions {
    * datasets (for example, to omit datasets that are not relevant).
    */
   datasetKeysForScenario?: (allDatasetKeys: DatasetKey[], scenario: ComparisonScenario) => DatasetKey[]
+  /**
+   * An optional function that allows for including additional reference plots
+   * on a comparison graph for a given dataset and scenario.  By default, no
+   * additional reference plots are included, but if a custom function is
+   * provided, it can return an array of `ComparisonPlot` objects.
+   */
+  referencePlotsForDataset?: (dataset: ComparisonDataset, scenario: ComparisonScenario) => ComparisonPlot[]
   /**
    * An optional function that allows for customizing the set of context graphs
    * that are shown for a given dataset and scenario.  By default, all graphs in

--- a/packages/check-core/src/comparison/config/comparison-datasets.ts
+++ b/packages/check-core/src/comparison/config/comparison-datasets.ts
@@ -4,7 +4,7 @@ import type { BundleGraphId, ModelSpec } from '../../bundle/bundle-types'
 import type { OutputVar } from '../../bundle/var-types'
 import type { DatasetKey } from '../../_shared/types'
 import type { ComparisonDataset, ComparisonScenario } from '../_shared/comparison-resolved-types'
-import type { ComparisonDatasetOptions } from './comparison-config'
+import type { ComparisonDatasetOptions, ComparisonPlot } from './comparison-config'
 
 /**
  * Provides access to the set of dataset definitions (`ComparisonDataset` instances) that are used
@@ -29,6 +29,15 @@ export interface ComparisonDatasets {
    * @param scenario The scenario definition.
    */
   getDatasetKeysForScenario(scenario: ComparisonScenario): DatasetKey[]
+
+  /**
+   * Return the reference plots that should be shown in the comparison graph for the
+   * given dataset and scenario.
+   *
+   * @param datasetKey The key for the dataset.
+   * @param scenario The scenario for which the dataset will be displayed.
+   */
+  getReferencePlotsForDataset(datasetKey: DatasetKey, scenario: ComparisonScenario): ComparisonPlot[]
 
   /**
    * Return the context graph IDs that should be shown for the given dataset and scenario.
@@ -155,6 +164,18 @@ class ComparisonDatasetsImpl implements ComparisonDatasets {
         return this.modelOutputVarKeys
       }
     }
+  }
+
+  // from ComparisonDatasets interface
+  getReferencePlotsForDataset(datasetKey: DatasetKey, scenario: ComparisonScenario): ComparisonPlot[] {
+    if (this.datasetOptions?.referencePlotsForDataset !== undefined) {
+      // Delegate to the custom function
+      const dataset = this.getDataset(datasetKey)
+      if (dataset !== undefined) {
+        return this.datasetOptions.referencePlotsForDataset(dataset, scenario)
+      }
+    }
+    return []
   }
 
   // from ComparisonDatasets interface

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -81,7 +81,8 @@ export * from './comparison/config/comparison-spec-types'
 export type {
   ComparisonConfig,
   ComparisonDatasetOptions,
-  ComparisonOptions
+  ComparisonOptions,
+  ComparisonPlot
 } from './comparison/config/comparison-config'
 export type { ComparisonScenarios } from './comparison/config/comparison-scenarios'
 export type { ComparisonDatasets } from './comparison/config/comparison-datasets'

--- a/packages/check-ui-shell/src/components/graphs/comparison-graph-vm.ts
+++ b/packages/check-ui-shell/src/components/graphs/comparison-graph-vm.ts
@@ -7,18 +7,18 @@ export interface Point {
   y: number
 }
 
-export type PlotStyle = 'normal' | 'wide' | 'dashed' | 'fill-to-next' | 'fill-above' | 'fill-below'
+export type ComparisonGraphPlotStyle = 'normal' | 'dashed' | 'fill-to-next' | 'fill-above' | 'fill-below'
 
-export interface RefPlot {
+export interface ComparisonGraphPlot {
   points: Point[]
-  style: PlotStyle
+  color: string
+  style?: ComparisonGraphPlotStyle
+  lineWidth?: number
 }
 
 export interface ComparisonGraphViewModel {
   key: string
-  refPlots: RefPlot[]
-  pointsL: Point[]
-  pointsR: Point[]
+  plots: ComparisonGraphPlot[]
   xMin?: number
   xMax?: number
   yMin?: number


### PR DESCRIPTION
Fixes #549 

This improves model-check by adding the ability to include extra reference plots in a comparison graph.  See issue for more details.
