### PR TITLE
fix: increase C input buffer size + change default optimization flag for C compilation to `-O2`

### DIFF
--- a/packages/cli/src/c/main.c
+++ b/packages/cli/src/c/main.c
@@ -2,7 +2,7 @@
 
 int main(int argc, char** argv) {
   // TODO make the input buffer size dynamic
-  char inputs[1500];
+  char inputs[500000];
   // When true, output data without newlines or a header, suitable for embedding reference data.
   bool raw_output = false;
   // When true, suppress data output when using PR* macros.

--- a/packages/cli/src/c/makefile
+++ b/packages/cli/src/c/makefile
@@ -1,6 +1,6 @@
 # Do "export P={c-file-basename}" before running this makefile.
 OBJECTS=main.o vensim.o model.o macros.o
-CFLAGS=-Wall -O3
+CFLAGS=-Wall -O2
 LDLIBS=
 
 # In case of a Linux build we need to add


### PR DESCRIPTION
Fixes #595

See issue #595 for details.
