### PR TITLE
refactor: convert Sass syntax in check-ui-shell Svelte files to SCSS syntax

### DIFF
--- a/examples/house-game/packages/app/src/app.svelte
+++ b/examples/house-game/packages/app/src/app.svelte
@@ -68,111 +68,120 @@ function onContinue() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.app-container
-  display: flex
-  flex-direction: row
-  gap: 10px
+.app-container {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
 
-.left-container
-  display: flex
-  flex-direction: column
-  flex-shrink: 0
-  gap: 10px
-  font-family: sans-serif
+.left-container {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: 10px;
+  font-family: sans-serif;
+}
 
-.text-container
-  display: flex
-  flex-direction: column
-  width: 250px
-  height: 240px
-  flex-shrink: 0
-  align-items: flex-start
-  gap: 10px
-  padding: 10px
-  border-radius: 8px
-  border: solid 1px #555
-  font-family: sans-serif
+.text-container {
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+  height: 240px;
+  flex-shrink: 0;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 8px;
+  border: solid 1px #555;
+  font-family: sans-serif;
+}
 
-.message
-  font-size: 14px
-  line-height: 1.4
-.message :global(.supply)
-  color: magenta
-  font-weight: 700
-.message :global(.demand)
-  color: #4080e0
-  font-weight: 700
+.message {
+  font-size: 14px;
+  line-height: 1.4;
 
-.input-row
-  display: flex
-  flex-direction: row
-  align-items: baseline
-  gap: 8px
-  font-size: 14px
-  line-height: 1.4
+  :global(.supply) {
+    color: magenta;
+    font-weight: 700;
+  }
 
-.spacer-flex
-  flex: 1
+  :global(.demand) {
+    color: #4080e0;
+    font-weight: 700;
+  }
+}
 
-.buttons
-  display: flex
-  flex-direction: row
-  width: 100%
-  justify-content: space-between
+.input-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+}
 
-button
-  background-color: transparent
-  background-repeat: no-repeat
-  border: solid 1px #fff
-  border-radius: 8px
-  padding: 4px 8px
-  outline: none
-  overflow: hidden
-  color: #fff
-  cursor: pointer
-  &.reset
-    border-color: #555
-    color: #555
-  &:disabled
-    opacity: 0.5
-    cursor: not-allowed
-  &:hover:not(:disabled)
-    background-color: rgba(128, 128, 128, 0.2)
+.spacer-flex {
+  flex: 1;
+}
 
-.text-container.assumptions
-  height: 160px
-  gap: 4px
-  color: #777
+.buttons {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+}
 
-.right-container
-  display: flex
-  flex-direction: column
-  padding: 10px
-  border-radius: 8px
-  border: solid 1px #555
+button {
+  background-color: transparent;
+  background-repeat: no-repeat;
+  border: solid 1px #fff;
+  border-radius: 8px;
+  padding: 4px 8px;
+  outline: none;
+  overflow: hidden;
+  color: #fff;
+  cursor: pointer;
 
-// textarea
-//   font-family: monospace
-//   min-height: 600px
-//   background-color: black
-//   color: #fff
-//   border: none
-//   border-radius: 8px
-//   padding: 8px
+  &.reset {
+    border-color: #555;
+    color: #555;
+  }
 
-.graph-container
-  position: relative
-  width: 500px
-  height: 300px
-  margin-top: 20px
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
-// .cell-column
-//   display: flex
-//   flex-direction: column
+  &:hover:not(:disabled) {
+    background-color: rgba(128, 128, 128, 0.2);
+  }
+}
 
-.cell-value
-  max-width: 40px
+.text-container.assumptions {
+  height: 160px;
+  gap: 4px;
+  color: #777;
+}
+
+.right-container {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  border-radius: 8px;
+  border: solid 1px #555;
+}
+
+.graph-container {
+  position: relative;
+  width: 500px;
+  height: 300px;
+  margin-top: 20px;
+}
+
+.cell-value {
+  max-width: 40px;
+}
 
 </style>

--- a/examples/house-game/packages/app/src/components/assumptions/assumptions.svelte
+++ b/examples/house-game/packages/app/src/components/assumptions/assumptions.svelte
@@ -29,25 +29,30 @@ export let viewModel: AssumptionsViewModel
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.assumptions-title
-  font-weight: 700
-  margin-bottom: 12px
+.assumptions-title {
+  font-weight: 700;
+  margin-bottom: 12px;
+}
 
-.assumption-rows
-  display: flex
-  flex-direction: column
-  width: 100%
+.assumption-rows {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
 
-.assumption-row
-  display: flex
-  flex-direction: row
-  width: 100%
-  justify-content: space-between
-  font-size: 14px
-  line-height: 1.4
-  &:nth-child(2)
-    margin-bottom: 12px
+.assumption-row {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+  font-size: 14px;
+  line-height: 1.4;
+
+  &:nth-child(2) {
+    margin-bottom: 12px;
+  }
+}
 
 </style>

--- a/examples/house-game/packages/app/src/components/graph/graph.svelte
+++ b/examples/house-game/packages/app/src/components/graph/graph.svelte
@@ -75,17 +75,18 @@ onMount(() => {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
 // zero offsets so that it fills its parent.
-.graph-inner-container
-  position: absolute
-  top: 0
-  left: 0
-  bottom: 0
-  right: 0
+.graph-inner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
 
 </style>

--- a/packages/check-ui-shell/src/app.svelte
+++ b/packages/check-ui-shell/src/app.svelte
@@ -162,25 +162,28 @@ function onKeyDown(event: KeyboardEvent) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.app-container
-  display: flex
-  flex-direction: column
-  flex: 1
+.app-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.loading-container
-  display: flex
-  flex-direction: column
-  flex: 1 1 auto
-  align-items: center
-  justify-content: center
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+}
 
-.progress-container
-  display: flex
-  height: 100vh
-  align-items: center
-  justify-content: center
-  font-size: 2em
+.progress-container {
+  display: flex;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+  font-size: 2em;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/_shared/lazy.svelte
+++ b/packages/check-ui-shell/src/components/_shared/lazy.svelte
@@ -89,11 +89,12 @@ onMount(() => {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.lazy-container
-  position: relative
-  display: flex
-  height: 100%
+.lazy-container {
+  position: relative;
+  display: flex;
+  height: 100%;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/_shared/selector.svelte
+++ b/packages/check-ui-shell/src/components/_shared/selector.svelte
@@ -38,26 +38,28 @@ function onChange() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-select
-  width: auto
-  font-family: inherit
-  font-size: inherit
-  color: inherit
+select {
+  width: auto;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
   // Note: The following values were derived from bootstrap
-  margin: 0
-  background-color: #fff
-  background-image: none
-  border: 1px solid #ccc
-  border-radius: 0
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075)
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out
-  text-transform: none
+  margin: 0;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  text-transform: none;
 
-select > option
-  // XXX: Firefox doesn't support @font-face in select menus, so
-  // the best we can do is try a similar sans serif font
-  font-family: 'Roboto Condensed', Helvetica, sans-serif
+  > option {
+    // XXX: Firefox doesn't support @font-face in select menus, so
+    // the best we can do is try a similar sans serif font
+    font-family: 'Roboto Condensed', Helvetica, sans-serif;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.svelte
@@ -47,15 +47,16 @@ $: if (visible !== previousVisible || viewModel.baseRequestKey !== previousViewM
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.graph-container
-  position: relative
-  display: flex
-  width: 36rem
-  height: 22rem
-  margin-left: 1rem
-  margin-top: .5rem
-  margin-bottom: 1rem
+.graph-container {
+  position: relative;
+  display: flex;
+  width: 36rem;
+  height: 22rem;
+  margin-left: 1rem;
+  margin-top: .5rem;
+  margin-bottom: 1rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-row.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-row.svelte
@@ -32,10 +32,11 @@ function onLabelClicked() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.check-graph
-  height: 23rem
-  margin-left: 8.5rem
+.check-graph {
+  height: 23rem;
+  margin-left: 8.5rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary.svelte
@@ -76,87 +76,108 @@ const showCheckDetail = true
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-$indent: 1rem
+$indent: 1rem;
 
-.check-summary-container
-  display: flex
-  flex-direction: column
+.check-summary-container {
+  display: flex;
+  flex-direction: column;
+}
 
-.check-detail
-  display: flex
-  flex-direction: column
+.check-detail {
+  display: flex;
+  flex-direction: column;
+}
 
-.group-container
-  margin-bottom: 1.2rem
+.group-container {
+  margin-bottom: 1.2rem;
 
-.group-container :global(.test-rows)
-  display: flex
-  flex-direction: column
+  :global(.test-rows) {
+    display: flex;
+    flex-direction: column;
+  }
 
-// Hide passed rows by default
-.group-container :global(.row.passed)
-  display: none
+  // Hide passed rows by default
+  :global(.row.passed) {
+    display: none;
+  }
 
-// Show passed rows when parent test has `expand-all` class
-.group-container :global(.test-rows.expand-all .row.passed)
-  display: flex
+  // Show passed rows when parent test has `expand-all` class
+  :global(.test-rows.expand-all .row.passed) {
+    display: flex;
+  }
 
-.group-container :global(.row)
-  display: flex
-  flex-direction: row
+  :global(.row) {
+    display: flex;
+    flex-direction: row;
+  }
 
-.group-container :global(.row.group)
-  font-size: 1.2em
+  :global(.row.group) {
+    font-size: 1.2em;
+  }
 
-.group-container :global(.row.test)
-  margin-top: .4rem
+  :global(.row.test) {
+    margin-top: .4rem;
+  }
 
-.group-container :global(.row.test > .label)
-  cursor: pointer
+  :global(.row.test > .label) {
+    cursor: pointer;
+  }
 
-.group-container :global(.row.scenario)
-  color: #777
+  :global(.row.scenario) {
+    color: #777;
+  }
 
-.group-container :global(.row.dataset)
-  color: #777
+  :global(.row.dataset) {
+    color: #777;
+  }
 
-.group-container :global(.row.predicate)
-  color: #777
+  :global(.row.predicate) {
+    color: #777;
+  }
 
-.group-container :global(.row.predicate > .label)
-  cursor: pointer
+  :global(.row.predicate > .label ){
+    cursor: pointer;
+  }
 
-.group-container :global(.bold)
-  font-weight: 700
-  color: #bbb
+  :global(.bold) {
+    font-weight: 700;
+    color: #bbb;
+  }
+}
 
-.summary-bar-row
-  display: flex
-  flex-direction: row
-  align-items: baseline
-  align-self: flex-start
-  margin: 2.6rem 0
-  opacity: 1.0
+.summary-bar-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  align-self: flex-start;
+  margin: 2.6rem 0;
+  opacity: 1.0;
+}
 
-.bar-container
-  display: flex
-  flex-direction: row
-  width: 15rem
-  height: .8rem
+.bar-container {
+  display: flex;
+  flex-direction: row;
+  width: 15rem;
+  height: .8rem;
+}
 
-.bar
-  height: .8rem
+.bar {
+  height: .8rem;
 
-.bar.gray
-  background-color: #777
+  &.gray {
+    background-color: #777;
+  }
+}
 
-.summary-label
-  margin-left: .8rem
-  color: #fff
+.summary-label {
+  margin-left: .8rem;
+  color: #fff;
+}
 
-.sep
-  color: #777
+.sep {
+  color: #777;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
@@ -133,104 +133,118 @@ function getMaxDiffSpan(content: CompareDetailBoxContent): string {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-$border-w: .3rem
-$border-w-2x: $border-w * 2
+$border-w: .3rem;
+$border-w-2x: $border-w * 2;
 
-$padding-w: .5rem
-$padding-w-2x: $padding-w * 2
+$padding-w: .5rem;
+$padding-w-2x: $padding-w * 2;
 
-$stats-h: 4rem
+$stats-h: 4rem;
 
-.detail-box
-  display: flex
-  flex-direction: column
-  --box-graph-w: calc(30rem * var(--graph-zoom))
-  --box-graph-h: calc(22rem * var(--graph-zoom))
+.detail-box {
+  display: flex;
+  flex-direction: column;
+  --box-graph-w: calc(30rem * var(--graph-zoom));
+  --box-graph-h: calc(22rem * var(--graph-zoom));
+}
 
-.title-row
-  position: relative
-  max-width: calc(var(--box-graph-w) + 1rem)
-  height: 1.4rem
-  cursor: pointer
+.title-row {
+  position: relative;
+  max-width: calc(var(--box-graph-w) + 1rem);
+  height: 1.4rem;
+  cursor: pointer;
+}
 
-.title-content
-  position: absolute
-  max-width: calc(var(--box-graph-w) + 1rem)
-  white-space: nowrap
-  overflow: hidden
-  text-overflow: ellipsis
+.title-content {
+  position: absolute;
+  max-width: calc(var(--box-graph-w) + 1rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
-.title-content:hover
-  width: max-content
-  max-width: unset
-  overflow: unset
-  z-index: 100
-  background-color: #3c3c3c
+  &:hover {
+    width: max-content;
+    max-width: unset;
+    overflow: unset;
+    z-index: 100;
+    background-color: #3c3c3c;
+  }
+}
 
-.title
-  margin-left: .7rem
-  font-size: 1.1em
-  font-weight: 700
+.title {
+  margin-left: .7rem;
+  font-size: 1.1em;
+  font-weight: 700;
+}
 
-.subtitle
-  color: #aaa
-  margin-left: .4rem
-  margin-right: .7rem
+.subtitle {
+  color: #aaa;
+  margin-left: .4rem;
+  margin-right: .7rem;
+}
 
-.content-container
-  display: flex
-  flex-direction: column
+.content-container {
+  display: flex;
+  flex-direction: column;
   // XXX: This is content size + padding + border; we use a fixed size so that
   // the box layout remains stable when the graph content is loaded lazily
-  width: calc(var(--box-graph-w) + $padding-w-2x + $border-w-2x)
-  max-width: calc(var(--box-graph-w) + $padding-w-2x + $border-w-2x)
-  height: calc(var(--box-graph-h) + $stats-h + $padding-w-2x + $border-w-2x)
-  max-height: calc(var(--box-graph-h) + $stats-h + $padding-w-2x + $border-w-2x)
+  width: calc(var(--box-graph-w) + $padding-w-2x + $border-w-2x);
+  max-width: calc(var(--box-graph-w) + $padding-w-2x + $border-w-2x);
+  height: calc(var(--box-graph-h) + $stats-h + $padding-w-2x + $border-w-2x);
+  max-height: calc(var(--box-graph-h) + $stats-h + $padding-w-2x + $border-w-2x);
+}
 
-.content
-  display: flex
-  flex-direction: column
-  height: calc(var(--box-graph-h) + $stats-h)
-  padding: $padding-w
-  border-width: $border-w
-  border-style: solid
-  border-radius: .8rem
+.content {
+  display: flex;
+  flex-direction: column;
+  height: calc(var(--box-graph-h) + $stats-h);
+  padding: $padding-w;
+  border-width: $border-w;
+  border-style: solid;
+  border-radius: .8rem;
+}
 
-.graph-container
-  position: relative
-  display: flex
-  width: var(--box-graph-w)
-  height: var(--box-graph-h)
+.graph-container {
+  position: relative;
+  display: flex;
+  width: var(--box-graph-w);
+  height: var(--box-graph-h);
+}
 
-.message-container
-  display: flex
-  flex-direction: column
-  max-width: var(--box-graph-w)
-  height: $stats-h
-  justify-content: flex-end
+.message-container {
+  display: flex;
+  flex-direction: column;
+  max-width: var(--box-graph-w);
+  height: $stats-h;
+  justify-content: flex-end;
+}
 
-.message
-  white-space: nowrap
-  overflow: hidden
-  text-overflow: ellipsis
+.message {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-.data-row
-  display: flex
-  flex-direction: row
-  align-items: baseline
+.data-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
 
-.data-label
-  font-size: .9em
-  color: #aaa
-  min-width: 2rem
-  margin-right: .4rem
-  text-align: right
+.data-label {
+  font-size: .9em;
+  color: #aaa;
+  min-width: 2rem;
+  margin-right: .4rem;
+  text-align: right;
+}
 
-.data-value
-  white-space: nowrap
-  overflow: hidden
-  text-overflow: ellipsis
+.data-value {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-row.svelte
@@ -116,57 +116,71 @@ function getContextGraphPadding(index: number): number {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.detail-row
-  display: flex
-  flex-direction: column
+.detail-row {
+  display: flex;
+  flex-direction: column;
+}
 
-.title-row
-  align-items: baseline
-  margin-bottom: .5rem
+.title-row {
+  align-items: baseline;
+  margin-bottom: .5rem;
+}
 
-.title
-  margin-right: .8rem
-  font-size: 1.5em
-  font-weight: 700
+.title {
+  margin-right: .8rem;
+  font-size: 1.5em;
+  font-weight: 700;
+}
 
-.subtitle
-  font-size: 1.3em
-  color: #aaa
+.subtitle {
+  font-size: 1.3em;
+  color: #aaa;
 
-.subtitle :global(.subtitle-sep)
-  color: #666
+  :global(.subtitle-sep) {
+    color: #666;
+  }
+}
 
-.boxes
-  display: flex
-  flex-direction: row
+.boxes {
+  display: flex;
+  flex-direction: row;
+}
 
-.box-container.dimmed
-  opacity: 0.2
+.box-container {
+  &.dimmed {
+    opacity: 0.2;
+  }
+}
 
-.spacer-fixed
-  min-width: 1.5rem
+.spacer-fixed {
+  min-width: 1.5rem;
+}
 
-.context-graphs-container
-  display: inline-flex
-  flex-direction: row
-  margin-top: 1rem
-  padding: 0 1rem
-  background-color: #555
+.context-graphs-container {
+  display: inline-flex;
+  flex-direction: row;
+  margin-top: 1rem;
+  padding: 0 1rem;
+  background-color: #555;
+}
 
-.context-graphs-column
-  display: inline-flex
-  flex-direction: column
+.context-graphs-column {
+  display: inline-flex;
+  flex-direction: column;
+}
 
-.context-graph-row
-  display: flex
-  flex-direction: row
+.context-graph-row {
+  display: flex;
+  flex-direction: row;
   // XXX: Remove this hardcoded value
-  width: 77.5rem
-  margin: 1rem 0
+  width: 77.5rem;
+  margin: 1rem 0;
+}
 
-.context-graph-spacer
-  min-width: 1.5rem
+.context-graph-spacer {
+  min-width: 1.5rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
@@ -266,136 +266,161 @@ onMount(() => {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.compare-detail-container
-  display: flex
-  flex-direction: column
-  flex: 1
+.compare-detail-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.header-container
-  display: flex
-  flex-direction: column
+.header-container {
+  display: flex;
+  flex-direction: column;
   // XXX: Use negative margin to make the shadow stretch all the way
   // across, then use extra padding to compensate
-  width: calc(100vw - 2rem)
-  margin: 0 -1rem
-  padding: 0 2rem
-  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.5)
-  z-index: 1
+  width: calc(100vw - 2rem);
+  margin: 0 -1rem;
+  padding: 0 2rem;
+  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.5);
+  z-index: 1;
+}
 
-.title-and-links
-  display: flex
-  flex-direction: row
-  align-items: center
+.title-and-links {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   // XXX: Use a fixed height for now so that it doesn't bounce around when
   // the title wraps to two lines
-  height: 4.5rem
+  height: 4.5rem;
+}
 
-.spacer-flex
-  flex: 1
+.spacer-flex {
+  flex: 1;
+}
 
-.nav-links
-  display: flex
-  flex-direction: row
-  font-size: .8em
+.nav-links {
+  display: flex;
+  flex-direction: row;
+  font-size: .8em;
+}
 
-.nav-link-sep
-  color: #444
+.nav-link-sep {
+  color: #444;
+}
 
-.nav-link
-  cursor: pointer
-  color: #777
+.nav-link {
+  cursor: pointer;
+  color: #777;
+}
 
 // .nav-link.disabled
 //   cursor: not-allowed
 //   color: #555
 
-.title-container
-  display: flex
-  flex-direction: column
+.title-container {
+  display: flex;
+  flex-direction: column;
+}
 
-.pretitle
-  margin-bottom: .2rem
-  font-size: .9em
-  font-weight: 700
-  color: #aaa
+.pretitle {
+  margin-bottom: .2rem;
+  font-size: .9em;
+  font-weight: 700;
+  color: #aaa;
+}
 
-.title-and-subtitle
-  display: flex
-  flex-direction: row
-  align-items: baseline
+.title-and-subtitle {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
 
-.title
-  margin-bottom: .4rem
-  font-size: 2em
-  font-weight: 700
-  cursor: pointer
+.title {
+  margin-bottom: .4rem;
+  font-size: 2em;
+  font-weight: 700;
+  cursor: pointer;
+}
 
-.subtitle
-  font-size: 1.2em
-  font-weight: 700
-  margin-left: 1.2rem
-  color: #aaa
+.subtitle {
+  font-size: 1.2em;
+  font-weight: 700;
+  margin-left: 1.2rem;
+  color: #aaa;
+}
 
-.annotations
-  margin-left: .3rem
-  color: #aaa
+.annotations {
+  margin-left: .3rem;
+  color: #aaa;
 
-.annotations :global(.annotation)
-  margin: 0 .3rem
-  padding: .1rem .3rem
-  background-color: #222
-  border: .5px solid #555
-  border-radius: .4rem
+  :global(.annotation) {
+    margin: 0 .3rem;
+    padding: .1rem .3rem;
+    background-color: #222;
+    border: .5px solid #555;
+    border-radius: .4rem;
+  }
+}
 
-.related
-  font-size: 1em
-  color: #aaa
-  margin-bottom: .6rem
+.related {
+  font-size: 1em;
+  color: #aaa;
+  margin-bottom: .6rem;
 
-ul
-  margin: .1rem 0
-  padding-left: 2rem
+  :global(.related-sep) {
+    color: #666;
+  }
+}
 
-.related :global(.related-sep)
-  color: #666
+ul {
+  margin: .1rem 0;
+  padding-left: 2rem;
+}
 
-.scroll-container
-  display: flex
-  flex-direction: row
-  max-width: 100vw
-  flex: 1 0 1px
-  overflow: auto
-  outline: none
-  background-color: #3c3c3c
+.scroll-container {
+  display: flex;
+  flex-direction: row;
+  max-width: 100vw;
+  flex: 1 0 1px;
+  overflow: auto;
+  outline: none;
+  background-color: #3c3c3c;
+}
 
-.scroll-content
-  position: relative
+.scroll-content {
+  position: relative;
+}
 
-.section-title
-  width: calc(100vw - 2rem)
-  margin: 1.5rem 1rem 2rem 1rem
-  padding: .2rem 0
-  border-bottom: solid 1px #555
-  color: #ccc
-  font-size: 1.4em
-  font-weight: 700
-  &:not(:first-child)
-    margin-top: 5rem
+.section-title {
+  width: calc(100vw - 2rem);
+  margin: 1.5rem 1rem 2rem 1rem;
+  padding: .2rem 0;
+  border-bottom: solid 1px #555;
+  color: #ccc;
+  font-size: 1.4em;
+  font-weight: 700;
 
-.row-container
-  display: flex
-  flex-direction: row
-  margin-top: .5rem
-  margin-bottom: 3rem
-  margin-left: 1rem
-  margin-right: 1rem
+  &:not(:first-child) {
+    margin-top: 5rem;
+  }
+}
 
-.row-container:first-child
-  margin-top: 3rem
+.row-container {
+  display: flex;
+  flex-direction: row;
+  margin-top: .5rem;
+  margin-bottom: 3rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
 
-.footer
-  height: 1rem
+  &:first-child {
+    margin-top: 3rem;
+  }
+}
+
+.footer {
+  height: 1rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-graphs-dataset.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-graphs-dataset.svelte
@@ -56,40 +56,46 @@ function onDatasetClicked() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.dataset-container
-  display: flex
-  flex: 1
-  flex-direction: column
+.dataset-container {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
 
-.dataset-row
-  display: flex
-  flex: 1
-  align-items: baseline
-  margin-left: .6rem
-  cursor: pointer
+.dataset-row {
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  margin-left: .6rem;
+  cursor: pointer;
 
-.dataset-row:hover
-  background-color: rgba(255, 255, 255, .05)
+  &:hover {
+    background-color: rgba(255, 255, 255, .05);
+  }
+}
 
-.dataset-arrow
-  color: #777
+.dataset-arrow {
+  color: #777;
+}
 
-.legend-item
-  font-family: 'Roboto Condensed'
-  font-weight: 700
-  font-size: 1rem
-  margin: .2rem .4rem
-  padding: .25rem .6rem .2rem .6rem
-  color: #fff
-  text-align: center
+.legend-item {
+  font-family: 'Roboto Condensed';
+  font-weight: 700;
+  font-size: 1rem;
+  margin: .2rem .4rem;
+  padding: .25rem .6rem .2rem .6rem;
+  color: #fff;
+  text-align: center;
+}
 
-.detail-box-container
-  display: flex
-  flex: 1
-  margin-top: .2rem
-  margin-bottom: .8rem
-  margin-left: .4rem
+.detail-box-container {
+  display: flex;
+  flex: 1;
+  margin-top: .2rem;
+  margin-bottom: .8rem;
+  margin-left: .4rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row.svelte
@@ -63,51 +63,62 @@ export let align: 'center' | 'left' = 'center'
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.graphs-row
-  display: flex
-  flex-direction: row
-  flex: 1
+.graphs-row {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+}
 
-.spacer-flex
-  flex: 1
+.spacer-flex {
+  flex: 1;
+}
 
-.spacer-fixed
-  flex: 0 0 2rem
+.spacer-fixed {
+  flex: 0 0 2rem;
+}
 
-.content
-  display: flex
-  flex-direction: column
-  flex: 1
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.graphs-container
-  display: flex
-  flex-direction: row
+.graphs-container {
+  display: flex;
+  flex-direction: row;
+}
 
-.metadata-container
-  display: flex
-  flex-direction: column
+.metadata-container {
+  display: flex;
+  flex-direction: column;
+}
 
-.metadata-header
-  margin-top: .6rem
+.metadata-header {
+  margin-top: .6rem;
+}
 
-.metadata-row
-  display: flex
-  flex-direction: row
+.metadata-row {
+  display: flex;
+  flex-direction: row;
 
-.metadata-row:hover
-  background-color: rgba(255, 255, 255, .05)
+  &:hover {
+    background-color: rgba(255, 255, 255, .05);
+  }
+}
 
-.metadata-col
-  display: flex
+.metadata-col {
+  display: flex;
   // XXX: This needs to match fixed `context-graph-container` width for now
-  width: 38rem
-  align-items: baseline
+  width: 38rem;
+  align-items: baseline;
+}
 
-.metadata-key
-  color: #aaa
-  font-size: .8em
-  margin-left: 1rem
+.metadata-key {
+  color: #aaa;
+  font-size: .8em;
+  margin-left: 1rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-pinned.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-pinned.svelte
@@ -68,14 +68,16 @@ function onToggleItemPinned(row: ComparisonSummaryRowViewModel): void {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.dnd-section
-  padding: .2rem 0
+.dnd-section {
+  padding: .2rem 0;
+}
 
-.dnd-item
-  display: flex
-  width: fit-content
-  background-color: #272727
+.dnd-item {
+  display: flex;
+  width: fit-content;
+  background-color: #272727;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row.svelte
@@ -64,75 +64,88 @@ function onLinkClicked() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-$bar-width: 15rem
+$bar-width: 15rem;
 
-.summary-row
-  display: flex
-  flex-direction: row
-  flex: 0 0 auto
-  align-items: flex-end
-  margin: .2rem 0
-  opacity: .8
+.summary-row {
+  display: flex;
+  flex-direction: row;
+  flex: 0 0 auto;
+  align-items: flex-end;
+  margin: .2rem 0;
+  opacity: .8;
 
-.summary-row:hover
-  opacity: 1.0
+  &:hover {
+    opacity: 1.0;
+  }
+}
 
-.bar-container
-  display: flex
-  flex-direction: row
-  width: $bar-width
-  height: .8rem
-  margin-bottom: .25rem
-  cursor: pointer
+.bar-container {
+  display: flex;
+  flex-direction: row;
+  width: $bar-width;
+  height: .8rem;
+  margin-bottom: .25rem;
+  cursor: pointer;
+}
 
-.bar
-  height: .8rem
+.bar {
+  height: .8rem;
 
-.bar.striped
-  width: 100%
-  background: repeating-linear-gradient(-45deg, goldenrod, goldenrod .4rem, darkgoldenrod .4rem, darkgoldenrod 1rem)
+  &.striped {
+    width: 100%;
+    background: repeating-linear-gradient(-45deg, goldenrod, goldenrod .4rem, darkgoldenrod .4rem, darkgoldenrod 1rem);
+  }
+}
 
-.title-container
-  display: flex
-  flex-direction: column
-  margin-left: .8rem
+.title-container {
+  display: flex;
+  flex-direction: column;
+  margin-left: .8rem;
+}
 
-// .grouping-part
-//   font-size: .7em
-//   color: #666
+// .grouping-part {
+//   font-size: .7em;
+//   color: #666;
+// }
 
-.title-part
-  display: flex
-  flex-direction: row
-  align-items: baseline
+.title-part {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
 
-.title
-  color: #fff
-  cursor: pointer
+.title {
+  color: #fff;
+  cursor: pointer;
+}
 
-.subtitle
-  font-size: .8em
-  margin-left: .6rem
-  color: #aaa
-  cursor: pointer
+.subtitle {
+  font-size: .8em;
+  margin-left: .6rem;
+  color: #aaa;
+  cursor: pointer;
+}
 
-// .values-part
-//   font-size: .8em
-//   margin-left: .6rem
-//   color: #aaa
+// .values-part {
+//   font-size: .8em;
+//   margin-left: .6rem;
+//   color: #aaa;
+// }
 
-.annotations
-  font-size: .8em
-  margin-left: .3rem
-  color: #aaa
+.annotations {
+  font-size: .8em;
+  margin-left: .3rem;
+  color: #aaa;
 
-.annotations :global(.annotation)
-  margin: 0 .3rem
-  padding: .1rem .3rem
-  background-color: #1c1c1c
-  border: .5px solid #555
-  border-radius: .4rem
+  :global(.annotation) {
+    margin: 0 .3rem;
+    padding: .1rem .3rem;
+    background-color: #1c1c1c;
+    border: .5px solid #555;
+    border-radius: .4rem;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-section.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-section.svelte
@@ -42,45 +42,56 @@ function onHeaderClicked() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // TODO: Share with comparison-summary-row
-$bar-width: 15rem
+$bar-width: 15rem;
 
-.section-container
-  display: flex
-  flex-direction: column
-  &:not(:last-child)
-    margin-bottom: 1.5rem
+.section-container {
+  display: flex;
+  flex-direction: column;
 
-.header-row
-  display: flex
-  flex-direction: row
-  align-items: center
-  margin: .4rem 0
-  cursor: pointer
-  &.collapsed
-    opacity: 0.5
-  &:hover
-    opacity: 0.8
+  &:not(:last-child) {
+    margin-bottom: 1.5rem;
+  }
+}
 
-.header-bar
-  display: flex
-  width: $bar-width
-  height: 1px
-  background-color: #555
+.header-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: .4rem 0;
+  cursor: pointer;
 
-.header-title
-  margin-left: .8rem
-  color: #fff
-  font-size: 1.2em
+  &.collapsed {
+    opacity: 0.5;
+  }
 
-.header-count
-  margin-left: .5rem
-  padding: .1rem .5rem
-  border-radius: 1rem
-  background-color: rgba(255, 165, 0, .7)
-  color: #eee
-  font-size: .85em
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.header-bar {
+  display: flex;
+  width: $bar-width;
+  height: 1px;
+  background-color: #555;
+}
+
+.header-title {
+  margin-left: .8rem;
+  color: #fff;
+  font-size: 1.2em;
+}
+
+.header-count {
+  margin-left: .5rem;
+  padding: .1rem .5rem;
+  border-radius: 1rem;
+  background-color: rgba(255, 165, 0, .7);
+  color: #eee;
+  font-size: .85em;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary.svelte
@@ -36,22 +36,27 @@ export let viewModel: ComparisonSummaryViewModel
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.comparison-summary-container
-  display: flex
-  flex-direction: column
-  padding-top: 2rem
+.comparison-summary-container {
+  display: flex;
+  flex-direction: column;
+  padding-top: 2rem;
+}
 
-.section-container
-  display: flex
-  flex-direction: column
+.section-container {
+  display: flex;
+  flex-direction: column;
   // Set scroll margin to account for headers when jumping to anchors
-  scroll-margin-top: 5rem
-  &:not(:last-child)
-    margin-bottom: 1.5rem
+  scroll-margin-top: 5rem;
 
-.footer
-  flex: 0 0 1rem
+  &:not(:last-child) {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.footer {
+  flex: 0 0 1rem;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
@@ -66,17 +66,18 @@ onMount(() => {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
 // zero offsets so that it fills its parent.
-.graph-inner-container
-  position: absolute
-  top: 0
-  left: 0
-  bottom: 0
-  right: 0
+.graph-inner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/graphs/context-graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/context-graph.svelte
@@ -102,60 +102,70 @@ function onLinkClicked(linkItem: LinkItem) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // The graph columns have a fixed width of 38rem (38% of app width);
 // this needs to match the `graphConfig.width` value above
-$graph-width: 38rem
-$graph-height: 20rem
+$graph-width: 38rem;
+$graph-height: 20rem;
 
-.context-graph-container
-  display: inline-flex
-  flex-direction: column
+.context-graph-container {
+  display: inline-flex;
+  flex-direction: column;
   // Use a fixed width measured in viewport-relative units
-  flex: 0 0 $graph-width
-  background-color: #fff
+  flex: 0 0 $graph-width;
+  background-color: #fff;
+}
 
-.graph-and-info
-  display: flex
-  flex-direction: column
+.graph-and-info {
+  display: flex;
+  flex-direction: column;
+}
 
-.graph-title
-  margin: .5rem 0
-  padding: 0 .8rem
-  font-family: 'Roboto Condensed'
-  font-size: 1.55rem
+.graph-title {
+  margin: .5rem 0;
+  padding: 0 .8rem;
+  font-family: 'Roboto Condensed';
+  font-size: 1.55rem;
+}
 
-.graph-container
-  display: block
-  position: relative
-  width: $graph-width
-  height: $graph-height
+.graph-container {
+  display: block;
+  position: relative;
+  width: $graph-width;
+  height: $graph-height;
+}
 
-.message
-  display: flex
-  flex: 1
-  min-height: $graph-height
-  align-items: center
-  justify-content: center
-  color: #aaa
-  border: solid 1px #fff
-  &.not-included
-    background-color: #555
+.message {
+  display: flex;
+  flex: 1;
+  min-height: $graph-height;
+  align-items: center;
+  justify-content: center;
+  color: #aaa;
+  border: solid 1px #fff;
 
-.link-container
-  display: flex
-  flex-direction: column
-  align-items: flex-start
-  margin-bottom: .4rem
+  &.not-included {
+    background-color: #555;
+  }
+}
 
-.link-row
-  height: 1.2rem
-  margin: 0 .8rem
-  color: #999
-  cursor: pointer
+.link-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: .4rem;
+}
 
-.link-row:hover
-  color: #000
+.link-row {
+  height: 1.2rem;
+  margin: 0 .8rem;
+  color: #999;
+  cursor: pointer;
+
+  &:hover {
+    color: #000;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/graphs/graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/graph.svelte
@@ -43,17 +43,18 @@ onMount(() => {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
 // zero offsets so that it fills its parent.
-.graph-inner-container
-  position: absolute
-  top: 0
-  left: 0
-  bottom: 0
-  right: 0
+.graph-inner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/graphs/legend.svelte
+++ b/packages/check-ui-shell/src/components/graphs/legend.svelte
@@ -23,30 +23,32 @@ export let graphSpec: BundleGraphSpec
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
 // Use `flex` with a fixed height to accomodate at most two rows of items,
 // with a small amount of vertical padding between the rows.  The negative
 // top margin allows the legend to slide up to cover excessive space left
 // at the bottom of the graph by the chart.js library.
-.legend-container
-  display: flex
-  flex-direction: row
-  flex-wrap: wrap
-  flex: 0 0 3.5rem
-  justify-content: center
-  align-items: center
-  width: 100%
-  margin-top: -.45rem
-  font-family: 'Roboto Condensed'
-  font-weight: 700
-  font-size: 1rem
-  line-height: 1.2
+.legend-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  flex: 0 0 3.5rem;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-top: -.45rem;
+  font-family: 'Roboto Condensed';
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.2;
+}
 
-.legend-item
-  margin: 0 .2rem .1rem .2rem
-  padding: .25rem .6rem .2rem .6rem
-  color: #fff
-  text-align: center
+.legend-item {
+  margin: 0 .2rem .1rem .2rem;
+  padding: .25rem .6rem .2rem .6rem;
+  color: #fff;
+  text-align: center;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -134,73 +134,85 @@ $: if ($simplifyScenarios !== undefined) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.header-container
-  display: flex
-  flex-direction: column
-  box-sizing: border-box
-  width: 100vw
-  padding: 0 1rem
-  color: #aaa
+.header-container {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100vw;
+  padding: 0 1rem;
+  color: #aaa;
+}
 
-.header-content
-  display: flex
-  flex-direction: row
-  margin: .4rem 0
+.header-content {
+  display: flex;
+  flex-direction: row;
+  margin: .4rem 0;
+}
 
-.header-group
-  display: flex
-  flex-direction: row
-  align-items: center
+.header-group {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
 
-.spacer-flex
-  flex: 1
+.spacer-flex {
+  flex: 1;
+}
 
-.spacer-fixed
-  width: 2rem
+.spacer-fixed {
+  width: 2rem;
+}
 
-.icon-button
-  color: #bbb
-  cursor: pointer
+.icon-button {
+  color: #bbb;
+  cursor: pointer;
 
-.icon-button:hover
-  color: #fff
+  &:hover {
+    color: #fff;
+  }
+}
 
-.label:not(:last-child)
-  margin-right: 1rem
+.label:not(:last-child) {
+  margin-right: 1rem;
+}
 
-select
-  margin-right: 1rem
-  font-family: Roboto, sans-serif
-  font-size: 1em
+select {
+  margin-right: 1rem;
+  font-family: Roboto, sans-serif;
+  font-size: 1em;
   // XXX: Remove browser-provided background, but preserve arrow; based on:
   //   https://stackoverflow.com/a/57510283
-  -webkit-appearance: none
-  -moz-appearance: none
-  appearance: none
-  padding: .2rem 1.6rem .2rem .4rem
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>") no-repeat
-  background-size: .8rem
-  background-position: calc(100% - .4rem) 70%
-  background-repeat: no-repeat
-  background-color: #353535
-  border: none
-  border-radius: .4rem
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: .2rem 1.6rem .2rem .4rem;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>") no-repeat;
+  background-size: .8rem;
+  background-position: calc(100% - .4rem) 70%;
+  background-repeat: no-repeat;
+  background-color: #353535;
+  border: none;
+  border-radius: .4rem;
+}
 
-.header-controls
-  display: flex
-  flex-direction: row
-  margin: .4rem 0
-  align-items: center
+.header-controls {
+  display: flex;
+  flex-direction: row;
+  margin: .4rem 0;
+  align-items: center;
+}
 
-input[type=range]
-  width: 10rem
-  margin: 0 .4rem
+input[type=range] {
+  width: 10rem;
+  margin: 0 .4rem;
+}
 
-.line
-  min-height: 1px
-  margin-bottom: 1rem
-  background-color: #555
+.line {
+  min-height: 1px;
+  margin-bottom: 1rem;
+  background-color: #555;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/perf/dot-plot.svelte
+++ b/packages/check-ui-shell/src/components/perf/dot-plot.svelte
@@ -28,45 +28,51 @@ export let colorClass: string
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-$dot-size: .8rem
-$height: 1.4rem
-$line-color: #555
+$dot-size: .8rem;
+$height: 1.4rem;
+$line-color: #555;
 
-.dot-plot-container
-  position: relative
-  width: 100%
-  height: $dot-size * 2
+.dot-plot-container {
+  position: relative;
+  width: 100%;
+  height: $dot-size * 2;
+}
 
-.hline
-  position: absolute
-  left: 0
-  top: $height * 0.5
-  width: 100%
-  height: 1px
-  background-color: $line-color
+.hline {
+  position: absolute;
+  left: 0;
+  top: $height * 0.5;
+  width: 100%;
+  height: 1px;
+  background-color: $line-color;
+}
 
-.vline
-  position: absolute
-  left: 0
-  height: $height
-  width: 1px
+.vline {
+  position: absolute;
+  left: 0;
+  height: $height;
+  width: 1px;
 
-.end-line
-  background-color: $line-color
+  &.end-line {
+    background-color: $line-color;
+  }
 
-.avg-line
-  width: 2px  
-  margin-left: -1px
+  &.avg-line {
+    width: 2px;
+    margin-left: -1px;
+  }
+}
 
-.dot
-  position: absolute
-  top: ($height * 0.5) - ($dot-size * 0.5)
-  width: $dot-size
-  height: $dot-size
-  margin-left: -$dot-size * 0.5
-  border-radius: $dot-size * 0.5
-  opacity: .2
+.dot {
+  position: absolute;
+  top: ($height * 0.5) - ($dot-size * 0.5);
+  width: $dot-size;
+  height: $dot-size;
+  margin-left: -$dot-size * 0.5;
+  border-radius: $dot-size * 0.5;
+  opacity: .2;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/perf/perf.svelte
+++ b/packages/check-ui-shell/src/components/perf/perf.svelte
@@ -80,49 +80,59 @@ function onRun() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.perf-container
-  display: flex
-  flex-direction: column
-  padding: 0 1rem
+.perf-container {
+  display: flex;
+  flex-direction: column;
+  padding: 0 1rem;
+}
 
-.controls-container
-  display: flex
-  flex-direction: column
-  align-items: flex-start
-  height: 3rem
+.controls-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 3rem;
+}
 
-.table-container
-  display: flex
-  flex: 1
+.table-container {
+  display: flex;
+  flex: 1;
+}
 
-table
-  border-collapse: collapse
+table {
+  border-collapse: collapse;
+}
 
-td, th
-  padding-top: .2rem
-  padding-bottom: .2rem
+td, th {
+  padding-top: .2rem;
+  padding-bottom: .2rem;
+}
 
-th
-  color: #aaa
-  text-align: right
-  font-weight: 500
+th {
+  color: #aaa;
+  text-align: right;
+  font-weight: 500;
+}
 
-td
-  width: 4.5rem
-  text-align: right
-  font-family: monospace
+td {
+  width: 4.5rem;
+  text-align: right;
+  font-family: monospace;
 
-td.rownum
-  width: 2rem
+  &.rownum {
+    width: 2rem;
+  }
 
-td.dim
-  color: #777
+  &.dim {
+    color: #777;
+  }
 
-td.plot
-  width: 30rem
-  padding-left: 2rem
-  padding-right: 2rem
+  &.plot {
+    width: 30rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/playground.svelte
+++ b/packages/check-ui-shell/src/components/playground/playground.svelte
@@ -83,69 +83,80 @@ function onNextClicked() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.playground-container
-  display: flex
-  flex-direction: column
-  flex: 1
+.playground-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.scroll-container
-  display: flex
+.scroll-container {
+  display: flex;
   // XXX: We use 1px here for flex-basis, otherwise in Firefox and Chrome the
   // whole page will scroll instead of just this container.  See also:
   //   https://stackoverflow.com/a/52489012
-  flex: 1 1 1px
-  flex-direction: column
-  padding: 0 1rem
-  overflow: auto
+  flex: 1 1 1px;
+  flex-direction: column;
+  padding: 0 1rem;
+  overflow: auto;
+}
 
-.wizard-container
-  display: flex
-  flex-direction: row
+.wizard-container {
+  display: flex;
+  flex-direction: row;
+}
 
-.card-container
-  display: flex
-  flex-direction: column
-  width: 54rem
+.card-container {
+  display: flex;
+  flex-direction: column;
+  width: 54rem;
+}
 
-.spacer-fixed
-  flex: 0 0 1rem
+.spacer-fixed {
+  flex: 0 0 1rem;
+}
 
-.card
-  display: flex
-  padding: 1.5rem
-  background-color: #eee
-  color: #000
-  border-radius: 1rem
-  cursor: pointer
+.card {
+  display: flex;
+  padding: 1.5rem;
+  background-color: #eee;
+  color: #000;
+  border-radius: 1rem;
+  cursor: pointer;
 
-.card.editing
-  cursor: default
+  &.editing {
+    cursor: default;
+  }
+}
 
-.button-row
-  display: flex
-  justify-content: flex-end
+.button-row {
+  display: flex;
+  justify-content: flex-end;
+}
 
-.next-button
-  border-radius: .5rem
-  margin-top: 1.5rem
-  margin-bottom: 1rem
-  padding: .625rem 2rem
-  background-color: #007700
-  color: #fff
-  cursor: pointer
-  user-select: none
+.next-button {
+  border-radius: .5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  padding: .625rem 2rem;
+  background-color: #007700;
+  color: #fff;
+  cursor: pointer;
+  user-select: none;
 
-.next-button:hover
-  background-color: #008800
+  &:hover {
+    background-color: #008800;
+  }
+}
 
-.graph-container
-  display: flex
-  flex-direction: column
-  width: 42rem
-  margin-left: 1rem
-  padding-top: 2rem
-  align-items: center
+.graph-container {
+  display: flex;
+  flex-direction: column;
+  width: 42rem;
+  margin-left: 1rem;
+  padding-top: 2rem;
+  align-items: center;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/search-list.svelte
+++ b/packages/check-ui-shell/src/components/playground/search-list.svelte
@@ -81,38 +81,44 @@ function onItemClicked(item: ListItemViewModel) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-input
-  height: 1.7rem
-  font-size: inherit
-  border: 1px solid #aaa
-  outline: none
+input {
+  height: 1.7rem;
+  font-size: inherit;
+  border: 1px solid #aaa;
+  outline: none;
 
-input:focus
-  border-color: blue
+  &:focus {
+    border-color: blue;
+  }
+}
 
-.items
-  display: flex
-  flex-direction: column
-  min-height: 8rem
-  max-height: 8rem
-  overflow-y: auto
-  background-color: #fff
+.items {
+  display: flex;
+  flex-direction: column;
+  min-height: 8rem;
+  max-height: 8rem;
+  overflow-y: auto;
+  background-color: #fff;
+}
 
-.item
-  display: flex
-  align-items: center
-  min-height: 1.6rem
-  padding: 0 .4rem
-  background-color: #fff
-  cursor: pointer
-  user-select: none
+.item {
+  display: flex;
+  align-items: center;
+  min-height: 1.6rem;
+  padding: 0 .4rem;
+  background-color: #fff;
+  cursor: pointer;
+  user-select: none;
 
-.item:hover
-  background-color: #ddd
+  &:hover {
+    background-color: #ddd;
+  }
   
-.item.active
-  background-color: #ccccff
+  &.active {
+    background-color: #ccccff;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/sel-list.svelte
+++ b/packages/check-ui-shell/src/components/playground/sel-list.svelte
@@ -30,26 +30,29 @@ function onItemClicked(item: ListItemViewModel) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.items
-  display: flex
-  flex-direction: column
-  overflow-y: auto
+.items {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
 
-.item
-  display: flex
-  align-items: center
-  height: 2rem
-  margin-bottom: .2rem
-  padding: 0 .6rem
-  background-color: #fff
-  border-radius: .4rem
-  border: solid 1px #ccc
-  cursor: pointer
-  user-select: none
+.item {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  margin-bottom: .2rem;
+  padding: 0 .6rem;
+  background-color: #fff;
+  border-radius: .4rem;
+  border: solid 1px #ccc;
+  cursor: pointer;
+  user-select: none;
 
-.item.active
-  background-color: lightblue
+  &.active {
+    background-color: lightblue;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-desc.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-desc.svelte
@@ -73,77 +73,94 @@ const expectation = viewModel.expectation
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.content
-  display: flex
-  flex-direction: column
-  flex: 1
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.icon-wrapper
-  display: flex
-  justify-content: center  
-  width: 1.5rem
-  margin-right: .8rem
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 1.5rem;
+  margin-right: .8rem;
+}
 
-.question
-  display: flex
-  align-items: center
+.question {
+  display: flex;
+  align-items: center;
+}
 
-.answer
-  display: flex
-  flex-direction: row
-  align-items: baseline
-  margin-top: 1rem
-  margin-left: 3.5rem
+.answer {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  margin-top: 1rem;
+  margin-left: 3.5rem;
+}
 
-input
-  outline: none
-  border: 1px solid #aaa
-  border-radius: .2rem
-  padding: .2rem .3rem
+input {
+  outline: none;
+  border: 1px solid #aaa;
+  border-radius: .2rem;
+  padding: .2rem .3rem;
 
-input:focus
-  border-color: blue
+  &:focus {
+    border-color: blue;
+  }
+}
 
-.desc
-  width: 11rem
+.desc {
+  width: 11rem;
+}
 
-.test
-  width: 25rem
+.test {
+  width: 25rem;
+}
 
-.examples
-  margin-left: 2.3rem
-  opacity: .6
+.examples {
+  margin-left: 2.3rem;
+  opacity: .6;
+}
 
-.header
-  margin-top: 1rem
-  margin-bottom: 0
+.header {
+  margin-top: 1rem;
+  margin-bottom: 0;
+}
 
-ul
-  margin: 0
-  padding-left: 2.5rem
+ul {
+  margin: 0;
+  padding-left: 2.5rem;
+}
 
-li
-  margin: .3rem 0
+li {
+  margin: .3rem 0;
+}
 
-.subject, .expect
-  border-radius: .4rem
-  padding: .08rem .2rem
+.subject, .expect {
+  border-radius: .4rem;
+  padding: .08rem .2rem;
+}
 
-.subject
-  background-color: #ddddff
-  // color: #0000ff
+.subject {
+  background-color: #ddddff;
+  // color: #0000ff;
+}
 
-.expect
-  background-color: #ccddcc
-  // color: #00aa00
+.expect {
+  background-color: #ccddcc;
+  // color: #00aa00;
+}
 
-.should
-  margin: 0 .25rem
+.should {
+  margin: 0 .25rem;
+}
 
-.summary
-  display: flex
-  align-items: center
+.summary {
+  display: flex;
+  align-items: center;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-inputs.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-inputs.svelte
@@ -68,46 +68,54 @@ $: console.log(selectedOption)
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.content
-  display: flex
-  flex-direction: column
-  flex: 1
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.icon-wrapper
-  display: flex
-  justify-content: center
-  width: 1.5rem
-  margin-right: .8rem
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 1.5rem;
+  margin-right: .8rem;
+}
 
-.question
-  display: flex
-  align-items: center
+.question {
+  display: flex;
+  align-items: center;
+}
 
-.answer
-  display: flex
-  flex-direction: column
-  flex: 1
-  margin-top: 1rem
-  margin-left: 3rem
+.answer {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin-top: 1rem;
+  margin-left: 3rem;
+}
 
-.row
-  display: flex
-  flex-direction: column
-  flex: 1
+.row {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-input[type="radio"]
-  margin-right: .4rem
+input[type="radio"] {
+  margin-right: .4rem;
+}
 
-.summary
-  display: flex
-  align-items: center
+.summary {
+  display: flex;
+  align-items: center;
+}
 
-.scenario
-  border-radius: .4rem
-  padding: .08rem .3rem
-  background-color: #ddd
-  font-weight: 700
+.scenario {
+  border-radius: .4rem;
+  padding: .08rem .3rem;
+  background-color: #ddd;
+  font-weight: 700;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-outputs.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-outputs.svelte
@@ -80,64 +80,75 @@ let selectedOption: Option = 'all_outputs'
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.content
-  display: flex
-  flex-direction: column
-  flex: 1
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.icon-wrapper
-  display: flex
-  justify-content: center  
-  width: 1.5rem
-  margin-right: .8rem
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 1.5rem;
+  margin-right: .8rem;
+}
 
-.question
-  display: flex
-  align-items: center
+.question {
+  display: flex;
+  align-items: center;
+}
 
-.answer
-  display: flex
-  flex-direction: column
-  flex: 1
-  margin-top: 1rem
-  margin-left: 3rem
+.answer {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin-top: 1rem;
+  margin-left: 3rem;
+}
 
-.row
-  display: flex
-  flex-direction: column
-  flex: 1
+.row {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-input[type="radio"]
-  margin-right: .4rem
+input[type="radio"] {
+  margin-right: .4rem;
+}
 
-.row-content
-  display: flex
-  flex-direction: row
+.row-content {
+  display: flex;
+  flex-direction: row;
+}
 
-.available-items-container
-  display: flex
-  flex-direction: column
-  width: 20rem
-  margin-top: .4rem
-  margin-left: 2rem
+.available-items-container {
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+  margin-top: .4rem;
+  margin-left: 2rem;
+}
 
-.selected-items-container
-  display: flex
-  flex-direction: column
-  width: 20rem
-  margin-top: .4rem
-  margin-left: 2rem
+.selected-items-container {
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+  margin-top: .4rem;
+  margin-left: 2rem;
+}
 
-.summary
-  display: flex
-  align-items: center
+.summary {
+  display: flex;
+  align-items: center;
+}
 
-.varname
-  border-radius: .4rem
-  padding: .08rem .3rem
-  background-color: #ddd
-  font-weight: 700
+.varname {
+  border-radius: .4rem;
+  padding: .08rem .3rem;
+  background-color: #ddd;
+  font-weight: 700;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-predicates.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-predicates.svelte
@@ -115,60 +115,72 @@ let selectedTimeOption: TimeOption = 'single'
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.content
-  display: flex
-  flex-direction: column
-  flex: 1
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.icon-wrapper
-  display: flex
-  justify-content: center  
-  width: 1.5rem
-  margin-right: .8rem
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 1.5rem;
+  margin-right: .8rem;
+}
 
-.question
-  display: flex
-  align-items: center
+.question {
+  display: flex;
+  align-items: center;
+}
 
-.answer
-  margin-top: 1rem
-  margin-left: 2.3rem
+.answer {
+  margin-top: 1rem;
+  margin-left: 2.3rem;
+}
 
-.ref-intro
-  margin-bottom: .5rem
+.ref-intro {
+  margin-bottom: .5rem;
+}
 
-.row
-  display: flex
-  flex-direction: column
-  flex: 1
-  margin-left: 1.2rem
+.row {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin-left: 1.2rem;
+}
 
-input[type="radio"]
-  margin-right: .4rem
+input[type="radio"] {
+  margin-right: .4rem;
+}
 
-.time-intro
-  margin-top: .8rem
-  margin-bottom: .5rem
+.time-intro {
+  margin-top: .8rem;
+  margin-bottom: .5rem;
+}
 
-input[type="checkbox"]
-  margin-left: 3rem
-  margin-right: .4rem
+input[type="checkbox"] {
+  margin-left: 3rem;
+  margin-right: .4rem;
+}
 
-input[type="number"]
-  width: 4rem
-  margin-left: .3rem
-  margin-right: .4rem
+input[type="number"] {
+  width: 4rem;
+  margin-left: .3rem;
+  margin-right: .4rem;
+}
 
-.summary
-  display: flex
-  align-items: center
+.summary {
+  display: flex;
+  align-items: center;
+}
 
-.varname
-  border-radius: .4rem
-  padding: .08rem .3rem
-  background-color: #ddd
-  font-weight: 700
+.varname {
+  border-radius: .4rem;
+  padding: .08rem .3rem;
+  background-color: #ddd;
+  font-weight: 700;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/stats/stats-table-row.svelte
+++ b/packages/check-ui-shell/src/components/stats/stats-table-row.svelte
@@ -79,47 +79,55 @@ function onShowPerf() {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-td
-  padding: 0
-  height: 1.8rem
+td {
+  padding: 0;
+  height: 1.8rem;
+}
 
-.name
-  padding-right: 3rem
-  max-width: 20rem
-  white-space: nowrap
-  overflow: hidden
-  text-overflow: ellipsis
+.name {
+  padding-right: 3rem;
+  max-width: 20rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-:global(.row-header)
-  color: #aaa
+:global(.row-header) {
+  color: #aaa;
+}
 
-.cell
-  display: flex
-  width: 100%
-  flex-direction: row
-  align-items: baseline
-  font-family: monospace
+.cell {
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  align-items: baseline;
+  font-family: monospace;
 
-.cell.dim
-  color: #777
+  &.dim {
+    color: #777;
+  }
+}
 
-.value
-  flex: 1
-  padding-right: .4rem
-  text-align: right
+.value {
+  flex: 1;
+  padding-right: .4rem;
+  text-align: right;
+}
 
-.change
-  flex: 1
-  padding-left: .4rem
-  text-align: left
-  font-size: .8em
+.change {
+  flex: 1;
+  padding-left: .4rem;
+  text-align: left;
+  font-size: .8em;
+}
 
-.plot
-  width: 12rem
-  padding-left: 2rem
-  padding-right: 2rem
-  cursor: pointer
+.plot {
+  width: 12rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  cursor: pointer;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/stats/stats-table.svelte
+++ b/packages/check-ui-shell/src/components/stats/stats-table.svelte
@@ -41,30 +41,37 @@ export let viewModel: StatsTableViewModel
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-table
-  border-collapse: collapse
+table {
+  border-collapse: collapse;
+}
 
-th
-  color: #aaa
-  text-align: left
-  font-family: Roboto
-  font-weight: 500
+th {
+  color: #aaa;
+  text-align: left;
+  font-family: Roboto;
+  font-weight: 500;
 
-th.dim
-  color: #555
+  &.dim {
+    color: #555;
+  }
 
-th:nth-child(2), th:nth-child(3)
-  width: 6rem
+  &:nth-child(2), &:nth-child(3) {
+    width: 6rem;
+  }
 
-th:nth-child(4), th:nth-child(5)
-  width: 10rem
+  &:nth-child(4), &:nth-child(5) {
+    width: 10rem;
+  }
 
-th:nth-child(6)
-  width: 8rem
+  &:nth-child(6) {
+    width: 8rem;
+  }
 
-th:nth-child(7), th:nth-child(8)
-  width: 8rem
+  &:nth-child(7), &:nth-child(8) {
+    width: 8rem;
+  }
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/summary/summary.svelte
+++ b/packages/check-ui-shell/src/components/summary/summary.svelte
@@ -44,30 +44,34 @@ const selectedTabId = viewModel.tabBarViewModel.selectedItemId
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.summary-container
-  display: flex
-  flex-direction: column
-  flex: 1
+.summary-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
-.scroll-container
-  position: relative
-  display: flex
+.scroll-container {
+  position: relative;
+  display: flex;
   // XXX: We use 1px here for flex-basis, otherwise in Firefox and Chrome the
   // whole page will scroll instead of just this container.  See also:
   //   https://stackoverflow.com/a/52489012
-  flex: 1 1 1px
-  flex-direction: column
-  padding: 0 1rem
-  overflow: auto
+  flex: 1 1 1px;
+  flex-direction: column;
+  padding: 0 1rem;
+  overflow: auto;
+}
 
-.header-container
-  margin-bottom: 1rem
+.header-container {
+  margin-bottom: 1rem;
+}
 
-.line
-  min-height: 1px
-  margin-bottom: .5rem
-  background-color: #555
+.line {
+  min-height: 1px;
+  margin-bottom: .5rem;
+  background-color: #555;
+}
 
 </style>

--- a/packages/check-ui-shell/src/components/summary/tab-bar.svelte
+++ b/packages/check-ui-shell/src/components/summary/tab-bar.svelte
@@ -54,46 +54,52 @@ function onKeyDown(event: KeyboardEvent) {
 
 
 <!-- STYLE -->
-<style lang='sass'>
+<style lang='scss'>
 
-.tab-bar
-  position: sticky
-  top: 0
-  display: flex
-  flex-direction: row
-  gap: 3rem
-  background-color: #272727
-  z-index: 1000
+.tab-bar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 3rem;
+  background-color: #272727;
+  z-index: 1000;
   // XXX: Use negative margin to make the shadow stretch all the way
   // across, then use extra padding to compensate
-  margin: 0 -1rem
-  padding: 0 1rem
-  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.8)
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.8);
+}
 
-.tab-item
-  display: flex
-  flex-direction: column
-  padding: .5rem 3rem .3rem 0
-  cursor: pointer
-  opacity: 0.7
-  border-bottom: solid 1px transparent
+.tab-item {
+  display: flex;
+  flex-direction: column;
+  padding: .5rem 3rem .3rem 0;
+  cursor: pointer;
+  opacity: 0.7;
+  border-bottom: solid 1px transparent;
 
-.tab-item:hover
-  opacity: 1.0
+  &:hover {
+    opacity: 1.0;
+  }
 
-.tab-item.selected
-  opacity: 1.0
-  border-bottom: solid 1px #555
+  &.selected {
+    opacity: 1.0;
+    border-bottom: solid 1px #555;
+  }
+}
 
-.tab-title
-  font-size: 1.6rem
-  font-weight: 700
-  color: #fff
-  margin-bottom: .2rem
-  cursor: pointer
+.tab-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: .2rem;
+  cursor: pointer;
+}
 
-.tab-subtitle
-  font-size: 1rem
-  font-weight: 400
+.tab-subtitle {
+  font-size: 1rem;
+  font-weight: 400;
+}
 
 </style>


### PR DESCRIPTION
Fixes #650 

See issue for details. This only affects the check-ui-shell package; no impact on other packages. This was largely completed by an LLM.  It got one detail wrong but I fixed that by hand; the rest looked as expected.  I used the sample-check-app to verify that things look the same as before.
