### PR TITLE
fix: allow for resetting a lookup at runtime back to its original data

### DIFF
--- a/packages/compile/src/generate/gen-code-c.spec.ts
+++ b/packages/compile/src/generate/gen-code-c.spec.ts
@@ -151,6 +151,9 @@ bool data_initialized = false;
 
 void initLookups0() {
   __lookup1 = __new_lookup(6, /*copy=*/false, __lookup1_data_);
+  for (size_t i = 0; i < 2; i++) {
+  _d_game_inputs[i] = __new_lookup(0, /*copy=*/false, NULL);
+  }
 }
 
 void initLookups() {
@@ -264,36 +267,31 @@ void setInputsFromBuffer(double* inputData) {
   _input = inputData[0];
 }
 
-void replaceLookup(Lookup** lookup, double* points, size_t numPoints) {
-  if (lookup == NULL) {
-    return;
-  }
-  if (*lookup != NULL) {
-    __delete_lookup(*lookup);
-    *lookup = NULL;
-  }
-  if (points != NULL) {
-    *lookup = __new_lookup(numPoints, /*copy=*/true, points);
-  }
-}
-
 void setLookup(size_t varIndex, size_t* subIndices, double* points, size_t numPoints) {
+  Lookup** pLookup = NULL;
   switch (varIndex) {
     case 6:
-      replaceLookup(&_d_game_inputs[subIndices[0]], points, numPoints);
+      pLookup = &_d_game_inputs[subIndices[0]];
       break;
     case 7:
-      replaceLookup(&_a_data[subIndices[0]], points, numPoints);
+      pLookup = &_a_data[subIndices[0]];
       break;
     case 8:
-      replaceLookup(&_b_data[subIndices[0]][subIndices[1]], points, numPoints);
+      pLookup = &_b_data[subIndices[0]][subIndices[1]];
       break;
     case 9:
-      replaceLookup(&_c_data, points, numPoints);
+      pLookup = &_c_data;
       break;
     default:
       fprintf(stderr, "No lookup found for var index %zu in setLookup\\n", varIndex);
       break;
+  }
+  if (pLookup != NULL) {
+    if (*pLookup == NULL) {
+      *pLookup = __new_lookup(numPoints, /*copy=*/true, points);
+    } else {
+      __set_lookup(*pLookup, numPoints, points);
+    }
   }
 }
 
@@ -418,16 +416,24 @@ void setLookup(size_t varIndex, size_t* subIndices, double* points, size_t numPo
     })
     expect(code).toMatch(`\
 void setLookup(size_t varIndex, size_t* subIndices, double* points, size_t numPoints) {
+  Lookup** pLookup = NULL;
   switch (varIndex) {
     case 6:
-      replaceLookup(&_q_data, points, numPoints);
+      pLookup = &_q_data;
       break;
     case 7:
-      replaceLookup(&_y_data[subIndices[0]], points, numPoints);
+      pLookup = &_y_data[subIndices[0]];
       break;
     default:
       fprintf(stderr, "No lookup found for var index %zu in setLookup\\n", varIndex);
       break;
+  }
+  if (pLookup != NULL) {
+    if (*pLookup == NULL) {
+      *pLookup = __new_lookup(numPoints, /*copy=*/true, points);
+    } else {
+      __set_lookup(*pLookup, numPoints, points);
+    }
   }
 }`)
   })

--- a/packages/compile/src/generate/gen-code-js.js
+++ b/packages/compile/src/generate/gen-code-js.js
@@ -251,10 +251,15 @@ ${chunkedFunctions('evalLevels', true, Model.levelVars(), '  // Evaluate levels'
   }
   const varIndex = varSpec.varIndex;
   const subs = varSpec.subscriptIndices;
+  let lookup;
   switch (varIndex) {
 ${setLookupImpl(Model.varIndexInfo(), spec.customLookups)}
     default:
       throw new Error(\`No lookup found for var index \${varIndex} in setLookup\`);
+  }
+  if (lookup) {
+    const size = points ? points.length / 2 : 0;
+    lookup.setData(size, points);
   }`
     } else {
       let msg = 'The setLookup function was not enabled for the generated model. '
@@ -307,7 +312,7 @@ ${customOutputSection(Model.varIndexInfo(), spec.customOutputs)}
     return `\
 /*export*/ function setInputs(valueAtIndex /*: (index: number) => number*/) {${inputsFromBufferImpl()}}
 
-/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array*/) {
+/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array | undefined*/) {
 ${setLookupBody}
 }
 
@@ -517,7 +522,7 @@ ${section(chunk)}
     return inputVars
   }
   function setLookupImpl(varIndexInfo, customLookups) {
-    // Emit `createLookup` calls for all lookups and data variables that can be overridden
+    // Emit case statements for all lookups and data variables that can be overridden
     // at runtime
     let overrideAllowed
     if (Array.isArray(customLookups)) {
@@ -543,7 +548,7 @@ ${section(chunk)}
       }
       let c = ''
       c += `    case ${info.varIndex}:\n`
-      c += `      ${lookupVar} = fns.createLookup(points.length / 2, points);\n`
+      c += `      lookup = ${lookupVar};\n`
       c += `      break;`
       return c
     })

--- a/packages/compile/src/generate/gen-code-js.spec.ts
+++ b/packages/compile/src/generate/gen-code-js.spec.ts
@@ -354,6 +354,9 @@ let data_initialized = false;
 
 function initLookups0() {
   __lookup1 = fns.createLookup(6, __lookup1_data_);
+  for (let i = 0; i < 2; i++) {
+  _d_game_inputs[i] = fns.createLookup(0, undefined);
+  }
 }
 
 function initLookups() {
@@ -446,27 +449,32 @@ function evalAux0() {
   _input = valueAtIndex(0);
 }
 
-/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array*/) {
+/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array | undefined*/) {
   if (!varSpec) {
     throw new Error('Got undefined varSpec in setLookup');
   }
   const varIndex = varSpec.varIndex;
   const subs = varSpec.subscriptIndices;
+  let lookup;
   switch (varIndex) {
     case 6:
-      _d_game_inputs[subs[0]] = fns.createLookup(points.length / 2, points);
+      lookup = _d_game_inputs[subs[0]];
       break;
     case 7:
-      _a_data[subs[0]] = fns.createLookup(points.length / 2, points);
+      lookup = _a_data[subs[0]];
       break;
     case 8:
-      _b_data[subs[0]][subs[1]] = fns.createLookup(points.length / 2, points);
+      lookup = _b_data[subs[0]][subs[1]];
       break;
     case 9:
-      _c_data = fns.createLookup(points.length / 2, points);
+      lookup = _c_data;
       break;
     default:
       throw new Error(\`No lookup found for var index \${varIndex} in setLookup\`);
+  }
+  if (lookup) {
+    const size = points ? points.length / 2 : 0;
+    lookup.setData(size, points);
   }
 }
 
@@ -725,7 +733,7 @@ export default async function () {
       bundleListing: true
     })
     expect(code).toMatch(`\
-/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array*/) {
+/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array | undefined*/) {
   throw new Error('The setLookup function was not enabled for the generated model. Set the customLookups property in the spec/config file to allow for overriding lookups at runtime.');
 }`)
   })
@@ -767,21 +775,26 @@ export default async function () {
       customLookups: ['y data[A1]', 'q data']
     })
     expect(code).toMatch(`\
-/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array*/) {
+/*export*/ function setLookup(varSpec /*: VarSpec*/, points /*: Float64Array | undefined*/) {
   if (!varSpec) {
     throw new Error('Got undefined varSpec in setLookup');
   }
   const varIndex = varSpec.varIndex;
   const subs = varSpec.subscriptIndices;
+  let lookup;
   switch (varIndex) {
     case 6:
-      _q_data = fns.createLookup(points.length / 2, points);
+      lookup = _q_data;
       break;
     case 7:
-      _y_data[subs[0]] = fns.createLookup(points.length / 2, points);
+      lookup = _y_data[subs[0]];
       break;
     default:
       throw new Error(\`No lookup found for var index \${varIndex} in setLookup\`);
+  }
+  if (lookup) {
+    const size = points ? points.length / 2 : 0;
+    lookup.setData(size, points);
   }
 }`)
   })

--- a/packages/compile/src/generate/gen-equation.js
+++ b/packages/compile/src/generate/gen-equation.js
@@ -113,13 +113,12 @@ export function generateEquation(variable, mode, extData, directData, modelDir, 
   // Apply special handling for lookup variables.  The data for lookup variables is already
   // defined as a set of explicit data points (stored in the `Variable` instance).
   if (variable.isLookup()) {
-    if (variable.varSubtype === 'gameInputs') {
-      // For a synthesized game inputs lookup, there is no data array (the data is expected
-      // to be supplied at runtime), so don't emit decl or init code for these
-      return []
+    // Emit decl/init code for the lookup
+    const lookupDef = generateLookupFromPoints(variable, mode, /*copy=*/ false, cLhs, loopIndexVars, outFormat)
+    if (lookupDef.length > 0) {
+      return [...openLoops, ...lookupDef, ...closeLoops]
     } else {
-      // For all other lookups, emit decl/init code for the lookup
-      return generateLookupFromPoints(variable, mode, /*copy=*/ false, cLhs, loopIndexVars, outFormat)
+      return []
     }
   }
 

--- a/packages/compile/src/generate/gen-lookup-from-points.js
+++ b/packages/compile/src/generate/gen-lookup-from-points.js
@@ -16,10 +16,23 @@ import { isDimension, isTrivialDimension, sub } from '../_shared/subscript.js'
  */
 export function generateLookupFromPoints(variable, mode, copy, varLhs, loopIndexVars, outFormat) {
   if (variable.points.length === 0) {
-    throw new Error(`Empty lookup data array for ${variable.modelLHS}`)
-  }
-
-  if (copy) {
+    // In the case where the lookup data array is empty (typically this only occurs in the
+    // case of game inputs), generate a new empty lookup
+    if (mode === 'decl') {
+      // Nothing to emit in decl mode
+      return []
+    } else if (mode === 'init-lookups') {
+      // In init mode, generate a new empty lookup
+      switch (outFormat) {
+        case 'c':
+          return [`  ${varLhs} = __new_lookup(0, /*copy=*/false, NULL);`]
+        case 'js':
+          return [`  ${varLhs} = fns.createLookup(0, undefined);`]
+        default:
+          throw new Error(`Unhandled output format '${outFormat}'`)
+      }
+    }
+  } else if (copy) {
     // Inline the data points and copy them when initializing the lookup
     if (mode === 'decl') {
       // Nothing to emit in decl mode

--- a/packages/runtime/docs/functions/createLookupDef.md
+++ b/packages/runtime/docs/functions/createLookupDef.md
@@ -11,7 +11,7 @@ Create a `LookupDef` instance from the given array of `Point` objects.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `varRef` | [`VarRef`](../interfaces/VarRef.md) | The reference to the lookup or data variable to be modified. |
-| `points` | [`Point`](../interfaces/Point.md)[] | The lookup data as an array of `Point` objects. |
+| `points` | [`Point`](../interfaces/Point.md)[] | The lookup data as an array of `Point` objects. This can be undefined, in which case the lookup data will be reset to the original data. |
 
 #### Returns
 

--- a/packages/runtime/docs/interfaces/LookupDef.md
+++ b/packages/runtime/docs/interfaces/LookupDef.md
@@ -16,6 +16,6 @@ ___
 
 ### points
 
- **points**: `Float64Array`
+ `Optional` **points**: `Float64Array`
 
 The lookup data as a flat array of (x,y) pairs.

--- a/packages/runtime/src/_shared/lookup-def.ts
+++ b/packages/runtime/src/_shared/lookup-def.ts
@@ -10,21 +10,25 @@ export interface LookupDef {
   varRef: VarRef
 
   /** The lookup data as a flat array of (x,y) pairs. */
-  points: Float64Array
+  points?: Float64Array
 }
 
 /**
  * Create a `LookupDef` instance from the given array of `Point` objects.
  *
  * @param varRef The reference to the lookup or data variable to be modified.
- * @param points The lookup data as an array of `Point` objects.
+ * @param points The lookup data as an array of `Point` objects.  This can be
+ * undefined, in which case the lookup data will be reset to the original data.
  */
-export function createLookupDef(varRef: VarRef, points: Point[]): LookupDef {
-  const flatPoints = new Float64Array(points.length * 2)
-  let i = 0
-  for (const p of points) {
-    flatPoints[i++] = p.x
-    flatPoints[i++] = p.y
+export function createLookupDef(varRef: VarRef, points: Point[] | undefined): LookupDef {
+  let flatPoints: Float64Array
+  if (points) {
+    flatPoints = new Float64Array(points.length * 2)
+    let i = 0
+    for (const p of points) {
+      flatPoints[i++] = p.x
+      flatPoints[i++] = p.y
+    }
   }
 
   return {

--- a/packages/runtime/src/_shared/var-indices.spec.ts
+++ b/packages/runtime/src/_shared/var-indices.spec.ts
@@ -65,26 +65,28 @@ describe('encodeVarIndices', () => {
 const p = (x: number, y: number) => ({ x, y })
 const lookupDefs: LookupDef[] = [
   createLookupDef({ varSpec: { varIndex: 1 } }, [p(0, 0), p(1, 1)]),
-  createLookupDef({ varSpec: { varIndex: 2, subscriptIndices: [1, 2] } }, [p(0, 0), p(1, 1)])
+  createLookupDef({ varSpec: { varIndex: 2, subscriptIndices: [1, 2] } }, [p(0, 0), p(1, 1)]),
+  createLookupDef({ varSpec: { varIndex: 3 } }, []),
+  createLookupDef({ varSpec: { varIndex: 4 } }, undefined)
 ]
 
 describe('getEncodedLookupBufferLengths', () => {
   it('should return the correct length', () => {
     const { lookupIndicesLength, lookupsLength } = getEncodedLookupBufferLengths(lookupDefs)
-    expect(lookupIndicesLength).toBe(11)
+    expect(lookupIndicesLength).toBe(19)
     expect(lookupsLength).toBe(8)
   })
 })
 
 describe('encodeLookups and decodeLookups', () => {
   it('should encode and decode the correct values', () => {
-    const lookupIndices = new Int32Array(13)
+    const lookupIndices = new Int32Array(21)
     const lookupValues = new Float64Array(10)
     encodeLookups(lookupDefs, lookupIndices, lookupValues)
 
     expect(lookupIndices).toEqual(
       new Int32Array([
-        2, // variable count
+        4, // variable count
 
         1, // var0 index
         0, // var0 subscript count
@@ -97,6 +99,16 @@ describe('encodeLookups and decodeLookups', () => {
         2, // var1 sub1 index
         4, // var1 data offset
         4, // var1 data length
+
+        3, // var2 index
+        0, // var2 subscript count
+        8, // var2 data offset
+        0, // var2 data length
+
+        4, // var3 index
+        0, // var3 subscript count
+        -1, // var3 data offset
+        0, // var3 data length
 
         // zero padding
         0,

--- a/packages/runtime/src/js-model/_mocks/mock-js-model.ts
+++ b/packages/runtime/src/js-model/_mocks/mock-js-model.ts
@@ -110,12 +110,13 @@ export class MockJsModel implements JsModel {
   }
 
   // from JsModel interface
-  setLookup(varSpec: VarSpec, points: Float64Array): void {
+  setLookup(varSpec: VarSpec, points: Float64Array | undefined): void {
     const varId = this.varIdForSpec(varSpec)
     if (varId === undefined) {
       throw new Error(`No lookup variable found for spec ${varSpec}`)
     }
-    this.lookups.set(varId, new JsModelLookup(points.length / 2, points))
+    const numPoints = points ? points.length / 2 : 0
+    this.lookups.set(varId, new JsModelLookup(numPoints, points))
   }
 
   // from JsModel interface

--- a/packages/runtime/src/js-model/js-model-functions.spec.ts
+++ b/packages/runtime/src/js-model/js-model-functions.spec.ts
@@ -48,8 +48,12 @@ describe('JsModelFunctions', () => {
   })
 
   it('should expose GAME', () => {
-    // Verify that it returns the `x` value when `inputs` is undefined
+    // Verify that it returns the `x` value when `inputs` lookup is undefined
     expect(fns.GAME(undefined, 10)).toBe(10)
+
+    // Verify that it returns the `x` value when `inputs` data is undefined
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.GAME(lookupWithUndefinedData, 10)).toBe(10)
 
     // Verify that it returns the `x` value when `inputs` is empty
     const empty = fns.createLookup(0, [])
@@ -231,12 +235,16 @@ describe('JsModelFunctions', () => {
     expect(fns.LOOKUP(lookup, 3)).toBe(6)
     expect(fns.LOOKUP(lookup, 4)).toBe(6)
 
+    // Verify that it returns _NA_ for an undefined lookup
+    expect(fns.LOOKUP(undefined, 0)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.LOOKUP(lookupWithUndefinedData, 0)).toBe(_NA_)
+
     // Verify that it returns _NA_ for an empty lookup
     const empty = fns.createLookup(0, [])
     expect(fns.LOOKUP(empty, 0)).toBe(_NA_)
-
-    // Verify that it returns _NA_ for an undefined lookup
-    expect(fns.LOOKUP(undefined, 0)).toBe(_NA_)
   })
 
   it('should expose LOOKUP_FORWARD', () => {
@@ -248,12 +256,16 @@ describe('JsModelFunctions', () => {
     expect(fns.LOOKUP_FORWARD(lookup, 3)).toBe(6)
     expect(fns.LOOKUP_FORWARD(lookup, 4)).toBe(6)
 
+    // Verify that it returns _NA_ for an undefined lookup
+    expect(fns.LOOKUP_FORWARD(undefined, 0)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.LOOKUP_FORWARD(lookupWithUndefinedData, 0)).toBe(_NA_)
+
     // Verify that it returns _NA_ for an empty lookup
     const empty = fns.createLookup(0, [])
     expect(fns.LOOKUP_FORWARD(empty, 0)).toBe(_NA_)
-
-    // Verify that it returns _NA_ for an undefined lookup
-    expect(fns.LOOKUP_FORWARD(undefined, 0)).toBe(_NA_)
   })
 
   it('should expose LOOKUP_BACKWARD', () => {
@@ -265,12 +277,16 @@ describe('JsModelFunctions', () => {
     expect(fns.LOOKUP_BACKWARD(lookup, 3)).toBe(6)
     expect(fns.LOOKUP_BACKWARD(lookup, 4)).toBe(6)
 
+    // Verify that it returns _NA_ for an undefined lookup
+    expect(fns.LOOKUP_BACKWARD(undefined, 0)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.LOOKUP_BACKWARD(lookupWithUndefinedData, 0)).toBe(_NA_)
+
     // Verify that it returns _NA_ for an empty lookup
     const empty = fns.createLookup(0, [])
     expect(fns.LOOKUP_BACKWARD(empty, 0)).toBe(_NA_)
-
-    // Verify that it returns _NA_ for an undefined lookup
-    expect(fns.LOOKUP_BACKWARD(undefined, 0)).toBe(_NA_)
   })
 
   it('should expose LOOKUP_INVERT', () => {
@@ -285,12 +301,16 @@ describe('JsModelFunctions', () => {
     expect(fns.LOOKUP_INVERT(lookup, 6)).toBe(3)
     expect(fns.LOOKUP_INVERT(lookup, 7)).toBe(3)
 
-    // Verify that it returns _NA_ for an empty lookup
-    const empty = fns.createLookup(0, [])
-    expect(fns.LOOKUP_INVERT(empty, 0)).toBe(_NA_)
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.LOOKUP_INVERT(lookupWithUndefinedData, 0)).toBe(_NA_)
 
     // Verify that it returns _NA_ for an undefined lookup
     expect(fns.LOOKUP_INVERT(undefined, 0)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for an empty lookup
+    const empty = fns.createLookup(0, [])
+    expect(fns.LOOKUP_INVERT(empty, 0)).toBe(_NA_)
   })
 
   it('should expose WITH_LOOKUP', () => {
@@ -301,12 +321,16 @@ describe('JsModelFunctions', () => {
     expect(fns.WITH_LOOKUP(3, lookup)).toBe(6)
     expect(fns.WITH_LOOKUP(4, lookup)).toBe(6)
 
+    // Verify that it returns _NA_ for an undefined lookup
+    expect(fns.WITH_LOOKUP(0, undefined)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.WITH_LOOKUP(0, lookupWithUndefinedData)).toBe(_NA_)
+
     // Verify that it returns _NA_ for an empty lookup
     const empty = fns.createLookup(0, [])
     expect(fns.WITH_LOOKUP(0, empty)).toBe(_NA_)
-
-    // Verify that it returns _NA_ for an undefined lookup
-    expect(fns.WITH_LOOKUP(0, undefined)).toBe(_NA_)
   })
 
   it('should expose GET_DATA_BETWEEN_TIMES', () => {
@@ -379,11 +403,15 @@ describe('JsModelFunctions', () => {
     expect(fns.GET_DATA_BETWEEN_TIMES(lookup, 10.5, -1)).toBe(70)
     expect(fns.GET_DATA_BETWEEN_TIMES(lookup, 11.0, -1)).toBe(70)
 
+    // Verify that it returns _NA_ for an undefined lookup
+    expect(fns.GET_DATA_BETWEEN_TIMES(undefined, 0, 0)).toBe(_NA_)
+
+    // Verify that it returns _NA_ for a lookup with undefined data
+    const lookupWithUndefinedData = fns.createLookup(0, undefined)
+    expect(fns.GET_DATA_BETWEEN_TIMES(lookupWithUndefinedData, 0, 0)).toBe(_NA_)
+
     // Verify that it returns _NA_ for an empty lookup
     const empty = fns.createLookup(0, [])
     expect(fns.GET_DATA_BETWEEN_TIMES(empty, 0, 0)).toBe(_NA_)
-
-    // Verify that it returns _NA_ for an undefined lookup
-    expect(fns.GET_DATA_BETWEEN_TIMES(undefined, 0, 0)).toBe(_NA_)
   })
 })

--- a/packages/runtime/src/js-model/js-model-lookup.spec.ts
+++ b/packages/runtime/src/js-model/js-model-lookup.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Climate Interactive / New Venture Fund
+
+import { describe, expect, it } from 'vitest'
+
+import { JsModelLookup } from './js-model-lookup'
+
+describe('JsModelLookup', () => {
+  it('should return expected data', () => {
+    // Create a lookup with initial data
+    const lookup = new JsModelLookup(3, [0, 0, 1, 1, 2, 2])
+
+    // Verify that original data is returned
+    expect(lookup.getValueForX(-1.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.5, 'interpolate')).toBe(0.5)
+    expect(lookup.getValueForX(1.0, 'interpolate')).toBe(1.0)
+    expect(lookup.getValueForX(1.5, 'interpolate')).toBe(1.5)
+    expect(lookup.getValueForX(2.0, 'interpolate')).toBe(2.0)
+    expect(lookup.getValueForX(3.0, 'interpolate')).toBe(2.0)
+
+    // Call `setData` with larger array
+    lookup.setData(2, new Float64Array([0, 0, 1, 1]))
+
+    // Verify that overridden data is returned
+    expect(lookup.getValueForX(-1.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.5, 'interpolate')).toBe(0.5)
+    expect(lookup.getValueForX(1.0, 'interpolate')).toBe(1.0)
+    expect(lookup.getValueForX(1.5, 'interpolate')).toBe(1.0)
+
+    // Call `setData` with larger array
+    lookup.setData(5, new Float64Array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4]))
+
+    // Verify that overridden data is returned
+    expect(lookup.getValueForX(-1.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.5, 'interpolate')).toBe(0.5)
+    expect(lookup.getValueForX(1.0, 'interpolate')).toBe(1.0)
+    expect(lookup.getValueForX(1.5, 'interpolate')).toBe(1.5)
+    expect(lookup.getValueForX(2.0, 'interpolate')).toBe(2.0)
+    expect(lookup.getValueForX(3.0, 'interpolate')).toBe(3.0)
+    expect(lookup.getValueForX(4.0, 'interpolate')).toBe(4.0)
+    expect(lookup.getValueForX(5.0, 'interpolate')).toBe(4.0)
+
+    // Call `setData` with undefined to reset to original data
+    lookup.setData(0, undefined)
+
+    // Verify that original data is returned
+    expect(lookup.getValueForX(-1.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.0, 'interpolate')).toBe(0.0)
+    expect(lookup.getValueForX(0.5, 'interpolate')).toBe(0.5)
+    expect(lookup.getValueForX(1.0, 'interpolate')).toBe(1.0)
+    expect(lookup.getValueForX(1.5, 'interpolate')).toBe(1.5)
+    expect(lookup.getValueForX(2.0, 'interpolate')).toBe(2.0)
+    expect(lookup.getValueForX(3.0, 'interpolate')).toBe(2.0)
+  })
+})

--- a/packages/runtime/src/js-model/js-model-lookup.ts
+++ b/packages/runtime/src/js-model/js-model-lookup.ts
@@ -8,23 +8,118 @@ export type JsModelLookupMode = 'interpolate' | 'forward' | 'backward'
  * @hidden This is not yet part of the public API; for internal use only.
  */
 export class JsModelLookup {
+  /** The original data passed to the constructor. */
+  private readonly originalData: number[] | Float64Array | undefined
+
+  /** The size (i.e., number of pairs) of the original data. */
+  private readonly originalSize: number
+
+  /**
+   * The dynamic data array.  This will be undefined initially, and the array
+   * will be allocated (or grown) by `setData`.
+   */
+  private dynamicData: Float64Array | undefined
+
+  /** The size (i.e., number of pairs) of the dynamic data. */
+  private dynamicSize: number
+
+  /**
+   * The active data array.  This will be the same as either `originalData`
+   * or `dynamicData`, depending on whether the lookup data is overridden
+   * at runtime using `setData`.
+   */
+  private activeData: number[] | Float64Array | undefined
+
+  /** The size (i.e., number of pairs) of the active data. */
+  private activeSize: number
+
+  /**
+   * The inverted version of the active data array.  This is allocated on demand
+   * only in the case of `LOOKUP INVERT` function calls.
+   */
   private invertedData?: number[]
+
+  /**
+   * The input value for the last hit.  This is cached for performance so that we
+   * can reduce the amount of linear searching in the common case where `LOOKUP`
+   * input values are monotonically increasing.
+   */
   private lastInput: number
+
+  /** The index for the last hit (see `lastInput`). */
   private lastHitIndex: number
 
   /**
-   * @param n The number of (x,y) pairs in the lookup.
+   * @param size The number of (x,y) pairs in the lookup.
    * @param data The lookup data, as (x,y) pairs.  The length of the array must be
    * >= 2*n.  Note that the data will be stored by reference, so if there is a chance
    * that the array will be reused or modified by other code, be sure to pass in a
    * copy of the array.
    */
-  constructor(private readonly n: number, private readonly data: number[] | Float64Array) {
+  constructor(size: number, data: number[] | Float64Array | undefined) {
     // Note that we reference the provided data without copying (assumed to be owned elsewhere)
-    if (data.length < n * 2) {
-      throw new Error(`Lookup data array length must be >= 2*size (length=${data.length} size=${n}`)
+    if (data && data.length < size * 2) {
+      throw new Error(`Lookup data array length must be >= 2*size (length=${data.length} size=${size}`)
     }
 
+    this.originalData = data
+    this.originalSize = size
+
+    this.dynamicData = undefined
+    this.dynamicSize = 0
+
+    this.activeData = this.originalData
+    this.activeSize = this.originalSize
+
+    this.lastInput = Number.MAX_VALUE
+    this.lastHitIndex = 0
+  }
+
+  /**
+   * Set new data for this lookup instance, or restore the original data.
+   *
+   * If `data` is undefined, the original data that was supplied to the constructor will
+   * be restored as the "active" data.  Otherwise, `data` will be copied to an internal
+   * data buffer, which will be the "active" data.  If `size` is greater than the size
+   * passed to previous calls, the internal data buffer will be grown as needed.
+   *
+   * @param size The number of (x,y) pairs in the lookup.
+   * @param data The lookup data, as (x,y) pairs.  The length of the array must be
+   * >= 2*n.  Note that the data will be copied into an internal data buffer, so it
+   * is not necessary to defensively copy data before calling this method.
+   */
+  public setData(size: number, data: Float64Array | undefined): void {
+    if (data) {
+      if (data.length < size * 2) {
+        throw new Error(`Lookup data array length must be >= 2*size (length=${data.length} size=${size}`)
+      }
+
+      // Allocate or grow the internal buffer as needed
+      const dataLengthInElems = size * 2
+      if (this.dynamicData === undefined || dataLengthInElems > this.dynamicData.length) {
+        this.dynamicData = new Float64Array(dataLengthInElems)
+      }
+
+      // Copy the given lookup data into the internally managed buffer
+      this.dynamicSize = size
+      if (size > 0) {
+        const subarray = data.subarray(0, dataLengthInElems)
+        this.dynamicData.set(subarray)
+      }
+
+      // Set the dynamic data as the "active" data
+      this.activeData = this.dynamicData
+      this.activeSize = this.dynamicSize
+    } else {
+      // Restore the original data as the "active" data
+      this.activeData = this.originalData
+      this.activeSize = this.originalSize
+    }
+
+    // Clear the cached inverted data
+    this.invertedData = undefined
+
+    // Reset the cached "last" values to the initial values
     this.lastInput = Number.MAX_VALUE
     this.lastHitIndex = 0
   }
@@ -36,8 +131,8 @@ export class JsModelLookup {
   public getValueForY(y: number): number {
     if (this.invertedData === undefined) {
       // Invert the matrix and cache it
-      const numValues = this.n * 2
-      const normalData = this.data
+      const numValues = this.activeSize * 2
+      const normalData = this.activeData
       const invertedData = Array(numValues)
       for (let i = 0; i < numValues; i += 2) {
         invertedData[i] = normalData[i + 1]
@@ -53,12 +148,12 @@ export class JsModelLookup {
    * NOTE: The x values are assumed to be monotonically increasing.
    */
   private getValue(input: number, useInvertedData: boolean, mode: JsModelLookupMode): number {
-    if (this.n === 0) {
+    if (this.activeSize === 0) {
       return _NA_
     }
 
-    const data = useInvertedData ? this.invertedData : this.data
-    const max = this.n * 2
+    const data = useInvertedData ? this.invertedData : this.activeData
+    const max = this.activeSize * 2
 
     // Use the cached values for improved lookup performance, except in the case
     // of `LOOKUP INVERT` (since it may not be accurate if calls flip back and forth
@@ -134,12 +229,12 @@ export class JsModelLookup {
    * no points) or if the provided time is earlier than the first data point.
    */
   public getValueForGameTime(time: number, defaultValue: number): number {
-    if (this.n <= 0) {
+    if (this.activeSize <= 0) {
       // The lookup is empty, so return the default value
       return defaultValue
     }
 
-    const x0 = this.data[0]
+    const x0 = this.activeData[0]
     if (time < x0) {
       // The provided time is earlier than the first data point, so return the
       // default value
@@ -159,11 +254,12 @@ export class JsModelLookup {
    * lookup behavior, so we implement it as a separate method here.
    */
   public getValueBetweenTimes(input: number, mode: JsModelLookupMode): number {
-    if (this.n === 0) {
+    if (this.activeSize === 0) {
       return _NA_
     }
 
-    const max = this.n * 2
+    const data = this.activeData
+    const max = this.activeSize * 2
 
     switch (mode) {
       case 'forward': {
@@ -171,27 +267,27 @@ export class JsModelLookup {
         // when mode is 1 (look forward), so we will do the same
         input = Math.floor(input)
         for (let xi = 0; xi < max; xi += 2) {
-          const x = this.data[xi]
+          const x = data[xi]
           if (x >= input) {
-            return this.data[xi + 1]
+            return data[xi + 1]
           }
         }
-        return this.data[max - 1]
+        return data[max - 1]
       }
       case 'backward': {
         // Vensim appears to round non-integral input values down to a whole number
         // when mode is -1 (hold backward), so we will do the same
         input = Math.floor(input)
         for (let xi = 2; xi < max; xi += 2) {
-          const x = this.data[xi]
+          const x = data[xi]
           if (x >= input) {
-            return this.data[xi - 1]
+            return data[xi - 1]
           }
         }
         if (max >= 4) {
-          return this.data[max - 3]
+          return data[max - 3]
         } else {
-          return this.data[1]
+          return data[1]
         }
       }
       case 'interpolate':
@@ -207,17 +303,17 @@ export class JsModelLookup {
           throw new Error(msg)
         }
         for (let xi = 2; xi < max; xi += 2) {
-          const x = this.data[xi]
+          const x = data[xi]
           if (x >= input) {
-            const last_x = this.data[xi - 2]
-            const last_y = this.data[xi - 1]
-            const y = this.data[xi + 1]
+            const last_x = data[xi - 2]
+            const last_y = data[xi - 1]
+            const y = data[xi + 1]
             const dx = x - last_x
             const dy = y - last_y
             return last_y + (dy / dx) * (input - last_x)
           }
         }
-        return this.data[max - 1]
+        return data[max - 1]
       }
     }
   }

--- a/packages/runtime/src/js-model/js-model.ts
+++ b/packages/runtime/src/js-model/js-model.ts
@@ -50,7 +50,7 @@ export interface JsModel {
   setInputs(inputValue: (index: number) => number): void
 
   /** @hidden */
-  setLookup(varSpec: VarSpec, points: Float64Array): void
+  setLookup(varSpec: VarSpec, points: Float64Array | undefined): void
 
   /** @hidden */
   storeOutputs(storeValue: (value: number) => void): void

--- a/tests/integration/override-lookups/run-tests.js
+++ b/tests/integration/override-lookups/run-tests.js
@@ -92,6 +92,18 @@ async function runTests(runnerKind, modelRunner) {
   // Verify that the empty data override is in effect
   verifyDeclaredOutputs(runnerKind, 4, outputs, 0, 60)
 
+  // Run the model with one data variable reset to its original values (by setting
+  // the points array for the lookup to undefined)
+  outputs = await modelRunner.runModel(inputs, outputs, {
+    lookups: [
+      createLookupDef({ varId: '_a_data[_a1]' }, undefined),
+      createLookupDef({ varId: '_b_data[_a2,_b1]' }, undefined)
+    ]
+  })
+
+  // Verify that the empty data override is in effect
+  verifyDeclaredOutputs(runnerKind, 5, outputs, 0, 0)
+
   // Terminate the model runner
   await modelRunner.terminate()
 }


### PR DESCRIPTION
Fixes #592 

See issue for more details.  The new behavior is well covered by tests, and I think the changes are low risk (in an area that is not yet used in many projects), so I will merge this as is and we can see later if it meets the needs of EPS.

/cc @ToddFincannonEI 
