### PR TITLE
fix: show full stack trace when build or test command fails

### DIFF
--- a/packages/cli/src/sde-build.js
+++ b/packages/cli/src/sde-build.js
@@ -43,7 +43,8 @@ export let build = async (model, opts) => {
     }
   } catch (e) {
     // Exit with a non-zero error code if any step failed
-    console.error(`ERROR: ${e.message}\n`)
+    console.error(e)
+    console.error()
     process.exit(1)
   }
 }

--- a/packages/cli/src/sde-test.js
+++ b/packages/cli/src/sde-test.js
@@ -66,7 +66,8 @@ export let test = async (model, opts) => {
     }
   } catch (e) {
     // Exit with a non-zero error code if any step failed
-    console.error(`ERROR: ${e.message}\n`)
+    console.error(e)
+    console.error()
     process.exit(1)
   }
 }


### PR DESCRIPTION
Fixes #579 

Simple change to the error handlers for `sde build` and `sde test` to match the error handlers in the other `sde` commands.
