### PR TITLE
fix: restore alphabetical sorting for `sde generate --preprocess` command

### DIFF
--- a/models/comments/expected.mdl
+++ b/models/comments/expected.mdl
@@ -1,7 +1,5 @@
 {UTF-8}
 
-DimA: A1, A2, A3 ~~|
-
 a[DimA]= 0, 1, 2 ~~|
 
 b = 3 ~~|
@@ -10,11 +8,13 @@ c = 4 ~~|
 
 d= 8760 ~~|
 
+DimA: A1, A2, A3 ~~|
+
 e = 41 + 1 ~~|
 
-INITIAL TIME = 0 ~~|
-
 FINAL TIME = 1 ~~|
+
+INITIAL TIME = 0 ~~|
 
 SAVEPER = 1 ~~|
 

--- a/models/preprocess/expected.mdl
+++ b/models/preprocess/expected.mdl
@@ -1,42 +1,42 @@
 {UTF-8}
 
-" quotes 2 with extra whitespace " = 1 ~~|
-
-"Quotes 1" = 1 ~~|
-
-"quotes 3 with | pipe character " = 2 ~~|
-
-apple 3 = 1 ~~|
-
-Carrot 3 Data 2 ~~|
-
-banana 3 = Banana 1 * Banana 2 ~~|
-
-carrot 3 Data 1 ~~|
-
-carrot 2 = 1 ~~|
-
-Look2((0,0),(1,1),(2,2)) ~~|
-
-Look1((0,0),(1,1),(2,2)) ~~|
+Apple 1 = 1 ~~|
 
 Apple 2 = 1 ~~|
 
-carrot 1 = 1 ~~|
-
-Banana 2 = 1 ~~|
+apple 3 = 1 ~~|
 
 Banana 1 = 1 ~~|
 
-Apple 1 = 1 ~~|
+Banana 2 = 1 ~~|
 
-dimB: B1, B2 ~~|
+banana 3 = Banana 1 * Banana 2 ~~|
+
+carrot 1 = 1 ~~|
+
+carrot 2 = 1 ~~|
+
+carrot 3 Data 1 ~~|
+
+Carrot 3 Data 2 ~~|
 
 DimA: A1, A2 ~~|
+
+dimB: B1, B2 ~~|
 
 FINAL TIME = 10 ~~|
 
 INITIAL TIME = 0 ~~|
+
+Look1((0,0),(1,1),(2,2)) ~~|
+
+Look2((0,0),(1,1),(2,2)) ~~|
+
+"Quotes 1" = 1 ~~|
+
+" quotes 2 with extra whitespace " = 1 ~~|
+
+"quotes 3 with | pipe character " = 2 ~~|
 
 SAVEPER = TIME STEP ~~|
 

--- a/packages/cli/src/sde-generate.js
+++ b/packages/cli/src/sde-generate.js
@@ -108,6 +108,13 @@ function preprocessModel(mdlContent) {
   // Run the preprocessor
   const { defs } = preprocessVensimModel(mdlContent)
 
+  // Sort the definitions alphabetically by key.  This mainly exists for compatibility
+  // with the legacy `sde generate --preprocess` command, which was changed in #55 to
+  // sort definitions alphabetically.
+  defs.sort((a, b) => {
+    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0
+  })
+
   // Join the preprocessed definitions into a single string
   let text = '{UTF-8}\n'
   for (const def of defs) {

--- a/packages/compile/src/parse-and-generate.js
+++ b/packages/compile/src/parse-and-generate.js
@@ -157,11 +157,6 @@ export function parseModel(input, modelDir, options) {
   }
 
   // Parse the model
-  // TODO: The `parseVensimModel` function implicitly runs the preprocess step
-  // on the input text.  We currently allow for setting the `sort` flag only
-  // for use in tests that assume the behavior of the legacy preprocessor
-  // (because it sorted alphabetically).  Once we update those tests, we can
-  // remove this option.
   const sort = options?.sort === true
   const root = parseVensimModel(input, parseContext, sort)
 

--- a/packages/parse/src/vensim/parse-vensim-model.ts
+++ b/packages/parse/src/vensim/parse-vensim-model.ts
@@ -22,8 +22,9 @@ export function parseVensimModel(input: string, context?: VensimParseContext, so
   // sections, etc) so that it can be parsed more easily by `antlr4-vensim`.
   const { defs } = preprocessVensimModel(input)
   if (sort) {
-    // XXX: This sorting is currently only needed for compatibility with the legacy
-    // preprocessor, which sorted definitions alphabetically.  Can consider removing this.
+    // Sort the definitions alphabetically by key.  This mainly exists for compatibility
+    // with the legacy preprocessor; it is not an essential step so is left disabled
+    // by default.
     defs.sort((a, b) => {
       return a.key < b.key ? -1 : a.key > b.key ? 1 : 0
     })


### PR DESCRIPTION
Fixes #586 

This restores the alphabetical sorting that we had before for the `sde generate --preprocess` command.  The default/implicit use of the preprocessor prior to parsing is unaffected.
