### PR TITLE
feat: add `separateAllVarsWithDims` option to spec file to separate all vars with a dimension on the LHS

### DIFF
--- a/models/separateall/separateall.dat
+++ b/models/separateall/separateall.dat
@@ -1,0 +1,23 @@
+a[A1]
+0	42
+1	42
+a[A2]
+0	42
+1	42
+b[B1]
+0	42
+1	42
+b[B2]
+0	42
+1	42
+c
+0	42
+FINAL TIME
+0	1
+INITIAL TIME
+0	0
+SAVEPER
+0	1
+1	1
+TIME STEP
+0	1

--- a/models/separateall/separateall.mdl
+++ b/models/separateall/separateall.mdl
@@ -1,0 +1,109 @@
+{UTF-8}
+DimB: B1, B2
+	~	
+	~		|
+
+DimA: A1, A2
+	~	
+	~		|
+
+a[DimA] = c
+	~	
+	~		|
+
+b[DimB] = c
+	~	
+	~		|
+
+c = 42
+	~	
+	~		|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 1
+	~	Month
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 0
+	~	Month
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  = 
+        TIME STEP
+	~	Month [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 1
+	~	Month [0,?]
+	~	The time step for the simulation.
+	|
+
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*View 1
+$-1--1--1,0,|12||-1--1--1|-1--1--1|-1--1--1|-1--1--1|-1--1--1|96,96,100,0
+///---\\\
+:L<%^E!@
+1:separateall.vdfx
+4:Time
+5:Time
+6:A1
+6:B1
+9:separateall
+19:100,0
+24:0
+25:1
+26:1
+57:1
+54:0
+55:0
+82:1
+86:0
+59:0
+56:0
+58:0
+71:0
+110:0
+111:0
+44:0
+46:0
+45:0
+49:0
+50:0
+51:
+52:
+53:
+43:/Users/todd/Projects/SDEverywhere/models/separateall/separateall.dat
+47:
+48:
+15:0,0,0,0,0,0
+27:0,
+34:0,
+42:0
+72:0
+73:0
+95:0
+96:0
+97:0
+77:0
+78:0
+102:0
+93:0
+94:0
+92:0
+91:0
+90:0
+87:0
+75:
+43:/Users/todd/Projects/SDEverywhere/models/separateall/separateall.dat
+103:8,8,8,3,8
+105:0,0,0,0,0,0,0,0,0,0
+104:Courier|12||0-0-0|0-0-0|-1--1--1|0-0-255|192-192-192|-1--1--1

--- a/models/separateall/separateall_check.sh
+++ b/models/separateall/separateall_check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+MODEL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJ_DIR="$MODEL_DIR/../.."
+SDE_MAIN="$PROJ_DIR/packages/cli/src/main.js"
+
+cd $MODEL_DIR
+node "$SDE_MAIN" generate --list --spec separateall_spec.json separateall.mdl
+
+grep 'refId(_a\[_a1\])' build/separateall_vars.txt >/dev/null
+if [ $? != 0 ]; then
+  echo "ERROR: separateall listing did not include _a[_a1]"
+  exit 1
+fi
+
+grep 'refId(_b\[_b1\])' build/separateall_vars.txt >/dev/null
+if [ $? != 0 ]; then
+  echo "ERROR: separateall listing did not include _b[_b1]"
+  exit 1
+fi
+
+echo "All validation checks passed!"

--- a/models/separateall/separateall_spec.json
+++ b/models/separateall/separateall_spec.json
@@ -1,0 +1,4 @@
+{
+  "specialSeparationDims": { "_a": "_dima" },
+  "separateAllVarsWithDims": ["_dimb"]
+}

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -71,6 +71,9 @@ function read(parsedModel, spec, extData, directData, modelDirname, opts) {
   // Some arrays need to be separated into variables with individual indices to
   // prevent eval cycles. They are manually added to the spec file.
   let specialSeparationDims = spec.specialSeparationDims
+  // All arrays with the specified dimensions are separated on those dimensions.
+  // This allows variables to be separated without listing each one.
+  let separateAllVarsWithDims = spec.separateAllVarsWithDims
 
   // Dimensions must be defined before reading variables that use them.
   readDimensionDefs(parsedModel, modelDirname)
@@ -79,7 +82,7 @@ function read(parsedModel, spec, extData, directData, modelDirname, opts) {
   if (opts?.stopAfterResolveSubscripts) return
 
   // Read variables from the model parse tree.
-  const vars = readVariables(parsedModel, specialSeparationDims)
+  const vars = readVariables(parsedModel, specialSeparationDims, separateAllVarsWithDims)
 
   // Include a placeholder variable for the exogenous `Time` variable
   const timeVar = new Variable()

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -71,8 +71,9 @@ function read(parsedModel, spec, extData, directData, modelDirname, opts) {
   // Some arrays need to be separated into variables with individual indices to
   // prevent eval cycles. They are manually added to the spec file.
   let specialSeparationDims = spec.specialSeparationDims
-  // All arrays with the specified dimensions are separated on those dimensions.
-  // This allows variables to be separated without listing each one.
+  // All arrays that have one of the specified dimension ID lists are
+  // separated on those dimensions. This allows variables to be separated
+  // without listing each one.
   let separateAllVarsWithDims = spec.separateAllVarsWithDims
 
   // Dimensions must be defined before reading variables that use them.

--- a/packages/compile/src/model/read-equations.js
+++ b/packages/compile/src/model/read-equations.js
@@ -114,6 +114,9 @@ class Context {
     const parsedModel = { kind: 'vensim', root: parseVensimModel(eqnText) }
 
     // Create one or more `Variable` instances from the equations
+    // TODO: Technically we should pass `spec.separateAllVarsWithDims` here so that any
+    // generated apply-to-all variables will be separated according to the spec like other
+    // normal variables
     const vars = readVariables(parsedModel)
 
     // Add the variables to the `Model`

--- a/packages/compile/src/model/read-variables.js
+++ b/packages/compile/src/model/read-variables.js
@@ -125,13 +125,13 @@ function variablesForEquation(eqn, specialSeparationDims, separateAllVarsWithDim
       // on dims from `separateAllVarsWithDims` if the var matches one of the dim lists.
       if (separationDims.length === 0) {
         for (let dimList of separateAllVarsWithDims) {
-          // The list entry from the spec is only considered a match if every dimension
-          // in the spec list appears on the LHS
+          // Technically we allow each entry in the spec array to be either a single
+          // dim ID string or an array of dim IDs, so convert to array if needed
           if (!Array.isArray(dimList)) {
-            // Technically we allow each entry in the spec array to be either a single
-            // dim ID string or an array of dim IDs
             dimList = [dimList]
           }
+          // The list entry from the spec is only considered a match if every dimension
+          // in the spec list appears on the LHS
           if (dimList.every(dim => subIds.includes(dim))) {
             separationDims = dimList
             break

--- a/packages/compile/src/model/read-variables.js
+++ b/packages/compile/src/model/read-variables.js
@@ -127,12 +127,12 @@ function variablesForEquation(eqn, specialSeparationDims, separateAllVarsWithDim
         for (let dimList of separateAllVarsWithDims) {
           // The list entry from the spec is only considered a match if every dimension
           // in the spec list appears on the LHS
-          if (dimList.every(dim => subIds.includes(dim))) {
+          if (!Array.isArray(dimList)) {
             // Technically we allow each entry in the spec array to be either a single
             // dim ID string or an array of dim IDs
-            if (!Array.isArray(dimList)) {
-              dimList = [dimList]
-            }
+            dimList = [dimList]
+          }
+          if (dimList.every(dim => subIds.includes(dim))) {
             separationDims = dimList
             break
           }


### PR DESCRIPTION
Fixes #601 

This PR proposes an alternative to the `specialSeparationDims` syntax to avoid having to maintain the list in cases where all variables containing a given subscript should be separated.

The spec file can now contain a property named `separateAllVarsWithDims` with an array value. Each entry is either a dimension name string in canonical format, or an array of dimension names.

If a variable LHS matches all dimension names in one of the `separateAllVarsWithDims` entries, then it is separated on those dimensions. If a variable is specifically called out in   `specialSeparationDims`, then that takes precedence, and `separateAllVarsWithDims` is not checked. It does not make sense for a variable separation to be listed in both formats.

I added a test model called `separateall.mdl` that has two apply-to-all arrays named `a` and `b`.

```
DimA: A1, A2 ~~|
DimB: B1, B2 ~~|
a[DimA] = c ~~|
b[DimB] = c ~~|
c = 42 ~~|
```

Without a spec file, the following code and variable listing is generated.

```
// a[DimA] = c
for (size_t i = 0; i < 2; i++) {
_a[i] = _c;
}
// b[DimB] = c
for (size_t i = 0; i < 2; i++) {
_b[i] = _c;

a[DimA]: aux
= c
refId(_a)
families(_dima)
subscripts(_dima)
hasInitValue(false)
refs(_c)

b[DimB]: aux
= c
refId(_b)
families(_dimb)
subscripts(_dimb)
hasInitValue(false)
refs(_c)
```

I made a spec file that tests both separation methods:
```
"specialSeparationDims": { "_a": "_dima" },
"separateAllVarsWithDims": ["_dimb"]
```

The variables are separated in both cases:
```
// a[DimA] = c
_a[0] = _c;
// a[DimA] = c
_a[1] = _c;
// b[DimB] = c
_b[0] = _c;
// b[DimB] = c
_b[1] = _c;

a[DimA]: aux (non-apply-to-all)
= c
refId(_a[_a1])
families(_dima)
subscripts(_a1)
separationDims(_dima)
hasInitValue(false)
refs(_c)

a[DimA]: aux (non-apply-to-all)
= c
refId(_a[_a2])
families(_dima)
subscripts(_a2)
separationDims(_dima)
hasInitValue(false)
refs(_c)

b[DimB]: aux (non-apply-to-all)
= c
refId(_b[_b1])
families(_dimb)
subscripts(_b1)
separationDims(_dimb)
hasInitValue(false)
refs(_c)

b[DimB]: aux (non-apply-to-all)
= c
refId(_b[_b2])
families(_dimb)
subscripts(_b2)
separationDims(_dimb)
hasInitValue(false)
refs(_c)
```

Because generation and execution do not fail in this test model, I added a check script that generates the model listing and confirms that both variables are separated. This is the only way to test the PR, since we don't have a failing test otherwise.

I tested this change on an EPS 4 model and confirmed that the new spec file format results in the same C code generation as the previous spec file that listed each variable separately.
