### PR TITLE
fix: skip questions in create script if config and/or emsdk directories exist

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@sdeverywhere/compile": "^0.7.20",
     "execa": "^6.1.0",
+    "find-up": "^6.3.0",
     "fs-extra": "^10.1.0",
     "giget": "^1.2.3",
     "kleur": "^4.1.5",

--- a/packages/create/src/step-emsdk.ts
+++ b/packages/create/src/step-emsdk.ts
@@ -4,6 +4,7 @@ import { existsSync, rmSync } from 'fs'
 import { join as joinPath, resolve as resolvePath } from 'path'
 
 import { execa } from 'execa'
+import { findUp } from 'find-up'
 import { bold, cyan, dim, green, red } from 'kleur/colors'
 import ora from 'ora'
 import prompts from 'prompts'
@@ -14,7 +15,16 @@ import type { Arguments } from 'yargs-parser'
 const version = '2.0.34'
 
 export async function chooseInstallEmsdk(projDir: string, args: Arguments): Promise<void> {
-  // TODO: Use findUp and skip this step if emsdk directory already exists
+  // Walk up the directory structure to see if there is an existing `emsdk` directory
+  const existingEmsdkDir = await findUp('emsdk', {
+    cwd: projDir,
+    type: 'directory'
+  })
+  if (existingEmsdkDir) {
+    ora().succeed('Found existing Emscripten SDK installation.')
+    ora().info(dim(`Your project will use "${cyan(existingEmsdkDir)}".`))
+    return
+  }
 
   // Prompt the user
   const underParentDir = resolvePath(projDir, '..', 'emsdk')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,9 @@ importers:
       execa:
         specifier: ^6.1.0
         version: 6.1.0
+      find-up:
+        specifier: ^6.3.0
+        version: 6.3.0
       fs-extra:
         specifier: ^10.1.0
         version: 10.1.0


### PR DESCRIPTION
Fixes #335 

These are simple changes to the `create` package script that streamline the process (and avoid confusion) in the case where there are pre-existing directories, like when using the `sir` example model.
