### PR TITLE
fix: catch toposort cyclic dependency errors and abort cleanly #597

### DIFF
--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -808,7 +808,13 @@ function sortVarsOfType(varType) {
   // Sort into an lhs dependency list.
   if (PRINT_AUX_GRAPH) printDepsGraph(graph, 'AUX')
   if (PRINT_LEVEL_GRAPH) printDepsGraph(graph, 'LEVEL')
-  let deps = toposort(graph).reverse()
+  let deps
+  try {
+    deps = toposort(graph).reverse()
+  } catch (err) {
+    console.error(err.message)
+    process.exit(1)
+  }
 
   // Turn the dependency-sorted var name list into a var list.
   let sortedVars = varsOfType(

--- a/packages/compile/src/model/toposort.js
+++ b/packages/compile/src/model/toposort.js
@@ -42,7 +42,7 @@ function toposort(nodes, edges) {
       } catch (e) {
         nodeRep = ''
       }
-      throw new Error('Found cyclic dependency during toposort:\n' + [...predecessors].join(' →\n') + nodeRep)
+      throw new Error('Found cyclic dependency during toposort:\n' + [...predecessors].join(' →\n') + ' →' + nodeRep)
     }
 
     if (!nodesHash.has(node)) {


### PR DESCRIPTION
See issue #597 for details.