### PR TITLE
feat: allow for showing a mix of dataset/scenario combinations in a single comparison view

### DIFF
--- a/examples/sample-check-tests/src/comparisons/comparisons.yaml
+++ b/examples/sample-check-tests/src/comparisons/comparisons.yaml
@@ -97,6 +97,57 @@
           graph_order: grouped-by-diffs
 
 - view_group:
+    title: Freeform (views defined with a mix of datasets and scenarios)
+    views:
+      - view:
+          title: Calibration
+          rows:
+            - row:
+                title: Outputs X and Y
+                subtitle: with sliders at min
+                boxes:
+                  - box:
+                      title: Output X
+                      subtitle: with input 1 at min
+                      dataset:
+                        name: Output X
+                      scenario_ref: input_1_at_min
+                  - box:
+                      title: Output X
+                      subtitle: with input 2 at min
+                      dataset:
+                        name: Output X
+                      scenario_ref: input_2_at_min
+                  - box:
+                      title: Output Y
+                      subtitle: with input 1 at min
+                      dataset:
+                        name: Output Y
+                      scenario_ref: input_1_at_min
+                  - box:
+                      title: Output Y
+                      subtitle: with input 2 at min
+                      dataset:
+                        name: Output Y
+                      scenario_ref: input_2_at_min
+            - row:
+                title: Outputs X
+                subtitle: with sliders at max
+                boxes:
+                  - box:
+                      title: Output X
+                      subtitle: with input 1 at max
+                      dataset:
+                        name: Output X
+                      scenario_ref: input_1_at_max
+                  - box:
+                      title: Output X
+                      subtitle: with input 2 at max
+                      dataset:
+                        name: Output X
+                      scenario_ref: input_2_at_max
+
+- view_group:
     title: Extremes
     views:
       - view:

--- a/packages/check-core/schema/comparison.schema.json
+++ b/packages/check-core/schema/comparison.schema.json
@@ -23,6 +23,21 @@
         }
       ]
     },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "scenario_array_item": {
       "type": "object",
       "additionalProperties": false,
@@ -379,6 +394,16 @@
       ]
     },
     "view": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/view_with_scenario"
+        },
+        {
+          "$ref": "#/$defs/view_with_rows"
+        }
+      ]
+    },
+    "view_with_scenario": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -399,8 +424,100 @@
         }
       },
       "required": [
-        "scenario_ref",
-        "graphs"
+        "scenario_ref"
+      ]
+    },
+    "view_with_rows": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "rows": {
+          "$ref": "#/$defs/view_rows_array"
+        }
+      },
+      "required": [
+        "title",
+        "rows"
+      ]
+    },
+    "view_rows_array": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/view_rows_array_item"
+      },
+      "minItems": 1
+    },
+    "view_rows_array_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "row": {
+          "$ref": "#/$defs/view_row"
+        }
+      }
+    },
+    "view_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "boxes": {
+          "$ref": "#/$defs/view_boxes_array"
+        }
+      },
+      "required": [
+        "title",
+        "boxes"
+      ]
+    },
+    "view_boxes_array": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/view_boxes_array_item"
+      },
+      "minItems": 1
+    },
+    "view_boxes_array_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "box": {
+          "$ref": "#/$defs/view_box"
+        }
+      }
+    },
+    "view_box": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "dataset": {
+          "$ref": "#/$defs/dataset"
+        },
+        "scenario_ref": {
+          "$ref": "#/$defs/scenario_ref_id"
+        }
+      },
+      "required": [
+        "title",
+        "dataset",
+        "scenario_ref"
       ]
     },
     "view_graphs": {

--- a/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
@@ -2,10 +2,11 @@
 
 import type { InputPosition, ScenarioSpec } from '../../../_shared/scenario-spec-types'
 import { allInputsAtPositionSpec, inputAtPositionSpec, inputAtValueSpec } from '../../../_shared/scenario-specs'
-import type { VarId } from '../../../_shared/types'
-import type { InputId, InputVar } from '../../../bundle/var-types'
+import type { DatasetKey, VarId } from '../../../_shared/types'
+import type { InputId, InputVar, OutputVar } from '../../../bundle/var-types'
 
 import type {
+  ComparisonDataset,
   ComparisonResolverError,
   ComparisonScenario,
   ComparisonScenarioGroup,
@@ -15,7 +16,9 @@ import type {
   ComparisonUnresolvedScenarioRef,
   ComparisonUnresolvedView,
   ComparisonView,
-  ComparisonViewGroup
+  ComparisonViewBox,
+  ComparisonViewGroup,
+  ComparisonViewRow
 } from '../comparison-resolved-types'
 import type {
   ComparisonGraphId,
@@ -23,6 +26,30 @@ import type {
   ComparisonScenarioId,
   ComparisonViewGraphOrder
 } from '../../config/comparison-spec-types'
+
+//
+// DATASETS
+//
+
+export function outputVar(varName: string, source?: string): [VarId, OutputVar] {
+  const varId = `_${varName.toLowerCase().replace(' ', '_')}`
+  const datasetKey = `${source || 'Model'}_${varId}`
+  const v: OutputVar = {
+    datasetKey,
+    varId,
+    varName
+  }
+  return [datasetKey, v]
+}
+
+export function dataset(key: DatasetKey, outputVarL: OutputVar, outputVarR: OutputVar): ComparisonDataset {
+  return {
+    kind: 'dataset',
+    key,
+    outputVarL,
+    outputVarR
+  }
+}
 
 //
 // SCENARIOS
@@ -221,7 +248,7 @@ export function scenarioGroup(
 // VIEWS
 //
 
-export function view(
+export function viewWithScenario(
   title: string,
   subtitle: string | undefined,
   scenario: ComparisonScenario,
@@ -235,6 +262,41 @@ export function view(
     scenario,
     graphIds,
     graphOrder: graphOrder || 'default'
+  }
+}
+
+export function viewWithRows(title: string, subtitle: string | undefined, rows: ComparisonViewRow[]): ComparisonView {
+  return {
+    kind: 'view',
+    title,
+    subtitle,
+    rows,
+    graphIds: [],
+    graphOrder: 'default'
+  }
+}
+
+export function viewRow(title: string, subtitle: string | undefined, boxes: ComparisonViewBox[]): ComparisonViewRow {
+  return {
+    kind: 'view-row',
+    title,
+    subtitle,
+    boxes
+  }
+}
+
+export function viewBox(
+  title: string,
+  subtitle: string | undefined,
+  dataset: ComparisonDataset,
+  scenario: ComparisonScenario
+): ComparisonViewBox {
+  return {
+    kind: 'view-box',
+    title,
+    subtitle,
+    dataset,
+    scenario
   }
 }
 

--- a/packages/check-core/src/comparison/_shared/comparison-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/comparison-resolved-types.ts
@@ -4,12 +4,18 @@ import type { DatasetKey } from '../../_shared/types'
 import type { InputPosition, ScenarioSpec } from '../../_shared/scenario-spec-types'
 import type { InputVar, OutputVar } from '../../bundle/var-types'
 import type {
+  ComparisonDatasetName,
+  ComparisonDatasetSource,
   ComparisonGraphId,
   ComparisonScenarioGroupId,
   ComparisonScenarioGroupTitle,
   ComparisonScenarioId,
   ComparisonViewGraphOrder,
   ComparisonViewGroupTitle,
+  ComparisonViewItemSubtitle,
+  ComparisonViewItemTitle,
+  ComparisonViewRowSubtitle,
+  ComparisonViewRowTitle,
   ComparisonViewSubtitle,
   ComparisonViewTitle
 } from '../config/comparison-spec-types'
@@ -162,15 +168,47 @@ export interface ComparisonGraphGroup {
 // VIEWS
 //
 
-/** A resolved view definition.  A view presents a set of graphs for a single input scenario. */
+/**
+ * A resolved comparison box to be shown in a view.
+ */
+export interface ComparisonViewBox {
+  kind: 'view-box'
+  /** The title of the box. */
+  title: ComparisonViewItemTitle
+  /** The subtitle of the box. */
+  subtitle?: ComparisonViewItemSubtitle
+  /** The resolved dataset shown in this comparison box. */
+  dataset: ComparisonDataset
+  /** The resolved scenario shown in this comparison box. */
+  scenario: ComparisonScenario
+}
+
+/**
+ * A resolved row of comparison boxes to be shown in a view.
+ */
+export interface ComparisonViewRow {
+  kind: 'view-row'
+  /** The title of the row. */
+  title: ComparisonViewRowTitle
+  /** The subtitle of the row. */
+  subtitle?: ComparisonViewRowSubtitle
+  /** The array of resolved boxes to be shown in the row. */
+  boxes: ComparisonViewBox[]
+}
+/**
+ * A resolved view definition.  A view presents a set of graphs, either for a single input scenario
+ * or for a mix of different dataset/scenario combinations.
+ */
 export interface ComparisonView {
   kind: 'view'
   /** The title of the view. */
   title: ComparisonViewTitle
   /** The subtitle of the view. */
   subtitle?: ComparisonViewSubtitle
-  /** The resolved scenario to be shown in the view. */
-  scenario: ComparisonScenario
+  /** The resolved scenario to be shown in the view if this is a single-scenario view. */
+  scenario?: ComparisonScenario
+  /** The array of resolved rows to be shown in the view if this is a freeform view. */
+  rows?: ComparisonViewRow[]
   /** The graphs to be shown for each scenario view. */
   graphIds: ComparisonGraphId[]
   /** The order in which the graphs will be displayed. */
@@ -184,6 +222,10 @@ export interface ComparisonUnresolvedView {
   title?: ComparisonViewTitle
   /** The requested subtitle of the view, if provided. */
   subtitle?: ComparisonViewSubtitle
+  /** The name of the referenced dataset that could not be resolved. */
+  datasetName?: ComparisonDatasetName
+  /** The source of the referenced dataset that could not be resolved. */
+  datasetSource?: ComparisonDatasetSource
   /** The ID of the referenced scenario that could not be resolved. */
   scenarioId?: ComparisonScenarioId
   /** The ID of the referenced scenario group that could not be resolved. */

--- a/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
+++ b/packages/check-core/src/comparison/config/_mocks/mock-spec-types.ts
@@ -1,6 +1,9 @@
 // Copyright (c) 2023 Climate Interactive / New Venture Fund
 
 import type {
+  ComparisonDatasetName,
+  ComparisonDatasetSource,
+  ComparisonDatasetSpec,
   ComparisonGraphGroupId,
   ComparisonGraphGroupRefSpec,
   ComparisonGraphGroupSpec,
@@ -21,12 +24,26 @@ import type {
   ComparisonScenarioWithAllInputsSpec,
   ComparisonScenarioWithDistinctInputsSpec,
   ComparisonScenarioWithInputsSpec,
+  ComparisonViewBoxSpec,
   ComparisonViewGraphOrder,
   ComparisonViewGraphsSpec,
   ComparisonViewGroupWithScenariosSpec,
   ComparisonViewGroupWithViewsSpec,
+  ComparisonViewRowSpec,
   ComparisonViewSpec
 } from '../comparison-spec-types'
+
+//
+// DATASETS
+//
+
+export function datasetSpec(name: ComparisonDatasetName, source?: ComparisonDatasetSource): ComparisonDatasetSpec {
+  return {
+    kind: 'dataset',
+    name,
+    source
+  }
+}
 
 //
 // SCENARIOS
@@ -176,11 +193,11 @@ export function graphGroupRefSpec(groupId: ComparisonGraphGroupId): ComparisonGr
 // VIEWS
 //
 
-export function viewSpec(
+export function viewWithScenarioSpec(
   title: string | undefined,
   subtitle: string | undefined,
   scenarioId: ComparisonScenarioId,
-  graphs: ComparisonViewGraphsSpec,
+  graphs?: ComparisonViewGraphsSpec,
   graphOrder?: ComparisonViewGraphOrder
 ): ComparisonViewSpec {
   return {
@@ -190,6 +207,47 @@ export function viewSpec(
     scenarioId,
     graphs,
     graphOrder
+  }
+}
+
+export function viewWithRowsSpec(
+  title: string | undefined,
+  subtitle: string | undefined,
+  rows: ComparisonViewRowSpec[]
+): ComparisonViewSpec {
+  return {
+    kind: 'view',
+    title,
+    subtitle,
+    rows
+  }
+}
+
+export function viewRowSpec(
+  title: string,
+  subtitle: string | undefined,
+  boxes: ComparisonViewBoxSpec[]
+): ComparisonViewRowSpec {
+  return {
+    kind: 'view-row',
+    title,
+    subtitle,
+    boxes
+  }
+}
+
+export function viewBoxSpec(
+  title: string,
+  subtitle: string | undefined,
+  dataset: ComparisonDatasetSpec,
+  scenarioId: ComparisonScenarioId
+): ComparisonViewBoxSpec {
+  return {
+    kind: 'view-box',
+    title,
+    subtitle,
+    dataset,
+    scenarioId
   }
 }
 

--- a/packages/check-core/src/comparison/config/comparison-datasets.ts
+++ b/packages/check-core/src/comparison/config/comparison-datasets.ts
@@ -144,7 +144,7 @@ class ComparisonDatasetsImpl implements ComparisonDatasets {
   }
 
   // from ComparisonDatasets interface
-  getDataset(datasetKey: string): ComparisonDataset | undefined {
+  getDataset(datasetKey: DatasetKey): ComparisonDataset | undefined {
     return this.allDatasets.get(datasetKey)
   }
 

--- a/packages/check-core/src/comparison/config/comparison-spec-types.ts
+++ b/packages/check-core/src/comparison/config/comparison-spec-types.ts
@@ -12,8 +12,12 @@ export type ComparisonDatasetSource = string
  */
 export interface ComparisonDatasetSpec {
   kind: 'dataset'
-  /** The  */
+  /** The name of the dataset (variable). */
   name: ComparisonDatasetName
+  /**
+   * The source of the dataset, if it is from an external data file.  If
+   * undefined, the dataset is assumed to be a model output.
+   */
   source?: ComparisonDatasetSource
 }
 

--- a/packages/check-core/src/comparison/config/comparison-spec-types.ts
+++ b/packages/check-core/src/comparison/config/comparison-spec-types.ts
@@ -1,6 +1,23 @@
 // Copyright (c) 2023 Climate Interactive / New Venture Fund
 
 //
+// DATASETS
+//
+
+export type ComparisonDatasetName = string
+export type ComparisonDatasetSource = string
+
+/**
+ * Specifies a dataset (variable) used for comparison.
+ */
+export interface ComparisonDatasetSpec {
+  kind: 'dataset'
+  /** The  */
+  name: ComparisonDatasetName
+  source?: ComparisonDatasetSource
+}
+
+//
 // SCENARIOS
 //
 
@@ -206,7 +223,41 @@ export interface ComparisonGraphGroupRefSpec {
 export type ComparisonViewTitle = string
 export type ComparisonViewSubtitle = string
 
+export type ComparisonViewRowTitle = string
+export type ComparisonViewRowSubtitle = string
+
+export type ComparisonViewItemTitle = string
+export type ComparisonViewItemSubtitle = string
+
 export type ComparisonViewGraphOrder = 'default' | 'grouped-by-diffs'
+
+/**
+ * Specifies a single comparison box to be shown in a view.
+ */
+export interface ComparisonViewBoxSpec {
+  kind: 'view-box'
+  /** The title of the box. */
+  title: ComparisonViewItemTitle
+  /** The subtitle of the box. */
+  subtitle?: ComparisonViewItemSubtitle
+  /** The dataset shown in this comparison box. */
+  dataset: ComparisonDatasetSpec
+  /** The scenario shown in this comparison box. */
+  scenarioId: ComparisonScenarioId
+}
+
+/**
+ * Specifies a row of comparison boxes to be shown in a view.
+ */
+export interface ComparisonViewRowSpec {
+  kind: 'view-row'
+  /** The title of the row. */
+  title: ComparisonViewRowTitle
+  /** The subtitle of the row. */
+  subtitle?: ComparisonViewRowSubtitle
+  /** The array of boxes to be shown in the row. */
+  boxes: ComparisonViewBoxSpec[]
+}
 
 /**
  * Specifies a set of graphs to be shown in a view.
@@ -217,18 +268,21 @@ export type ComparisonViewGraphsSpec =
   | ComparisonGraphGroupRefSpec
 
 /**
- * A definition of a view.  A view presents a set of graphs for a single input scenario.
+ * A definition of a view.  A view presents a set of graphs, either for a single input scenario
+ * or for a mix of different dataset/scenario combinations.
  */
 export interface ComparisonViewSpec {
   kind: 'view'
   /** The title of the view.  If undefined, the title will be inferred from the scenario. */
   title?: ComparisonViewTitle
   /** The subtitle of the view.  If undefined, the subtitle will be inferred from the scenario. */
-  subtitle?: ComparisonViewGroupTitle
-  /** The scenario to be shown in the view. */
-  scenarioId: ComparisonScenarioId
-  /** The graphs to be shown for each scenario view. */
-  graphs: ComparisonViewGraphsSpec
+  subtitle?: ComparisonViewSubtitle
+  /** The scenario to be shown in the view if this is a single-scenario view. */
+  scenarioId?: ComparisonScenarioId
+  /** The array of rows to be shown in the view if this is a freeform view. */
+  rows?: ComparisonViewRowSpec[]
+  /** The graphs to be shown in the view. */
+  graphs?: ComparisonViewGraphsSpec
   /**
    * The order in which the graphs will be displayed.  If undefined, the graphs will be
    * displayed in the "default" order, i.e., in the same order that the IDs were specified.

--- a/packages/check-core/src/comparison/config/parse/comparison-parser.spec.ts
+++ b/packages/check-core/src/comparison/config/parse/comparison-parser.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { parseComparisonSpecs } from './comparison-parser'
 import {
+  datasetSpec,
   graphGroupRefSpec,
   graphGroupSpec,
   graphsArraySpec,
@@ -16,9 +17,12 @@ import {
   scenarioRefSpec,
   scenarioWithAllInputsSpec,
   scenarioWithInputsSpec,
+  viewBoxSpec,
   viewGroupWithScenariosSpec,
   viewGroupWithViewsSpec,
-  viewSpec
+  viewRowSpec,
+  viewWithRowsSpec,
+  viewWithScenarioSpec
 } from '../_mocks/mock-spec-types'
 
 describe('parseComparisonSpecs', () => {
@@ -109,11 +113,15 @@ describe('parseComparisonSpecs', () => {
             - '86'
             - '87'
       - view:
-          title: Temp for Scenario_1
+          title: Temp for Scenario_1 (with graph group)
           subtitle: Subtitle goes here
           scenario_ref: S1
           graphs:
             graph_group_ref: GraphGroup1
+      - view:
+          title: Temp for Scenario_1 (no graphs)
+          subtitle: Subtitle goes here
+          scenario_ref: S1
 
 - view_group:
     title: Temp (shorthand)
@@ -124,12 +132,59 @@ describe('parseComparisonSpecs', () => {
     graphs:
       - '86'
       - '87'
+
+- view_group:
+    title: Calibration (explicit view with freeform rows)
+    views:
+      - view:
+          title: Calibration Scenarios (mix of datasets and scenarios per row)
+          rows:
+            - row:
+                title: Row 1
+                subtitle: Subtitle goes here
+                boxes:
+                  - box:
+                      title: Output X
+                      subtitle: with Scenario 0
+                      dataset:
+                        name: Output X
+                      scenario_ref: S0
+                  - box:
+                      title: Output Y
+                      subtitle: with Scenario 1
+                      dataset:
+                        name: Output Y
+                      scenario_ref: S1
+            - row:
+                title: Row 2
+                boxes:
+                  - box:
+                      title: Output Z
+                      subtitle: with Scenario 2
+                      dataset:
+                        name: Output Z
+                        source: External
+                      scenario_ref: S2
 `
 
+    // TODO: Add support for shorthand with same dataset repeated across the row
+    // - view:
+    //     title: Calibration Scenarios (one dataset per row)
+    //     rows:
+    //       - dataset:
+    //           name: Output X
+    //         scenarios:
+    //           - scenario_ref: S0
+    //           - scenario_ref: S1
+    //       - dataset:
+    //           name: Output Y
+    //         scenarios:
+    //           - scenario_ref: S0
+    //           - scenario_ref: S1
+
     const result = parseComparisonSpecs({ kind: 'yaml', content: yaml })
-    expect(result.isOk()).toBe(true)
-    if (!result.isOk()) {
-      return
+    if (result.isErr()) {
+      throw result.error
     }
 
     const comparisonSpecs = result.value
@@ -158,16 +213,35 @@ describe('parseComparisonSpecs', () => {
     expect(comparisonSpecs.graphGroups).toEqual([graphGroupSpec('GraphGroup1', ['86', '87'])])
 
     expect(comparisonSpecs.viewGroups).toEqual([
-      viewGroupWithViewsSpec('Baseline', [viewSpec('All graphs', undefined, 'S0', graphsPresetSpec('all'))]),
+      viewGroupWithViewsSpec('Baseline', [
+        viewWithScenarioSpec('All graphs', undefined, 'S0', graphsPresetSpec('all'))
+      ]),
       viewGroupWithViewsSpec('Temp (explicit views)', [
-        viewSpec('Temp for Scenario_0', undefined, 'S0', graphsArraySpec(['86', '87'])),
-        viewSpec('Temp for Scenario_1', 'Subtitle goes here', 'S1', graphGroupRefSpec('GraphGroup1'))
+        viewWithScenarioSpec('Temp for Scenario_0', undefined, 'S0', graphsArraySpec(['86', '87'])),
+        viewWithScenarioSpec(
+          'Temp for Scenario_1 (with graph group)',
+          'Subtitle goes here',
+          'S1',
+          graphGroupRefSpec('GraphGroup1')
+        ),
+        viewWithScenarioSpec('Temp for Scenario_1 (no graphs)', 'Subtitle goes here', 'S1')
       ]),
       viewGroupWithScenariosSpec(
         'Temp (shorthand)',
         [scenarioRefSpec('S0'), scenarioRefSpec('S1'), scenarioGroupRefSpec('G1')],
         graphsArraySpec(['86', '87'])
-      )
+      ),
+      viewGroupWithViewsSpec('Calibration (explicit view with freeform rows)', [
+        viewWithRowsSpec('Calibration Scenarios (mix of datasets and scenarios per row)', undefined, [
+          viewRowSpec('Row 1', 'Subtitle goes here', [
+            viewBoxSpec('Output X', 'with Scenario 0', datasetSpec('Output X'), 'S0'),
+            viewBoxSpec('Output Y', 'with Scenario 1', datasetSpec('Output Y'), 'S1')
+          ]),
+          viewRowSpec('Row 2', undefined, [
+            viewBoxSpec('Output Z', 'with Scenario 2', datasetSpec('Output Z', 'External'), 'S2')
+          ])
+        ])
+      ])
     ])
   })
 

--- a/packages/check-core/src/comparison/config/parse/comparison.schema.js
+++ b/packages/check-core/src/comparison/config/parse/comparison.schema.js
@@ -24,6 +24,24 @@ export default {
     },
 
     //
+    // DATASETS
+    //
+
+    dataset: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: {
+          type: 'string'
+        },
+        source: {
+          type: 'string'
+        }
+      },
+      required: ['name']
+    },
+
+    //
     // SCENARIOS
     //
 
@@ -346,6 +364,10 @@ export default {
     //
 
     view: {
+      oneOf: [{ $ref: '#/$defs/view_with_scenario' }, { $ref: '#/$defs/view_with_rows' }]
+    },
+
+    view_with_scenario: {
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -365,7 +387,97 @@ export default {
           $ref: '#/$defs/view_graph_order'
         }
       },
-      required: ['scenario_ref', 'graphs']
+      required: ['scenario_ref']
+    },
+
+    view_with_rows: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: {
+          type: 'string'
+        },
+        subtitle: {
+          type: 'string'
+        },
+        rows: {
+          $ref: '#/$defs/view_rows_array'
+        }
+      },
+      required: ['title', 'rows']
+    },
+
+    view_rows_array: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/view_rows_array_item'
+      },
+      minItems: 1
+    },
+
+    view_rows_array_item: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        row: {
+          $ref: '#/$defs/view_row'
+        }
+      }
+    },
+
+    view_row: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: {
+          type: 'string'
+        },
+        subtitle: {
+          type: 'string'
+        },
+        boxes: {
+          $ref: '#/$defs/view_boxes_array'
+        }
+      },
+      required: ['title', 'boxes']
+    },
+
+    view_boxes_array: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/view_boxes_array_item'
+      },
+      minItems: 1
+    },
+
+    view_boxes_array_item: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        box: {
+          $ref: '#/$defs/view_box'
+        }
+      }
+    },
+
+    view_box: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: {
+          type: 'string'
+        },
+        subtitle: {
+          type: 'string'
+        },
+        dataset: {
+          $ref: '#/$defs/dataset'
+        },
+        scenario_ref: {
+          $ref: '#/$defs/scenario_ref_id'
+        }
+      },
+      required: ['title', 'dataset', 'scenario_ref']
     },
 
     view_graphs: {

--- a/packages/check-core/src/comparison/report/comparison-group-scores.ts
+++ b/packages/check-core/src/comparison/report/comparison-group-scores.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 Climate Interactive / New Venture Fund
+
+import { getBucketIndex } from './buckets'
+import type { ComparisonGroupScores } from './comparison-group-types'
+import type { ComparisonTestSummary } from './comparison-report-types'
+
+/**
+ * Compute the overall scores for the given group of comparison test summaries.
+ *
+ * @param testSummaries The comparison test summaries to consider.
+ * @param thresholds The array of thresholds that determine the buckets into which
+ * the scores will be summarized.
+ */
+export function getScoresForTestSummaries(
+  testSummaries: ComparisonTestSummary[],
+  thresholds: number[]
+): ComparisonGroupScores {
+  // Add up scores and group them into buckets
+  const diffCountByBucket = Array(thresholds.length + 2).fill(0)
+  const totalMaxDiffByBucket = Array(thresholds.length + 2).fill(0)
+  let totalDiffCount = 0
+  for (const testSummary of testSummaries) {
+    const bucketIndex = getBucketIndex(testSummary.md, thresholds)
+    diffCountByBucket[bucketIndex]++
+    totalMaxDiffByBucket[bucketIndex] += testSummary.md
+    totalDiffCount++
+  }
+
+  // Get the percentage of diffs for each bucket relative to the total number
+  // of comparisons in the given set
+  let diffPercentByBucket: number[]
+  if (totalDiffCount > 0) {
+    diffPercentByBucket = diffCountByBucket.map(count => (count / totalDiffCount) * 100)
+  } else {
+    diffPercentByBucket = []
+  }
+
+  return {
+    totalDiffCount,
+    totalMaxDiffByBucket,
+    diffCountByBucket,
+    diffPercentByBucket
+  }
+}

--- a/packages/check-core/src/comparison/report/comparison-group-types.ts
+++ b/packages/check-core/src/comparison/report/comparison-group-types.ts
@@ -87,6 +87,8 @@ export interface ComparisonGroupSummariesByCategory {
  * Rolls up all by-scenario and by-dataset groupings.
  */
 export interface ComparisonCategorizedResults {
+  /** All summaries for the comparison tests that were performed. */
+  allTestSummaries: ComparisonTestSummary[]
   /** The full set of by-scenario groupings. */
   byScenario: ComparisonGroupSummariesByCategory
   /** The full set of by-dataset groupings. */

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -98,6 +98,7 @@ export * from './comparison/report/comparison-report-types'
 export { comparisonSummaryFromReport } from './comparison/report/comparison-reporting'
 
 export * from './comparison/report/comparison-group-types'
+export * from './comparison/report/comparison-group-scores'
 export { categorizeComparisonTestSummaries } from './comparison/report/comparison-grouping'
 
 //

--- a/packages/check-ui-shell/src/app-vm.ts
+++ b/packages/check-ui-shell/src/app-vm.ts
@@ -191,8 +191,6 @@ export class AppViewModel {
       }
     } else {
       // Show the detail view for the given freeform view
-      // TODO: Create a separate PinnedItemState for pinned freeform rows
-      const pinnedItemState = new PinnedItemState()
       return createCompareDetailViewModelForFreeformView(
         summaryRowViewModel.key,
         this.appModel.config.comparison,
@@ -200,7 +198,7 @@ export class AppViewModel {
         this.userPrefs,
         viewGroup,
         view,
-        pinnedItemState
+        this.pinnedItemStates.pinnedFreeformRows
       )
     }
   }

--- a/packages/check-ui-shell/src/app-vm.ts
+++ b/packages/check-ui-shell/src/app-vm.ts
@@ -20,7 +20,8 @@ import type { CompareDetailViewModel } from './components/compare/detail/compare
 import {
   createCompareDetailViewModelForScenario,
   createCompareDetailViewModelForDataset,
-  createCompareDetailViewModelForFreeformView
+  createCompareDetailViewModelForFreeformView,
+  createCompareDetailViewModelForUnresolvedView
 } from './components/compare/detail/compare-detail-vm'
 import type { ComparisonSummaryRowViewModel } from './components/compare/summary/comparison-summary-row-vm'
 import type { ComparisonSummaryViewModel } from './components/compare/summary/comparison-summary-vm'
@@ -157,6 +158,10 @@ export class AppViewModel {
 
     const viewGroup = summaryRowViewModel.viewMetadata?.viewGroup
     const view = summaryRowViewModel.viewMetadata?.view
+
+    if (view?.kind === 'unresolved-view') {
+      return createCompareDetailViewModelForUnresolvedView(summaryRowViewModel.key, viewGroup, view)
+    }
 
     if (groupSummary !== undefined) {
       if (groupSummary.group.kind === 'by-dataset') {

--- a/packages/check-ui-shell/src/app-vm.ts
+++ b/packages/check-ui-shell/src/app-vm.ts
@@ -14,7 +14,7 @@ import type { UserPrefs } from './_shared/user-prefs'
 import type { AppModel } from './model/app-model'
 
 import type { ComparisonGroupingKind } from './components/compare/_shared/comparison-grouping-kind'
-import { PinnedItemState, type PinnedItemStates } from './components/compare/_shared/pinned-item-state'
+import { type PinnedItemStates } from './components/compare/_shared/pinned-item-state'
 import { createPinnedItemStates } from './components/compare/_shared/pinned-item-state'
 import type { CompareDetailViewModel } from './components/compare/detail/compare-detail-vm'
 import {

--- a/packages/check-ui-shell/src/components/_shared/lazy.svelte
+++ b/packages/check-ui-shell/src/components/_shared/lazy.svelte
@@ -10,6 +10,14 @@ export let visible = false
 let container: HTMLElement
 
 onMount(() => {
+  // XXX: It appears that `rootMargin` does not work if `root` is null
+  // (see https://stackoverflow.com/a/58625634) so we will use the scroll
+  // container as the root
+  const rootContainer = container.closest('.scroll-container')
+  if (rootContainer === undefined) {
+    throw new Error(`Lazy component requires an ancestor marked with the 'scroll-container' class`)
+  }
+
   // Wait for the container to become visible before loading the child component
   let observer = new IntersectionObserver(entries => {
     const intersecting = entries[0].isIntersecting
@@ -21,8 +29,18 @@ onMount(() => {
       visible = false
     }
   }, {
-    // Use the browser viewport for visibility checking
-    root: null
+    // Use the scroll container for visibility checking
+    root: rootContainer,
+    // XXX: For now, increase the size of the root bounds so that items are loaded
+    // before they become fully visible.  We use 200% for the right/bottom margins
+    // so that up to two "viewports" worth of items are loaded before scrolling
+    // down or to the right, and we use 100% for the others so that up to one
+    // "viewport" is loaded before scrolling up or to the left.  This means that
+    // we potentially keep more items in memory than strictly necessary, which
+    // may have memory pressure implications, but it is much more efficient than
+    // not using the lazy component at all, and provides a better UX (less flashing)
+    // compared to the default `rootMargin`.
+    rootMargin: '100% 200% 200% 100%'
   })
   observer.observe(container)
 

--- a/packages/check-ui-shell/src/components/compare/_shared/pinned-item-state.ts
+++ b/packages/check-ui-shell/src/components/compare/_shared/pinned-item-state.ts
@@ -7,6 +7,7 @@ export type PinnedItemKey = string
 export interface PinnedItemStates {
   pinnedDatasets: PinnedItemState
   pinnedScenarios: PinnedItemState
+  pinnedFreeformRows: PinnedItemState
 }
 
 export class PinnedItemState {
@@ -102,6 +103,7 @@ function validateKey(key: PinnedItemKey): void {
 export function createPinnedItemStates(): PinnedItemStates {
   return {
     pinnedDatasets: new PinnedItemState(),
-    pinnedScenarios: new PinnedItemState()
+    pinnedScenarios: new PinnedItemState(),
+    pinnedFreeformRows: new PinnedItemState()
   }
 }

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box-vm.ts
@@ -62,7 +62,7 @@ export class CompareDetailBoxViewModel {
     public readonly subtitle: string | undefined,
     public readonly scenario: ComparisonScenario,
     public readonly datasetKey: DatasetKey,
-    public readonly pinnedItemKey: PinnedItemKey
+    public readonly pinnedItemKey: PinnedItemKey | undefined
   ) {
     this.requestKey = `detail-box::${requestId++}::${scenario.key}::${datasetKey}`
 

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box-vm.ts
@@ -36,6 +36,8 @@ export interface CompareDetailBoxContent {
   comparisonGraphViewModel: ComparisonGraphViewModel
 }
 
+export type CompareDetailBoxKind = 'scenario' | 'dataset' | 'freeform'
+
 export interface AxisRange {
   min: number
   max: number
@@ -58,6 +60,7 @@ export class CompareDetailBoxViewModel {
   constructor(
     public readonly comparisonConfig: ComparisonConfig,
     public readonly dataCoordinator: ComparisonDataCoordinator,
+    public readonly kind: CompareDetailBoxKind,
     public readonly title: string,
     public readonly subtitle: string | undefined,
     public readonly scenario: ComparisonScenario,

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
@@ -38,6 +38,12 @@ function onTitleClicked() {
 }
 
 function onContextMenu(e: Event) {
+  // If the box cannot be pinned (as is the case for boxes in freeform rows),
+  // don't show a context menu for now
+  if (viewModel.pinnedItemKey === undefined) {
+    return
+  }
+
   dispatch('show-context-menu', {
     kind: 'box',
     itemKey: viewModel.pinnedItemKey,

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
@@ -40,7 +40,7 @@ function onTitleClicked() {
 function onContextMenu(e: Event) {
   // If the box cannot be pinned (as is the case for boxes in freeform rows),
   // don't show a context menu for now
-  if (viewModel.pinnedItemKey === undefined) {
+  if (viewModel.kind === 'freeform') {
     return
   }
 

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
+import assertNever from 'assert-never'
+
 import { derived, type Readable } from 'svelte/store'
 
 import type {
@@ -17,7 +19,6 @@ import type { PinnedItemKey } from '../_shared/pinned-item-state'
 
 import { CompareDetailBoxViewModel, type AxisRange } from './compare-detail-box-vm'
 import type { ComparisonDetailItem } from './compare-detail-item'
-import assertNever from 'assert-never'
 
 export interface CompareDetailContextGraphRowViewModel {
   graphL: ContextGraphViewModel

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-row-vm.ts
@@ -17,7 +17,7 @@ import { ContextGraphViewModel } from '../../graphs/context-graph-vm'
 
 import type { PinnedItemKey } from '../_shared/pinned-item-state'
 
-import { CompareDetailBoxViewModel, type AxisRange } from './compare-detail-box-vm'
+import { CompareDetailBoxViewModel, type AxisRange, type CompareDetailBoxKind } from './compare-detail-box-vm'
 import type { ComparisonDetailItem } from './compare-detail-item'
 
 export interface CompareDetailContextGraphRowViewModel {
@@ -74,19 +74,24 @@ export function createCompareDetailRowViewModel(
         assertNever(kind)
     }
 
-    // Determine which key to use as the pinned item key.  Currently,
-    // individual boxes in a freeform row cannot be pinned, so we use
-    // undefined in that case.
+    // Determine which key to use as the pinned item key
+    let boxKind: CompareDetailBoxKind
     let pinnedItemKey: PinnedItemKey
     switch (kind) {
       case 'scenarios':
+        boxKind = 'scenario'
         pinnedItemKey = item.scenario.key
         break
       case 'datasets':
+        boxKind = 'dataset'
         pinnedItemKey = item.testSummary.d
         break
       case 'freeform':
-        pinnedItemKey = undefined
+        // Note that boxes in freeform rows can't currently be pinned (because there's
+        // not as much of a use case for this, so we only create the `pinnedItemKey`
+        // here for the purposes of building a `pinnedItemKey` for the whole row)
+        boxKind = 'freeform'
+        pinnedItemKey = `${item.scenario.key}::${item.testSummary.d}`
         break
       default:
         assertNever(kind)
@@ -96,6 +101,7 @@ export function createCompareDetailRowViewModel(
       new CompareDetailBoxViewModel(
         comparisonConfig,
         dataCoordinator,
+        boxKind,
         boxTitle,
         boxSubtitle,
         item.scenario,

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
@@ -407,6 +407,11 @@ function createCompareGraphsSectionViewModels(
   view: ComparisonView,
   testSummaries: ComparisonTestSummary[]
 ): CompareGraphsSectionViewModel[] {
+  // XXX
+  if (view.rows !== undefined) {
+    throw new Error('View with freeform rows not yet supported')
+  }
+
   // No sections when there are no graphs
   if (view.graphIds.length === 0) {
     return []

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
@@ -2,7 +2,7 @@
 
 import assertNever from 'assert-never'
 
-import { derived, type Readable } from 'svelte/store'
+import { derived, writable, type Readable } from 'svelte/store'
 
 import type {
   ComparisonConfig,
@@ -13,6 +13,7 @@ import type {
   ComparisonScenario,
   ComparisonScenarioKey,
   ComparisonTestSummary,
+  ComparisonUnresolvedView,
   ComparisonView,
   ComparisonViewGroup,
   DatasetKey,
@@ -77,6 +78,27 @@ export interface CompareDetailViewModel {
   pinnedDetailRows: Readable<CompareDetailRowViewModel[]>
   /** The shared pinned item state for this view. */
   pinnedItemState: PinnedItemState
+}
+
+export function createCompareDetailViewModelForUnresolvedView(
+  summaryRowKey: string,
+  viewGroup: ComparisonViewGroup,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _view: ComparisonUnresolvedView
+): CompareDetailViewModel {
+  return {
+    kind: 'freeform-view',
+    summaryRowKey,
+    pretitle: viewGroup?.title,
+    title: 'Unresolved view',
+    annotations: undefined,
+    relatedListHeader: '',
+    relatedItems: [],
+    graphSections: [],
+    regularDetailRows: [],
+    pinnedDetailRows: writable([]),
+    pinnedItemState: undefined
+  }
 }
 
 export function createCompareDetailViewModelForFreeformView(

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-vm.ts
@@ -97,17 +97,17 @@ export function createCompareDetailViewModelForFreeformView(
         title: boxSpec.title,
         subtitle: boxSpec.subtitle,
         scenario: boxSpec.scenario,
-        // TODO: Find this in all test summaries
+        // XXX: For now we don't need to use the real test summary here (we can use
+        // `md: 0` since the data and comparison will be loaded/performed on demand)
         testSummary: {
           d: boxSpec.dataset.key,
           s: boxSpec.scenario.key,
-          md: 0 // TODO: Get the actual maxDiff
+          md: 0
         }
       }
       items.push(detailItem)
     }
 
-    // const items = group.items[0] !== allAtDefaultItem ? [allAtDefaultItem, ...group.items] : group.items
     const detailRow = createCompareDetailRowViewModel(
       comparisonConfig,
       dataCoordinator,
@@ -446,9 +446,11 @@ function createCompareGraphsSectionViewModels(
   view: ComparisonView,
   testSummaries: ComparisonTestSummary[]
 ): CompareGraphsSectionViewModel[] {
-  // XXX
+  // TODO: We don't yet support including user graphs in a freeform view, so treat this
+  // as an error for now.  Technically it is possible to support this, but we would need
+  // to change the schema to allow for specifying which scenario to use for each graph.
   if (view.rows !== undefined) {
-    throw new Error('View with freeform rows not yet supported')
+    throw new Error('Graphs section is not yet supported in a freeform view')
   }
 
   // No sections when there are no graphs

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
@@ -332,6 +332,7 @@ ul
 
 .scroll-content
   position: relative
+  margin-bottom: 2rem
 
 .section-title
   width: calc(100vw - 2rem)

--- a/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row-vm.ts
@@ -95,11 +95,12 @@ export function createCompareGraphsRowViewModel(
       const detailBoxViewModel = new CompareDetailBoxViewModel(
         comparisonConfig,
         dataCoordinator,
+        'freeform',
         '',
         '',
         scenario,
         datasetKey,
-        datasetKey
+        undefined
       )
 
       datasetRows.push({

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row-vm.ts
@@ -4,6 +4,7 @@ import type {
   DatasetKey,
   ComparisonScenarioKey,
   ComparisonGroupSummary,
+  ComparisonUnresolvedView,
   ComparisonView,
   ComparisonViewGroup
 } from '@sdeverywhere/check-core'
@@ -17,7 +18,7 @@ export interface ComparisonSummaryRowViewMetadata {
   /** The view group that the view belongs to. */
   viewGroup: ComparisonViewGroup
   /** The metadata for the view. */
-  view: ComparisonView
+  view: ComparisonView | ComparisonUnresolvedView
   /** The number of changed graphs, if this is an "all graphs" row. */
   changedGraphCount?: number
 }

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
@@ -145,6 +145,10 @@ export function createComparisonSummaryViewModels(
     const viewRows: ComparisonSummaryRowViewModel[] = viewGroup.views.map(view => {
       switch (view.kind) {
         case 'view': {
+          // XXX
+          if (view.rows !== undefined) {
+            throw new Error('View with freeform rows not yet supported')
+          }
           // Get the comparison test results for the scenario used in this view
           const scenario = view.scenario
           const groupSummary = groupsByScenario.allGroupSummaries.get(scenario.key)

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
@@ -249,7 +249,11 @@ export function createComparisonSummaryViewModels(
           return {
             kind: 'views',
             key: genViewKey(),
-            title: 'Unresolved view'
+            title: 'Unresolved view',
+            viewMetadata: {
+              viewGroup,
+              view
+            }
           }
         default:
           assertNever(view)

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-vm.ts
@@ -4,8 +4,14 @@ import { assertNever } from 'assert-never'
 
 import { derived, writable, type Readable } from 'svelte/store'
 
-import type { ComparisonConfig, ComparisonGroupSummary, ComparisonTestSummary } from '@sdeverywhere/check-core'
-import { categorizeComparisonTestSummaries } from '@sdeverywhere/check-core'
+import type {
+  ComparisonConfig,
+  ComparisonGroupSummary,
+  ComparisonTestSummary,
+  ComparisonView,
+  ComparisonViewGroup
+} from '@sdeverywhere/check-core'
+import { categorizeComparisonTestSummaries, getScoresForTestSummaries } from '@sdeverywhere/check-core'
 
 import { getAnnotationsForDataset, getAnnotationsForScenario } from '../_shared/annotations'
 import { hasSignificantDiffs } from '../_shared/buckets'
@@ -130,6 +136,7 @@ export function createComparisonSummaryViewModels(
 
   // Group and categorize the comparison results
   const comparisonGroups = categorizeComparisonTestSummaries(comparisonConfig, terseSummaries)
+  const allTestSummaries = comparisonGroups.allTestSummaries
   const groupsByScenario = comparisonGroups.byScenario
   const groupsByDataset = comparisonGroups.byDataset
 
@@ -139,56 +146,106 @@ export function createComparisonSummaryViewModels(
     return `view_${viewId++}`
   }
 
+  // Helper function that creates a summary row view model for a single-scenario comparison view
+  function rowForViewWithScenario(view: ComparisonView, viewGroup: ComparisonViewGroup): ComparisonSummaryRowViewModel {
+    // Get the comparison test results for the scenario used in this view
+    const scenario = view.scenario
+    const groupSummary = groupsByScenario.allGroupSummaries.get(scenario.key)
+    let diffPercentByBucket: number[]
+    let changedGraphCount: number
+    if (view.graphOrder === 'grouped-by-diffs') {
+      // Use the graph differences (instead of the dataset differences) for the purposes of computing
+      // bucket colors for the bar
+      // TODO: We should save the result of this comparison; currently we do it once here,
+      // and then again when the detail view is shown
+      const testSummaries = groupSummary.group.testSummaries
+      const grouped = getGraphsGroupedByDiffs(comparisonConfig, undefined, scenario, testSummaries, view.graphIds)
+      diffPercentByBucket = grouped.diffPercentByBucket
+      changedGraphCount = grouped.nonZeroDiffCount
+    } else {
+      // Otherwise, use the dataset differences
+      // TODO: We should only look at datasets that appear in the specified graphs, not all datasets
+      diffPercentByBucket = groupSummary.scores?.diffPercentByBucket
+    }
+    return {
+      kind: 'views',
+      key: genViewKey(),
+      title: view.title,
+      subtitle: view.subtitle,
+      diffPercentByBucket,
+      groupSummary,
+      viewMetadata: {
+        viewGroup,
+        view,
+        changedGraphCount
+      }
+    }
+  }
+
+  // Helper function that creates a summary row view model for a comparison view with freeform rows
+  function rowForViewWithFreeformRows(
+    view: ComparisonView,
+    viewGroup: ComparisonViewGroup
+  ): ComparisonSummaryRowViewModel {
+    // Get the comparison test results for the boxes used in this view
+    const testSummariesForView: ComparisonTestSummary[] = []
+    for (const row of view.rows) {
+      for (const box of row.boxes) {
+        // TODO: For now we assume that we only show boxes that have a fully resolved dataset/scenario
+        // pairing.  If we change that assumption, this code may need to change to only include the
+        // results where both sides are valid/resolved.
+        const testSummary = allTestSummaries.find(s => s.d === box.dataset.key && s.s === box.scenario.key)
+        if (testSummary) {
+          testSummariesForView.push(testSummary)
+        }
+      }
+    }
+
+    // Determine the number of differences per bucket
+    const scoresForView = getScoresForTestSummaries(testSummariesForView, comparisonConfig.thresholds)
+    const diffPercentByBucket = scoresForView.diffPercentByBucket
+
+    return {
+      kind: 'views',
+      key: genViewKey(),
+      title: view.title,
+      subtitle: view.subtitle,
+      diffPercentByBucket,
+      viewMetadata: {
+        viewGroup,
+        view
+      }
+    }
+  }
+
+  // Create summary row view models for each comparison view
   let viewRowsWithDiffs = 0
   const viewGroupSections: ComparisonSummarySectionViewModel[] = []
   for (const viewGroup of comparisonConfig.viewGroups) {
+    const headerRow: ComparisonSummaryRowViewModel = {
+      kind: 'views',
+      title: viewGroup.title,
+      header: true
+    }
     const viewRows: ComparisonSummaryRowViewModel[] = viewGroup.views.map(view => {
       switch (view.kind) {
         case 'view': {
-          // XXX
-          if (view.rows !== undefined) {
-            throw new Error('View with freeform rows not yet supported')
-          }
-          // Get the comparison test results for the scenario used in this view
-          const scenario = view.scenario
-          const groupSummary = groupsByScenario.allGroupSummaries.get(scenario.key)
-          let diffPercentByBucket: number[]
-          let changedGraphCount: number
-          if (view.graphOrder === 'grouped-by-diffs') {
-            // Use the graph differences (instead of the dataset differences) for the purposes of computing
-            // bucket colors for the bar
-            // TODO: We should save the result of this comparison; currently we do it once here,
-            // and then again when the detail view is shown
-            const testSummaries = groupSummary.group.testSummaries
-            const grouped = getGraphsGroupedByDiffs(comparisonConfig, undefined, scenario, testSummaries, view.graphIds)
-            diffPercentByBucket = grouped.diffPercentByBucket
-            changedGraphCount = grouped.nonZeroDiffCount
+          let summaryRow: ComparisonSummaryRowViewModel
+          if (view.scenario) {
+            summaryRow = rowForViewWithScenario(view, viewGroup)
           } else {
-            // Otherwise, use the dataset differences
-            // TODO: We should only look at datasets that appear in the specified graphs, not all datasets
-            diffPercentByBucket = groupSummary.scores?.diffPercentByBucket
+            summaryRow = rowForViewWithFreeformRows(view, viewGroup)
           }
-          if (hasSignificantDiffs(diffPercentByBucket)) {
+          if (hasSignificantDiffs(summaryRow.diffPercentByBucket)) {
             // If the scenario has issues or has non-zero differences, treat it as a row with diffs
             viewRowsWithDiffs++
           }
-          return {
-            kind: 'views',
-            key: genViewKey(),
-            title: view.title,
-            subtitle: view.subtitle,
-            diffPercentByBucket,
-            groupSummary,
-            viewMetadata: {
-              viewGroup,
-              view,
-              changedGraphCount
-            }
-          }
+          return summaryRow
         }
         case 'unresolved-view':
-          // TODO: Show proper error message here
+          // If the view is unresolved, treat it as a row with diffs
           viewRowsWithDiffs++
+          // TODO: Show proper error message here
           return {
             kind: 'views',
             key: genViewKey(),
@@ -198,13 +255,6 @@ export function createComparisonSummaryViewModels(
           assertNever(view)
       }
     })
-
-    const headerRow: ComparisonSummaryRowViewModel = {
-      kind: 'views',
-      title: viewGroup.title,
-      header: true
-    }
-
     viewGroupSections.push({
       header: headerRow,
       rows: viewRows

--- a/packages/check-ui-shell/src/components/summary/summary-vm.ts
+++ b/packages/check-ui-shell/src/components/summary/summary-vm.ts
@@ -108,7 +108,8 @@ export function createSummaryViewModel(
         // TODO: We may end up counting the same graph here multiple times if there are multiple
         // views that use "grouped-by-diffs" mode and display the same subset of graphs in each.
         // Ideally we would get the number of unique graphs with changes here instead.
-        if (row.viewMetadata?.view.graphOrder === 'grouped-by-diffs') {
+        const view = row.viewMetadata?.view
+        if (view?.kind === 'view' && view.graphOrder === 'grouped-by-diffs') {
           changedGraphCount += row?.viewMetadata?.changedGraphCount || 0
         }
       }


### PR DESCRIPTION
Fixes #552 

This adds support for "free-form" comparison views that contain arbitrary rows that can have a mix of different dataset and scenario combinations.  No impact on existing model-check configurations.  See issue for more details.
