### PR TITLE
fix: set input to correct value for at-max setting

### DIFF
--- a/packages/plugin-check/template-bundle/src/inputs.ts
+++ b/packages/plugin-check/template-bundle/src/inputs.ts
@@ -81,7 +81,7 @@ export function setInputsForScenario(inputs: Map<InputVarId, Input>, scenario: S
     input.value.set(input.minValue)
   }
   function setInputToMaximum(input: Input): void {
-    input.value.set(input.minValue)
+    input.value.set(input.maxValue)
   }
 
   function setAllToDefault(): void {


### PR DESCRIPTION
Fixes #570 

Small fix to correct typo that affects the default model-check bundle template.
