### PR TITLE
build: apply Prettier formatting to Svelte files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,11 @@
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
+  "svelteSortOrder": "options-scripts-markup-styles",
+  "svelteIndentScriptAndStyle": false,
+  "svelteStrictMode": false,
+  "svelteAllowShorthand": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,6 @@
   "[svelte]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "prettier.documentSelectors": ["examples/template-svelte/packages/app/**/*.svelte"],
   "files.associations": {
     "*.svelte": "svelte"
   }

--- a/examples/house-game/packages/app/.prettierignore
+++ b/examples/house-game/packages/app/.prettierignore
@@ -1,3 +1,2 @@
 public
 src/model/generated
-**/*.svelte

--- a/examples/house-game/packages/app/src/app.svelte
+++ b/examples/house-game/packages/app/src/app.svelte
@@ -1,6 +1,5 @@
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import './global.css'
 
 import Assumptions from './components/assumptions/assumptions.svelte'
@@ -22,15 +21,9 @@ function onReset() {
 function onContinue() {
   viewModel.nextStep()
 }
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="app-container">
   <div class="left-container">
     <div class="text-container">
@@ -56,20 +49,14 @@ function onContinue() {
   <div class="right-container">
     <div class="column">
       <div class="graph-container">
-        <Graph viewModel={viewModel.supplyGraphViewModel} width={500} height={400}/>
+        <Graph viewModel={viewModel.supplyGraphViewModel} width={500} height={400} />
       </div>
     </div>
   </div>
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .app-container {
   display: flex;
   flex-direction: row;
@@ -183,5 +170,4 @@ button {
 .cell-value {
   max-width: 40px;
 }
-
 </style>

--- a/examples/house-game/packages/app/src/components/assumptions/assumptions.svelte
+++ b/examples/house-game/packages/app/src/components/assumptions/assumptions.svelte
@@ -1,18 +1,11 @@
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { AssumptionsViewModel } from './assumptions-vm'
 
 export let viewModel: AssumptionsViewModel
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="assumptions-title">Assumptions</div>
 <div class="assumption-rows">
   {#each viewModel.rows as row (row.label)}
@@ -23,14 +16,8 @@ export let viewModel: AssumptionsViewModel
   {/each}
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .assumptions-title {
   font-weight: 700;
   margin-bottom: 12px;
@@ -54,5 +41,4 @@ export let viewModel: AssumptionsViewModel
     margin-bottom: 12px;
   }
 }
-
 </style>

--- a/examples/house-game/packages/app/src/components/graph/graph.svelte
+++ b/examples/house-game/packages/app/src/components/graph/graph.svelte
@@ -1,6 +1,5 @@
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { onMount } from 'svelte'
 
 import type { GraphViewModel } from './graph-vm'
@@ -58,25 +57,13 @@ onMount(() => {
     graphView = undefined
   }
 })
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="graph-inner-container" bind:this={container} style={containerStyle} />
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
@@ -88,5 +75,4 @@ onMount(() => {
   bottom: 0;
   right: 0;
 }
-
 </style>

--- a/examples/sample-check-app/.prettierignore
+++ b/examples/sample-check-app/.prettierignore
@@ -1,3 +1,2 @@
 public
 suite-summary.json
-**/*.svelte

--- a/examples/template-svelte/packages/app/package.json
+++ b/examples/template-svelte/packages/app/package.json
@@ -26,7 +26,7 @@
     "@types/chart.js": "^2.9.34",
     "postcss": "^8.4.41",
     "prettier": "^3.6.2",
-    "prettier-plugin-svelte": "^3.3.3",
+    "prettier-plugin-svelte": "^3.4.0",
     "sass": "^1.77.8",
     "svelte": "^4.2.19",
     "svelte-check": "^3.8.6",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "glob": "^8.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.6.2",
+    "prettier-plugin-svelte": "^3.4.0",
     "tsup": "^8.2.4",
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",

--- a/packages/check-ui-shell/.prettierignore
+++ b/packages/check-ui-shell/.prettierignore
@@ -1,4 +1,3 @@
 dist
 docs
-**/*.svelte
 CHANGELOG.md

--- a/packages/check-ui-shell/src/app-shell.svelte
+++ b/packages/check-ui-shell/src/app-shell.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import App from './app.svelte'
 import type { AppViewModel } from './app-vm'
 
@@ -11,11 +10,7 @@ import type { AppViewModel } from './app-vm'
 import './global.css'
 
 export let appViewModel: AppViewModel
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 {#if appViewModel}

--- a/packages/check-ui-shell/src/app.svelte
+++ b/packages/check-ui-shell/src/app.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import FontFaceObserver from 'fontfaceobserver'
 
 import type { ComparisonGroupingKind } from './components/compare/_shared/comparison-grouping-kind'
@@ -92,7 +91,11 @@ function onCommand(event: CustomEvent) {
     case 'show-comparison-detail-for-previous':
     case 'show-comparison-detail-for-next': {
       const delta = cmd === 'show-comparison-detail-for-previous' ? -1 : +1
-      const adjacent = viewModel.createCompareDetailViewModelForSummaryRowWithDelta(cmdObj.kind, cmdObj.summaryRowKey, delta)
+      const adjacent = viewModel.createCompareDetailViewModelForSummaryRowWithDelta(
+        cmdObj.kind,
+        cmdObj.summaryRowKey,
+        delta
+      )
       if (adjacent) {
         compareDetailViewModel = adjacent
         viewMode = 'comparison-detail'
@@ -130,11 +133,7 @@ function onKeyDown(event: KeyboardEvent) {
       break
   }
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <svelte:window on:keydown={onKeyDown} />
@@ -148,9 +147,9 @@ function onKeyDown(event: KeyboardEvent) {
       <div class="progress-container">
         <div class="progress">{$progress}</div>
       </div>
-    {:else if viewMode === "comparison-detail"}
+    {:else if viewMode === 'comparison-detail'}
       <ComparisonDetail on:command={onCommand} viewModel={compareDetailViewModel} />
-    {:else if viewMode === "perf"}
+    {:else if viewMode === 'perf'}
       <Perf on:command={onCommand} viewModel={perfViewModel} />
     {:else}
       <Summary on:command={onCommand} viewModel={viewModel.summaryViewModel} />
@@ -158,12 +157,8 @@ function onKeyDown(event: KeyboardEvent) {
   </div>
 {/await}
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .app-container {
   display: flex;
   flex-direction: column;
@@ -185,5 +180,4 @@ function onKeyDown(event: KeyboardEvent) {
   justify-content: center;
   font-size: 2em;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/_shared/context-menu.svelte
+++ b/packages/check-ui-shell/src/components/_shared/context-menu.svelte
@@ -6,18 +6,15 @@ Based on example code by @dukenmarga from:
 -->
 
 <script context="module" lang="ts">
-
 export interface ContextMenuItem {
   key: string
   displayText: string
   iconClass?: string
   disabled?: boolean
 }
-
 </script>
 
 <script lang="ts">
-
 import { createEventDispatcher } from 'svelte'
 
 import { clickOutside } from './click-outside'
@@ -48,7 +45,6 @@ $: if (initialEvent) {
 function onItemSelected(cmd: string) {
   dispatch('item-selected', cmd)
 }
-
 </script>
 
 {#if showMenu}
@@ -56,10 +52,14 @@ function onItemSelected(cmd: string) {
     <div class="navbar" id="navbar">
       <ul>
         {#each items as item}
-          {#if item.key == "hr"}
-            <hr>
+          {#if item.key == 'hr'}
+            <hr />
           {:else}
-            <li><button class:disabled={item.disabled === true} on:click={() => onItemSelected(item.key)}><i class={item.iconClass}></i>{item.displayText}</button></li>
+            <li>
+              <button class:disabled={item.disabled === true} on:click={() => onItemSelected(item.key)}
+                ><i class={item.iconClass}></i>{item.displayText}</button
+              >
+            </li>
           {/if}
         {/each}
       </ul>

--- a/packages/check-ui-shell/src/components/_shared/lazy.svelte
+++ b/packages/check-ui-shell/src/components/_shared/lazy.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c)2020-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { onMount } from 'svelte'
 
 export let visible = false
@@ -33,29 +32,32 @@ onMount(() => {
   }
 
   // Wait for the container to become visible before loading the child component
-  let observer = new IntersectionObserver(entries => {
-    const intersecting = entries[0].isIntersecting
-    if (intersecting && !visible) {
-      // Show the child component when the container comes into view
-      visible = true
-    } else if (!intersecting && visible) {
-      // Hide the child component when the container goes out of view
-      visible = false
+  let observer = new IntersectionObserver(
+    entries => {
+      const intersecting = entries[0].isIntersecting
+      if (intersecting && !visible) {
+        // Show the child component when the container comes into view
+        visible = true
+      } else if (!intersecting && visible) {
+        // Hide the child component when the container goes out of view
+        visible = false
+      }
+    },
+    {
+      // Use the scroll container for visibility checking
+      root: rootContainer,
+      // XXX: For now, increase the size of the root bounds so that items are loaded
+      // before they become fully visible.  We use 200% for the right/bottom margins
+      // so that up to two "viewports" worth of items are loaded before scrolling
+      // down or to the right, and we use 100% for the others so that up to one
+      // "viewport" is loaded before scrolling up or to the left.  This means that
+      // we potentially keep more items in memory than strictly necessary, which
+      // may have memory pressure implications, but it is much more efficient than
+      // not using the lazy component at all, and provides a better UX (less flashing)
+      // compared to the default `rootMargin`.
+      rootMargin: '100% 200% 200% 100%'
     }
-  }, {
-    // Use the scroll container for visibility checking
-    root: rootContainer,
-    // XXX: For now, increase the size of the root bounds so that items are loaded
-    // before they become fully visible.  We use 200% for the right/bottom margins
-    // so that up to two "viewports" worth of items are loaded before scrolling
-    // down or to the right, and we use 100% for the others so that up to one
-    // "viewport" is loaded before scrolling up or to the left.  This means that
-    // we potentially keep more items in memory than strictly necessary, which
-    // may have memory pressure implications, but it is much more efficient than
-    // not using the lazy component at all, and provides a better UX (less flashing)
-    // compared to the default `rootMargin`.
-    rootMargin: '100% 200% 200% 100%'
-  })
+  )
   observer.observe(container)
 
   if (syncInit) {
@@ -72,11 +74,7 @@ onMount(() => {
     observer.disconnect()
   }
 })
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="lazy-container" bind:this={container}>
@@ -85,16 +83,11 @@ onMount(() => {
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .lazy-container {
   position: relative;
   display: flex;
   height: 100%;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/_shared/selector.svelte
+++ b/packages/check-ui-shell/src/components/_shared/selector.svelte
@@ -4,8 +4,7 @@
 <!-- svelte-ignore a11y-no-onchange -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { get } from 'svelte/store'
 
 import type { SelectorViewModel } from './selector-vm'
@@ -19,11 +18,7 @@ function onChange() {
   // `change` event is emitted, so it reflects the current value here.
   viewModel.onUserChange?.(get(selectedValue))
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <select bind:value={$selectedValue} on:change={onChange}>
@@ -34,12 +29,8 @@ function onChange() {
   {/each}
 </select>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 select {
   width: auto;
   font-family: inherit;
@@ -52,7 +43,9 @@ select {
   border: 1px solid #ccc;
   border-radius: 0;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition:
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
   text-transform: none;
 
   > option {
@@ -61,5 +54,4 @@ select {
     font-family: 'Roboto Condensed', Helvetica, sans-serif;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.svelte
@@ -1,9 +1,7 @@
-
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import Lazy from '../../_shared/lazy.svelte'
 import ComparisonGraph from '../../graphs/comparison-graph.svelte'
 import type { CheckSummaryGraphBoxViewModel } from './check-summary-graph-box-vm'
@@ -28,14 +26,10 @@ $: if (visible !== previousVisible || viewModel.baseRequestKey !== previousViewM
     viewModel.requestData()
   }
 }
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<Lazy bind:visible={visible}>
+<Lazy bind:visible>
   {#if $content}
     <div class="graph-container">
       <ComparisonGraph viewModel={$content.comparisonGraphViewModel} />
@@ -43,20 +37,15 @@ $: if (visible !== previousVisible || viewModel.baseRequestKey !== previousViewM
   {/if}
 </Lazy>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .graph-container {
   position: relative;
   display: flex;
   width: 36rem;
   height: 22rem;
   margin-left: 1rem;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
   margin-bottom: 1rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-row.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-row.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import CheckGraphBox from './check-summary-graph-box.svelte'
 import type { CheckSummaryRowViewModel } from './check-summary-row-vm'
 
@@ -12,11 +11,7 @@ const graphVisible = viewModel.graphVisible
 function onLabelClicked() {
   graphVisible.update(v => !v)
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class={`row ${viewModel.rowClasses}`}>
@@ -28,15 +23,10 @@ function onLabelClicked() {
   </div>
 {/if}
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .check-graph {
   height: 23rem;
   margin-left: 8.5rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-test.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-test.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import SummaryRow from './check-summary-row.svelte'
 import type { CheckSummaryTestViewModel } from './check-summary-test-vm'
 
@@ -12,15 +11,13 @@ const expandAll = viewModel.expandAll
 function onTestClicked() {
   expandAll.update(v => !v)
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="row test">
-  <span class="label" on:click={onTestClicked}>{@html viewModel.testRow.span}{$expandAll || viewModel.testRow.status !== 'passed' ? ':' : ''}</span>
+  <span class="label" on:click={onTestClicked}
+    >{@html viewModel.testRow.span}{$expandAll || viewModel.testRow.status !== 'passed' ? ':' : ''}</span
+  >
 </div>
 <div class="test-rows" class:expand-all={$expandAll}>
   {#each viewModel.childRows as row}

--- a/packages/check-ui-shell/src/components/check/summary/check-summary.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { CheckSummaryViewModel } from './check-summary-vm'
 import CheckSummaryTest from './check-summary-test.svelte'
 
@@ -12,11 +11,7 @@ export let viewModel: CheckSummaryViewModel
 // tabs, that is less useful, so always show them
 // let showCheckDetail = viewModel.total > 0 && viewModel.total !== viewModel.passed
 const showCheckDetail = true
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="check-summary-container">
@@ -72,12 +67,8 @@ const showCheckDetail = true
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 $indent: 1rem;
 
 .check-summary-container {
@@ -118,7 +109,7 @@ $indent: 1rem;
   }
 
   :global(.row.test) {
-    margin-top: .4rem;
+    margin-top: 0.4rem;
   }
 
   :global(.row.test > .label) {
@@ -137,7 +128,7 @@ $indent: 1rem;
     color: #777;
   }
 
-  :global(.row.predicate > .label ){
+  :global(.row.predicate > .label) {
     cursor: pointer;
   }
 
@@ -153,18 +144,18 @@ $indent: 1rem;
   align-items: baseline;
   align-self: flex-start;
   margin: 2.6rem 0;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 .bar-container {
   display: flex;
   flex-direction: row;
   width: 15rem;
-  height: .8rem;
+  height: 0.8rem;
 }
 
 .bar {
-  height: .8rem;
+  height: 0.8rem;
 
   &.gray {
     background-color: #777;
@@ -172,12 +163,11 @@ $indent: 1rem;
 }
 
 .summary-label {
-  margin-left: .8rem;
+  margin-left: 0.8rem;
   color: #fff;
 }
 
 .sep {
   color: #777;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 
 import Lazy from '../../_shared/lazy.svelte'
@@ -80,11 +79,7 @@ function getMaxDiffSpan(content: CompareDetailBoxContent): string {
   }
   return span
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="detail-box">
@@ -99,7 +94,7 @@ function getMaxDiffSpan(content: CompareDetailBoxContent): string {
     </div>
   {/if}
   <div class="content-container">
-    <Lazy bind:visible={visible}>
+    <Lazy bind:visible>
       {#if $content}
         <div class={`content ${$content.bucketClass}`}>
           <div class="graph-container">
@@ -129,16 +124,12 @@ function getMaxDiffSpan(content: CompareDetailBoxContent): string {
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
-$border-w: .3rem;
+<style lang="scss">
+$border-w: 0.3rem;
 $border-w-2x: $border-w * 2;
 
-$padding-w: .5rem;
+$padding-w: 0.5rem;
 $padding-w-2x: $padding-w * 2;
 
 $stats-h: 4rem;
@@ -174,15 +165,15 @@ $stats-h: 4rem;
 }
 
 .title {
-  margin-left: .7rem;
+  margin-left: 0.7rem;
   font-size: 1.1em;
   font-weight: 700;
 }
 
 .subtitle {
   color: #aaa;
-  margin-left: .4rem;
-  margin-right: .7rem;
+  margin-left: 0.4rem;
+  margin-right: 0.7rem;
 }
 
 .content-container {
@@ -203,7 +194,7 @@ $stats-h: 4rem;
   padding: $padding-w;
   border-width: $border-w;
   border-style: solid;
-  border-radius: .8rem;
+  border-radius: 0.8rem;
 }
 
 .graph-container {
@@ -234,10 +225,10 @@ $stats-h: 4rem;
 }
 
 .data-label {
-  font-size: .9em;
+  font-size: 0.9em;
   color: #aaa;
   min-width: 2rem;
-  margin-right: .4rem;
+  margin-right: 0.4rem;
   text-align: right;
 }
 
@@ -246,5 +237,4 @@ $stats-h: 4rem;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-row.svelte
@@ -1,16 +1,12 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 
 import ContextGraph from '../../graphs/context-graph.svelte'
 
-import type {
-  CompareDetailContextGraphRowViewModel,
-  CompareDetailRowViewModel,
-} from './compare-detail-row-vm'
+import type { CompareDetailContextGraphRowViewModel, CompareDetailRowViewModel } from './compare-detail-row-vm'
 import { createContextGraphRows } from './compare-detail-row-vm'
 import DetailBox from './compare-detail-box.svelte'
 
@@ -57,26 +53,20 @@ function getContextGraphPadding(index: number): number {
 
   if (viewModel.boxes.length > 0) {
     // Calculate the center of the box as a percentage of the width of the row
-    return ((index + 0.5) / (viewModel.boxes.length)) * 100
+    return ((index + 0.5) / viewModel.boxes.length) * 100
   } else {
     return 0
   }
 }
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="detail-row">
   {#if viewModel.title}
     <div class="title-row" on:contextmenu|preventDefault={onContextMenu}>
-      <div class="title">{ @html viewModel.title }</div>
+      <div class="title">{@html viewModel.title}</div>
       {#if viewModel.subtitle}
-        <div class="subtitle">{ @html viewModel.subtitle }</div>
+        <div class="subtitle">{@html viewModel.subtitle}</div>
       {/if}
     </div>
   {/if}
@@ -87,14 +77,20 @@ function getContextGraphPadding(index: number): number {
         <div class="spacer-fixed"></div>
       {/if}
       <div class="box-container" class:dimmed={isDimmed(i, expandedIndex)}>
-        <DetailBox viewModel={boxViewModel} on:toggle-context-graphs={() => onToggleContextGraphs(i)} on:show-context-menu />
+        <DetailBox
+          viewModel={boxViewModel}
+          on:toggle-context-graphs={() => onToggleContextGraphs(i)}
+          on:show-context-menu
+        />
       </div>
     {/each}
   </div>
 
   {#if expandedIndex !== undefined}
     <div class="context-graphs-container">
-      <div style="min-width: max(0%, min(calc({getContextGraphPadding(expandedIndex)}% - 38.75rem), calc(100% - 77.5rem)))"></div>
+      <div
+        style="min-width: max(0%, min(calc({getContextGraphPadding(expandedIndex)}% - 38.75rem), calc(100% - 77.5rem)))"
+      ></div>
       <div class="context-graphs-column">
         {#if contextGraphRows}
           {#each contextGraphRows as rowViewModel}
@@ -110,14 +106,8 @@ function getContextGraphPadding(index: number): number {
   {/if}
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .detail-row {
   display: flex;
   flex-direction: column;
@@ -125,11 +115,11 @@ function getContextGraphPadding(index: number): number {
 
 .title-row {
   align-items: baseline;
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 
 .title {
-  margin-right: .8rem;
+  margin-right: 0.8rem;
   font-size: 1.5em;
   font-weight: 700;
 }
@@ -182,5 +172,4 @@ function getContextGraphPadding(index: number): number {
 .context-graph-spacer {
   min-width: 1.5rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import assertNever from 'assert-never'
 
 import { createEventDispatcher, onMount } from 'svelte'
@@ -177,11 +176,7 @@ onMount(() => {
   // Make the scroll container have focus by default to allow for easier keyboard navigation
   scrollContainer.focus()
 })
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <svelte:window on:keydown={onKeyDown} />
@@ -205,9 +200,9 @@ onMount(() => {
       </div>
       <div class="spacer-flex"></div>
       <div class="nav-links no-selection">
-        <div class="nav-link" on:click={() => onNavLink("detail-previous")}>previous</div>
+        <div class="nav-link" on:click={() => onNavLink('detail-previous')}>previous</div>
         <div class="nav-link-sep">&nbsp;|&nbsp;</div>
-        <div class="nav-link" on:click={() => onNavLink("detail-next")}>next</div>
+        <div class="nav-link" on:click={() => onNavLink('detail-next')}>next</div>
       </div>
     </div>
     {#if relatedItemsVisible && viewModel.relatedItems.length > 0}
@@ -257,17 +252,19 @@ onMount(() => {
         </div>
       {/each}
       <div class="footer"></div>
-      <ContextMenu items={contextMenuItems} parentElem={scrollContent} initialEvent={contextMenuEvent} on:item-selected={onContextMenuItemSelected} on:clickout={onHideContextMenu} />
+      <ContextMenu
+        items={contextMenuItems}
+        parentElem={scrollContent}
+        initialEvent={contextMenuEvent}
+        on:item-selected={onContextMenuItemSelected}
+        on:clickout={onHideContextMenu}
+      />
     </div>
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .compare-detail-container {
   display: flex;
   flex-direction: column;
@@ -282,7 +279,7 @@ onMount(() => {
   width: calc(100vw - 2rem);
   margin: 0 -1rem;
   padding: 0 2rem;
-  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.5);
+  box-shadow: 0 1rem 0.5rem -0.5rem rgba(0, 0, 0, 0.5);
   z-index: 1;
 }
 
@@ -302,7 +299,7 @@ onMount(() => {
 .nav-links {
   display: flex;
   flex-direction: row;
-  font-size: .8em;
+  font-size: 0.8em;
 }
 
 .nav-link-sep {
@@ -324,8 +321,8 @@ onMount(() => {
 }
 
 .pretitle {
-  margin-bottom: .2rem;
-  font-size: .9em;
+  margin-bottom: 0.2rem;
+  font-size: 0.9em;
   font-weight: 700;
   color: #aaa;
 }
@@ -337,7 +334,7 @@ onMount(() => {
 }
 
 .title {
-  margin-bottom: .4rem;
+  margin-bottom: 0.4rem;
   font-size: 2em;
   font-weight: 700;
   cursor: pointer;
@@ -351,22 +348,22 @@ onMount(() => {
 }
 
 .annotations {
-  margin-left: .3rem;
+  margin-left: 0.3rem;
   color: #aaa;
 
   :global(.annotation) {
-    margin: 0 .3rem;
-    padding: .1rem .3rem;
+    margin: 0 0.3rem;
+    padding: 0.1rem 0.3rem;
     background-color: #222;
-    border: .5px solid #555;
-    border-radius: .4rem;
+    border: 0.5px solid #555;
+    border-radius: 0.4rem;
   }
 }
 
 .related {
   font-size: 1em;
   color: #aaa;
-  margin-bottom: .6rem;
+  margin-bottom: 0.6rem;
 
   :global(.related-sep) {
     color: #666;
@@ -374,7 +371,7 @@ onMount(() => {
 }
 
 ul {
-  margin: .1rem 0;
+  margin: 0.1rem 0;
   padding-left: 2rem;
 }
 
@@ -395,7 +392,7 @@ ul {
 .section-title {
   width: calc(100vw - 2rem);
   margin: 1.5rem 1rem 2rem 1rem;
-  padding: .2rem 0;
+  padding: 0.2rem 0;
   border-bottom: solid 1px #555;
   color: #ccc;
   font-size: 1.4em;
@@ -409,7 +406,7 @@ ul {
 .row-container {
   display: flex;
   flex-direction: row;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
   margin-bottom: 3rem;
   margin-left: 1rem;
   margin-right: 1rem;
@@ -422,5 +419,4 @@ ul {
 .footer {
   height: 1rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-graphs-dataset.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-graphs-dataset.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import DetailBox from './compare-detail-box.svelte'
 
 import type { CompareGraphsDatasetViewModel } from './compare-graphs-dataset-vm'
@@ -20,11 +19,7 @@ const detailBoxVisible = viewModel.detailBoxVisible
 function onDatasetClicked() {
   detailBoxVisible.update(v => !v)
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="dataset-container">
@@ -52,12 +47,8 @@ function onDatasetClicked() {
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .dataset-container {
   display: flex;
   flex: 1;
@@ -68,11 +59,11 @@ function onDatasetClicked() {
   display: flex;
   flex: 1;
   align-items: baseline;
-  margin-left: .6rem;
+  margin-left: 0.6rem;
   cursor: pointer;
 
   &:hover {
-    background-color: rgba(255, 255, 255, .05);
+    background-color: rgba(255, 255, 255, 0.05);
   }
 }
 
@@ -84,8 +75,8 @@ function onDatasetClicked() {
   font-family: 'Roboto Condensed';
   font-weight: 700;
   font-size: 1rem;
-  margin: .2rem .4rem;
-  padding: .25rem .6rem .2rem .6rem;
+  margin: 0.2rem 0.4rem;
+  padding: 0.25rem 0.6rem 0.2rem 0.6rem;
   color: #fff;
   text-align: center;
 }
@@ -93,9 +84,8 @@ function onDatasetClicked() {
 .detail-box-container {
   display: flex;
   flex: 1;
-  margin-top: .2rem;
-  margin-bottom: .8rem;
-  margin-left: .4rem;
+  margin-top: 0.2rem;
+  margin-bottom: 0.8rem;
+  margin-left: 0.4rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-graphs-row.svelte
@@ -1,23 +1,18 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import ContextGraph from '../../graphs/context-graph.svelte'
 import DatasetRow from './compare-graphs-dataset.svelte'
 import type { CompareGraphsRowViewModel } from './compare-graphs-row-vm'
 
 export let viewModel: CompareGraphsRowViewModel
 export let align: 'center' | 'left' = 'center'
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="graphs-row">
-  {#if align === "center"}
+  {#if align === 'center'}
     <div class="spacer-flex"></div>
   {/if}
   <div class="content">
@@ -54,17 +49,13 @@ export let align: 'center' | 'left' = 'center'
       {/if}
     </div>
   </div>
-  {#if align === "center"}
+  {#if align === 'center'}
     <div class="spacer-flex"></div>
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .graphs-row {
   display: flex;
   flex-direction: row;
@@ -96,7 +87,7 @@ export let align: 'center' | 'left' = 'center'
 }
 
 .metadata-header {
-  margin-top: .6rem;
+  margin-top: 0.6rem;
 }
 
 .metadata-row {
@@ -104,7 +95,7 @@ export let align: 'center' | 'left' = 'center'
   flex-direction: row;
 
   &:hover {
-    background-color: rgba(255, 255, 255, .05);
+    background-color: rgba(255, 255, 255, 0.05);
   }
 }
 
@@ -117,8 +108,7 @@ export let align: 'center' | 'left' = 'center'
 
 .metadata-key {
   color: #aaa;
-  font-size: .8em;
+  font-size: 0.8em;
   margin-left: 1rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-pinned.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-pinned.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2024 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 import { type Readable } from 'svelte/store'
 
@@ -18,7 +17,7 @@ const flipDurationMs = 300
 const dispatch = createEventDispatcher()
 
 // Rebuild the local array of pinned items when the source array is changed
-type LocalItem = { id: string, row: ComparisonSummaryRowViewModel }
+type LocalItem = { id: string; row: ComparisonSummaryRowViewModel }
 $: localItems = $rows.map(row => {
   // TODO: This isn't currently used, so not sure if `rowKey` is correct here
   return {
@@ -45,33 +44,26 @@ function onToggleItemPinned(row: ComparisonSummaryRowViewModel): void {
     row
   })
 }
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
-<div class="dnd-section" use:dndzone={{items: localItems, flipDurationMs}} on:consider={onDndConsider} on:finalize={onDndFinalize}>
-  {#each localItems as item(item.id)}
-    <div class="dnd-item" animate:flip={{duration: flipDurationMs}}>
-      <SummaryRow viewModel={item.row} on:toggle-item-pinned={() => onToggleItemPinned(item.row)} on:command/>
+<div
+  class="dnd-section"
+  use:dndzone={{ items: localItems, flipDurationMs }}
+  on:consider={onDndConsider}
+  on:finalize={onDndFinalize}
+>
+  {#each localItems as item (item.id)}
+    <div class="dnd-item" animate:flip={{ duration: flipDurationMs }}>
+      <SummaryRow viewModel={item.row} on:toggle-item-pinned={() => onToggleItemPinned(item.row)} on:command />
     </div>
   {/each}
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .dnd-section {
-  padding: .2rem 0;
+  padding: 0.2rem 0;
 }
 
 .dnd-item {
@@ -79,5 +71,4 @@ function onToggleItemPinned(row: ComparisonSummaryRowViewModel): void {
   width: fit-content;
   background-color: #272727;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-row.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 
 import type { ComparisonSummaryRowViewModel } from './comparison-summary-row-vm'
@@ -24,11 +23,7 @@ function onLinkClicked() {
 // function onTogglePinned() {
 //   dispatch('toggle-item-pinned')
 // }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="summary-row">
@@ -60,12 +55,8 @@ function onLinkClicked() {
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 $bar-width: 15rem;
 
 .summary-row {
@@ -73,11 +64,11 @@ $bar-width: 15rem;
   flex-direction: row;
   flex: 0 0 auto;
   align-items: flex-end;
-  margin: .2rem 0;
-  opacity: .8;
+  margin: 0.2rem 0;
+  opacity: 0.8;
 
   &:hover {
-    opacity: 1.0;
+    opacity: 1;
   }
 }
 
@@ -85,24 +76,30 @@ $bar-width: 15rem;
   display: flex;
   flex-direction: row;
   width: $bar-width;
-  height: .8rem;
-  margin-bottom: .25rem;
+  height: 0.8rem;
+  margin-bottom: 0.25rem;
   cursor: pointer;
 }
 
 .bar {
-  height: .8rem;
+  height: 0.8rem;
 
   &.striped {
     width: 100%;
-    background: repeating-linear-gradient(-45deg, goldenrod, goldenrod .4rem, darkgoldenrod .4rem, darkgoldenrod 1rem);
+    background: repeating-linear-gradient(
+      -45deg,
+      goldenrod,
+      goldenrod 0.4rem,
+      darkgoldenrod 0.4rem,
+      darkgoldenrod 1rem
+    );
   }
 }
 
 .title-container {
   display: flex;
   flex-direction: column;
-  margin-left: .8rem;
+  margin-left: 0.8rem;
 }
 
 // .grouping-part {
@@ -122,8 +119,8 @@ $bar-width: 15rem;
 }
 
 .subtitle {
-  font-size: .8em;
-  margin-left: .6rem;
+  font-size: 0.8em;
+  margin-left: 0.6rem;
   color: #aaa;
   cursor: pointer;
 }
@@ -135,17 +132,16 @@ $bar-width: 15rem;
 // }
 
 .annotations {
-  font-size: .8em;
-  margin-left: .3rem;
+  font-size: 0.8em;
+  margin-left: 0.3rem;
   color: #aaa;
 
   :global(.annotation) {
-    margin: 0 .3rem;
-    padding: .1rem .3rem;
+    margin: 0 0.3rem;
+    padding: 0.1rem 0.3rem;
     background-color: #1c1c1c;
-    border: .5px solid #555;
-    border-radius: .4rem;
+    border: 0.5px solid #555;
+    border-radius: 0.4rem;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-section.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-section.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import SummaryRow from './comparison-summary-row.svelte'
 import type { ComparisonSummarySectionViewModel } from './comparison-summary-section-vm'
 
@@ -12,19 +11,14 @@ const expanded = viewModel.expanded
 function onHeaderClicked() {
   expanded.update(value => !value)
 }
-
 </script>
 
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="section-container">
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div class="header-row {$expanded ? 'expanded' : 'collapsed'}" on:click={onHeaderClicked}>
     <div class="header-bar"></div>
-    <div class="header-title">{ @html viewModel.header.title }</div>
+    <div class="header-title">{@html viewModel.header.title}</div>
     {#if viewModel.rowsWithDiffs > 0}
       <div class="header-count">{viewModel.rowsWithDiffs}</div>
     {/if}
@@ -36,14 +30,8 @@ function onHeaderClicked() {
   {/if}
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // TODO: Share with comparison-summary-row
 $bar-width: 15rem;
 
@@ -60,7 +48,7 @@ $bar-width: 15rem;
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin: .4rem 0;
+  margin: 0.4rem 0;
   cursor: pointer;
 
   &.collapsed {
@@ -80,18 +68,17 @@ $bar-width: 15rem;
 }
 
 .header-title {
-  margin-left: .8rem;
+  margin-left: 0.8rem;
   color: #fff;
   font-size: 1.2em;
 }
 
 .header-count {
-  margin-left: .5rem;
-  padding: .1rem .5rem;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.5rem;
   border-radius: 1rem;
-  background-color: rgba(255, 165, 0, .7);
+  background-color: rgba(255, 165, 0, 0.7);
   color: #eee;
-  font-size: .85em;
+  font-size: 0.85em;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary-toc.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary-toc.svelte
@@ -2,20 +2,15 @@
 
 <!-- SCRIPT -->
 <script lang="ts">
-
 import type { ComparisonSummarySectionViewModel } from './comparison-summary-section-vm'
 
 export let sections: ComparisonSummarySectionViewModel[]
 
 // Only show sections that have differences
 $: visibleSections = sections.filter(section => section.rowsWithDiffs > 0)
-
 </script>
 
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="toc-container">
   <div class="toc-title">Groups with differences</div>
   <div class="toc-entries">
@@ -31,11 +26,6 @@ $: visibleSections = sections.filter(section => section.rowsWithDiffs > 0)
     {/if}
   </div>
 </div>
-
-</template>
-
-
-
 
 <!-- STYLE -->
 <style lang="sass">

--- a/packages/check-ui-shell/src/components/compare/summary/comparison-summary.svelte
+++ b/packages/check-ui-shell/src/components/compare/summary/comparison-summary.svelte
@@ -1,22 +1,15 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import ComparisonSummarySection from './comparison-summary-section.svelte'
 import ComparisonSummaryToc from './comparison-summary-toc.svelte'
 import type { ComparisonSummaryViewModel } from './comparison-summary-vm'
 
 export let viewModel: ComparisonSummaryViewModel
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<template>
-
 <div class="comparison-summary-container">
   <!-- TODO: Add an option to show the TOC -->
   {#if viewModel.kind === ''}
@@ -30,14 +23,8 @@ export let viewModel: ComparisonSummaryViewModel
   <div class="footer"></div>
 </div>
 
-</template>
-
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .comparison-summary-container {
   display: flex;
   flex-direction: column;
@@ -58,5 +45,4 @@ export let viewModel: ComparisonSummaryViewModel
 .footer {
   flex: 0 0 1rem;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/comparison-graph.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c)2020-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { onMount } from 'svelte'
 
 import type { ComparisonGraphViewModel } from './comparison-graph-vm'
@@ -53,21 +52,13 @@ onMount(() => {
     graphView = undefined
   }
 })
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="graph-inner-container" bind:this={container}></div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
@@ -79,5 +70,4 @@ onMount(() => {
   bottom: 0;
   right: 0;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/graphs/context-graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/context-graph.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import assertNever from 'assert-never'
 import copyToClipboard from 'copy-text-to-clipboard'
 
@@ -54,22 +53,18 @@ function onLinkClicked(linkItem: LinkItem) {
       assertNever(linkItem.kind)
   }
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="context-graph-container">
   {#if viewModel.graphSpec}
     <div class="graph-and-info">
-      <div class="graph-title" class:dataset-color-0={viewModel.datasetClass === 'dataset-color-0'} class:dataset-color-1={viewModel.datasetClass === 'dataset-color-1'}>
+      <div class={`graph-title ${viewModel.datasetClass}`}>
         {@html viewModel.graphSpec.title}
       </div>
       {#if viewModel.requestKey}
         <div class="graph-container">
-          <Lazy bind:visible={visible}>
+          <Lazy bind:visible>
             {#if $content && $content.graphData}
               <Graph viewModel={$content.graphData} config={graphConfig} />
             {/if}
@@ -86,24 +81,20 @@ function onLinkClicked(linkItem: LinkItem) {
       {:else}
         <div class="message not-shown">
           <span>Graph not shown: scenario is invalid in&nbsp;</span>
-          <span class:dataset-color-0={viewModel.datasetClass === 'dataset-color-0'} class:dataset-color-1={viewModel.datasetClass === 'dataset-color-1'}>{viewModel.bundleName}</span>
+          <span class={viewModel.datasetClass}>{viewModel.bundleName}</span>
         </div>
       {/if}
     </div>
   {:else}
     <div class="message not-included">
       <span>Graph not included in&nbsp;</span>
-      <span class:dataset-color-0={viewModel.datasetClass === 'dataset-color-0'} class:dataset-color-1={viewModel.datasetClass === 'dataset-color-1'}>{viewModel.bundleName}</span>
+      <span class={viewModel.datasetClass}>{viewModel.bundleName}</span>
     </div>
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // The graph columns have a fixed width of 38rem (38% of app width);
 // this needs to match the `graphConfig.width` value above
 $graph-width: 38rem;
@@ -123,8 +114,8 @@ $graph-height: 20rem;
 }
 
 .graph-title {
-  margin: .5rem 0;
-  padding: 0 .8rem;
+  margin: 0.5rem 0;
+  padding: 0 0.8rem;
   font-family: 'Roboto Condensed';
   font-size: 1.55rem;
 }
@@ -154,12 +145,12 @@ $graph-height: 20rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-bottom: .4rem;
+  margin-bottom: 0.4rem;
 }
 
 .link-row {
   height: 1.2rem;
-  margin: 0 .8rem;
+  margin: 0 0.8rem;
   color: #999;
   cursor: pointer;
 
@@ -167,5 +158,4 @@ $graph-height: 20rem;
     color: #000;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/graphs/graph.svelte
+++ b/packages/check-ui-shell/src/components/graphs/graph.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c)2020-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { onMount } from 'svelte'
 import type { BundleGraphData, BundleGraphView } from '@sdeverywhere/check-core'
 import type { GraphViewConfig } from './graph-view-config'
@@ -28,23 +27,15 @@ onMount(() => {
     graphView = undefined
   }
 })
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="graph-inner-container" style={containerStyle}>
   <canvas bind:this={canvas}></canvas>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // This container is set up to allow for automatic responsive sizing
 // by Chart.js.  For this to work, we need the canvas element to have
 // this parent container with `position: absolute` and configured with
@@ -56,5 +47,4 @@ onMount(() => {
   bottom: 0;
   right: 0;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/graphs/legend.svelte
+++ b/packages/check-ui-shell/src/components/graphs/legend.svelte
@@ -1,16 +1,11 @@
 <!-- Copyright (c)2020-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { BundleGraphSpec } from '@sdeverywhere/check-core'
 
 export let graphSpec: BundleGraphSpec
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="legend-container">
@@ -19,12 +14,8 @@ export let graphSpec: BundleGraphSpec
   {/each}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 // Use `flex` with a fixed height to accomodate at most two rows of items,
 // with a small amount of vertical padding between the rows.  The negative
 // top margin allows the legend to slide up to cover excessive space left
@@ -37,7 +28,7 @@ export let graphSpec: BundleGraphSpec
   justify-content: center;
   align-items: center;
   width: 100%;
-  margin-top: -.45rem;
+  margin-top: -0.45rem;
   font-family: 'Roboto Condensed';
   font-weight: 700;
   font-size: 1rem;
@@ -45,10 +36,9 @@ export let graphSpec: BundleGraphSpec
 }
 
 .legend-item {
-  margin: 0 .2rem .1rem .2rem;
-  padding: .25rem .6rem .2rem .6rem;
+  margin: 0 0.2rem 0.1rem 0.2rem;
+  padding: 0.25rem 0.6rem 0.2rem 0.6rem;
   color: #fff;
   text-align: center;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/header/header.svelte
+++ b/packages/check-ui-shell/src/components/header/header.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 import Icon from 'svelte-awesome/components/Icon.svelte'
 import { faCog, faHome } from '@fortawesome/free-solid-svg-icons'
@@ -55,11 +54,7 @@ $: if ($simplifyScenarios !== undefined) {
     document.dispatchEvent(new CustomEvent('sde-check-simplify-scenarios-toggled'))
   }
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="header-container">
@@ -130,12 +125,8 @@ $: if ($simplifyScenarios !== undefined) {
   <div class="line"></div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .header-container {
   display: flex;
   flex-direction: column;
@@ -148,7 +139,7 @@ $: if ($simplifyScenarios !== undefined) {
 .header-content {
   display: flex;
   flex-direction: row;
-  margin: .4rem 0;
+  margin: 0.4rem 0;
 }
 
 .header-group {
@@ -187,26 +178,27 @@ select {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding: .2rem 1.6rem .2rem .4rem;
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>") no-repeat;
-  background-size: .8rem;
-  background-position: calc(100% - .4rem) 70%;
+  padding: 0.2rem 1.6rem 0.2rem 0.4rem;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23555'><polygon points='0,0 100,0 50,60'/></svg>")
+    no-repeat;
+  background-size: 0.8rem;
+  background-position: calc(100% - 0.4rem) 70%;
   background-repeat: no-repeat;
   background-color: #353535;
   border: none;
-  border-radius: .4rem;
+  border-radius: 0.4rem;
 }
 
 .header-controls {
   display: flex;
   flex-direction: row;
-  margin: .4rem 0;
+  margin: 0.4rem 0;
   align-items: center;
 }
 
-input[type=range] {
+input[type='range'] {
   width: 10rem;
-  margin: 0 .4rem;
+  margin: 0 0.4rem;
 }
 
 .line {
@@ -214,5 +206,4 @@ input[type=range] {
   margin-bottom: 1rem;
   background-color: #555;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/perf/dot-plot.svelte
+++ b/packages/check-ui-shell/src/components/perf/dot-plot.svelte
@@ -1,17 +1,12 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { DotPlotViewModel } from './dot-plot-vm'
 
 export let viewModel: DotPlotViewModel
 export let colorClass: string
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="dot-plot-container">
@@ -19,18 +14,14 @@ export let colorClass: string
   <div class="vline end-line" style="left: 0;"></div>
   <div class="vline end-line" style="left: 100%;"></div>
   {#each viewModel.points as point}
-    <div class="dot" class:dataset-bg-0={colorClass === 'dataset-bg-0'} class:dataset-bg-1={colorClass === 'dataset-bg-1'} style="left: {point}%;"></div>
+    <div class={`dot ${colorClass}`} style="left: {point}%;"></div>
   {/each}
-  <div class="vline avg-line" class:dataset-bg-0={colorClass === 'dataset-bg-0'} class:dataset-bg-1={colorClass === 'dataset-bg-1'} style="left: {viewModel.avgPoint}%;"></div>
+  <div class={`vline avg-line ${colorClass}`} style="left: {viewModel.avgPoint}%;"></div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
-$dot-size: .8rem;
+<style lang="scss">
+$dot-size: 0.8rem;
 $height: 1.4rem;
 $line-color: #555;
 
@@ -72,7 +63,6 @@ $line-color: #555;
   height: $dot-size;
   margin-left: -$dot-size * 0.5;
   border-radius: $dot-size * 0.5;
-  opacity: .2;
+  opacity: 0.2;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/perf/perf.svelte
+++ b/packages/check-ui-shell/src/components/perf/perf.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { PerfRunner } from '@sdeverywhere/check-core'
 
 import DotPlot from './dot-plot.svelte'
@@ -28,11 +27,7 @@ function onRun() {
   }
   perfRunner.start()
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="perf-container">
@@ -76,12 +71,8 @@ function onRun() {
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .perf-container {
   display: flex;
   flex-direction: column;
@@ -104,9 +95,10 @@ table {
   border-collapse: collapse;
 }
 
-td, th {
-  padding-top: .2rem;
-  padding-bottom: .2rem;
+td,
+th {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
 }
 
 th {
@@ -134,5 +126,4 @@ td {
     padding-right: 2rem;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/playground.svelte
+++ b/packages/check-ui-shell/src/components/playground/playground.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { slide } from 'svelte/transition'
 
 import CheckGraphBox from '../check/summary/check-summary-graph-box.svelte'
@@ -32,11 +31,7 @@ function onNextClicked() {
   maxCompleted++
   activeCard++
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="playground-container">
@@ -79,12 +74,8 @@ function onNextClicked() {
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .playground-container {
   display: flex;
   flex-direction: column;
@@ -136,10 +127,10 @@ function onNextClicked() {
 }
 
 .next-button {
-  border-radius: .5rem;
+  border-radius: 0.5rem;
   margin-top: 1.5rem;
   margin-bottom: 1rem;
-  padding: .625rem 2rem;
+  padding: 0.625rem 2rem;
   background-color: #007700;
   color: #fff;
   cursor: pointer;
@@ -158,5 +149,4 @@ function onNextClicked() {
   padding-top: 2rem;
   align-items: center;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/search-list.svelte
+++ b/packages/check-ui-shell/src/components/playground/search-list.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { ListItemViewModel } from './list-item-vm'
 import type { SearchListViewModel } from './search-list-vm'
 
@@ -61,11 +60,7 @@ function onItemClicked(item: ListItemViewModel) {
   // Notify that the item has been selected
   viewModel.onItemSelected?.(item)
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <input type="text" placeholder="Search variables..." bind:value={$query} on:input={onInput} />
@@ -77,12 +72,8 @@ function onItemClicked(item: ListItemViewModel) {
 
 <svelte:window on:keydown={onKeyDown} />
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 input {
   height: 1.7rem;
   font-size: inherit;
@@ -107,7 +98,7 @@ input {
   display: flex;
   align-items: center;
   min-height: 1.6rem;
-  padding: 0 .4rem;
+  padding: 0 0.4rem;
   background-color: #fff;
   cursor: pointer;
   user-select: none;
@@ -115,10 +106,9 @@ input {
   &:hover {
     background-color: #ddd;
   }
-  
+
   &.active {
     background-color: #ccccff;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/sel-list.svelte
+++ b/packages/check-ui-shell/src/components/playground/sel-list.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import type { ListItemViewModel } from './list-item-vm'
 import type { SelListViewModel } from './sel-list-vm'
 
@@ -13,25 +12,19 @@ const selectedItemId = viewModel.selectedItemId
 function onItemClicked(item: ListItemViewModel) {
   viewModel.selectedItemId.set(item.id)
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="items">
   {#each $items as item}
-    <div class="item" on:click={() => onItemClicked(item)} class:active={item.id === $selectedItemId}>{@html item.label}</div>
+    <div class="item" on:click={() => onItemClicked(item)} class:active={item.id === $selectedItemId}>
+      {@html item.label}
+    </div>
   {/each}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .items {
   display: flex;
   flex-direction: column;
@@ -42,10 +35,10 @@ function onItemClicked(item: ListItemViewModel) {
   display: flex;
   align-items: center;
   height: 2rem;
-  margin-bottom: .2rem;
-  padding: 0 .6rem;
+  margin-bottom: 0.2rem;
+  padding: 0 0.6rem;
   background-color: #fff;
-  border-radius: .4rem;
+  border-radius: 0.4rem;
   border: solid 1px #ccc;
   cursor: pointer;
   user-select: none;
@@ -54,5 +47,4 @@ function onItemClicked(item: ListItemViewModel) {
     background-color: lightblue;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-desc.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-desc.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { slide } from 'svelte/transition'
 import Icon from 'svelte-awesome/components/Icon.svelte'
 import { faLightbulb } from '@fortawesome/free-regular-svg-icons'
@@ -14,11 +13,7 @@ export let editing: boolean
 
 const subject = viewModel.subject
 const expectation = viewModel.expectation
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="content">
@@ -28,7 +23,7 @@ const expectation = viewModel.expectation
         <div class="icon-wrapper">
           <Icon class="icon" data={faLightbulb} />
         </div>
-        What part of the model are we checking?  And what is the expected behavior?
+        What part of the model are we checking? And what is the expected behavior?
       </div>
       <div class="answer">
         <input class="desc" placeholder="Part of the model" bind:value={$subject} />
@@ -69,12 +64,8 @@ const expectation = viewModel.expectation
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .content {
   display: flex;
   flex-direction: column;
@@ -85,7 +76,7 @@ const expectation = viewModel.expectation
   display: flex;
   justify-content: center;
   width: 1.5rem;
-  margin-right: .8rem;
+  margin-right: 0.8rem;
 }
 
 .question {
@@ -104,8 +95,8 @@ const expectation = viewModel.expectation
 input {
   outline: none;
   border: 1px solid #aaa;
-  border-radius: .2rem;
-  padding: .2rem .3rem;
+  border-radius: 0.2rem;
+  padding: 0.2rem 0.3rem;
 
   &:focus {
     border-color: blue;
@@ -122,7 +113,7 @@ input {
 
 .examples {
   margin-left: 2.3rem;
-  opacity: .6;
+  opacity: 0.6;
 }
 
 .header {
@@ -136,12 +127,13 @@ ul {
 }
 
 li {
-  margin: .3rem 0;
+  margin: 0.3rem 0;
 }
 
-.subject, .expect {
-  border-radius: .4rem;
-  padding: .08rem .2rem;
+.subject,
+.expect {
+  border-radius: 0.4rem;
+  padding: 0.08rem 0.2rem;
 }
 
 .subject {
@@ -155,12 +147,11 @@ li {
 }
 
 .should {
-  margin: 0 .25rem;
+  margin: 0 0.25rem;
 }
 
 .summary {
   display: flex;
   align-items: center;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-inputs.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-inputs.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { slide } from 'svelte/transition'
 import Icon from 'svelte-awesome/components/Icon.svelte'
 import { faArrowRightToBracket } from '@fortawesome/free-solid-svg-icons'
@@ -20,11 +19,7 @@ console.log(viewModel.todo)
 
 // XXX: This is just so `selectedOption` is read
 $: console.log(selectedOption)
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="content">
@@ -64,12 +59,8 @@ $: console.log(selectedOption)
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .content {
   display: flex;
   flex-direction: column;
@@ -80,7 +71,7 @@ $: console.log(selectedOption)
   display: flex;
   justify-content: center;
   width: 1.5rem;
-  margin-right: .8rem;
+  margin-right: 0.8rem;
 }
 
 .question {
@@ -102,8 +93,8 @@ $: console.log(selectedOption)
   flex: 1;
 }
 
-input[type="radio"] {
-  margin-right: .4rem;
+input[type='radio'] {
+  margin-right: 0.4rem;
 }
 
 .summary {
@@ -112,10 +103,9 @@ input[type="radio"] {
 }
 
 .scenario {
-  border-radius: .4rem;
-  padding: .08rem .3rem;
+  border-radius: 0.4rem;
+  padding: 0.08rem 0.3rem;
   background-color: #ddd;
   font-weight: 700;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-outputs.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-outputs.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { slide } from 'svelte/transition'
 import Icon from 'svelte-awesome/components/Icon.svelte'
 import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
@@ -16,11 +15,7 @@ export let editing: boolean
 
 type Option = 'all_outputs' | 'all_in_group' | 'specify'
 let selectedOption: Option = 'all_outputs'
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="content">
@@ -41,7 +36,13 @@ let selectedOption: Option = 'all_outputs'
         </div>
         <div class="row">
           <label for="in_group">
-            <input type="radio" id="all_in_group" name="all_in_group" bind:group={selectedOption} value="all_in_group" />
+            <input
+              type="radio"
+              id="all_in_group"
+              name="all_in_group"
+              bind:group={selectedOption}
+              value="all_in_group"
+            />
             Check all variables in a predefined group
           </label>
         </div>
@@ -49,7 +50,7 @@ let selectedOption: Option = 'all_outputs'
           <label for="selected">
             <input type="radio" id="specify" name="specify" bind:group={selectedOption} value="specify" />
             Check the following variables...
-            {#if selectedOption === "specify"}
+            {#if selectedOption === 'specify'}
               <div class="row-content">
                 <div class="available-items-container">
                   <SearchList viewModel={viewModel.availableOutputs} />
@@ -76,12 +77,8 @@ let selectedOption: Option = 'all_outputs'
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .content {
   display: flex;
   flex-direction: column;
@@ -92,7 +89,7 @@ let selectedOption: Option = 'all_outputs'
   display: flex;
   justify-content: center;
   width: 1.5rem;
-  margin-right: .8rem;
+  margin-right: 0.8rem;
 }
 
 .question {
@@ -114,8 +111,8 @@ let selectedOption: Option = 'all_outputs'
   flex: 1;
 }
 
-input[type="radio"] {
-  margin-right: .4rem;
+input[type='radio'] {
+  margin-right: 0.4rem;
 }
 
 .row-content {
@@ -127,7 +124,7 @@ input[type="radio"] {
   display: flex;
   flex-direction: column;
   width: 20rem;
-  margin-top: .4rem;
+  margin-top: 0.4rem;
   margin-left: 2rem;
 }
 
@@ -135,7 +132,7 @@ input[type="radio"] {
   display: flex;
   flex-direction: column;
   width: 20rem;
-  margin-top: .4rem;
+  margin-top: 0.4rem;
   margin-left: 2rem;
 }
 
@@ -145,10 +142,9 @@ input[type="radio"] {
 }
 
 .varname {
-  border-radius: .4rem;
-  padding: .08rem .3rem;
+  border-radius: 0.4rem;
+  padding: 0.08rem 0.3rem;
   background-color: #ddd;
   font-weight: 700;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/playground/wizard-card-predicates.svelte
+++ b/packages/check-ui-shell/src/components/playground/wizard-card-predicates.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { slide } from 'svelte/transition'
 import Icon from 'svelte-awesome/components/Icon.svelte'
 import { faCircleCheck } from '@fortawesome/free-regular-svg-icons'
@@ -24,11 +23,7 @@ let selectedRefOption: RefOption = 'constant'
 
 type TimeOption = 'single' | 'range'
 let selectedTimeOption: TimeOption = 'single'
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="content">
@@ -52,7 +47,7 @@ let selectedTimeOption: TimeOption = 'single'
           <label for="constant">
             <input type="radio" id="constant" name="constant" bind:group={selectedRefOption} value="constant" />
             a constant value
-            {#if selectedRefOption === "constant"}
+            {#if selectedRefOption === 'constant'}
               <input type="number" id="constant-val" bind:value={$constantValue} />
             {/if}
           </label>
@@ -78,7 +73,7 @@ let selectedTimeOption: TimeOption = 'single'
             a range of years
           </label>
         </div>
-        {#if selectedTimeOption === "range"}
+        {#if selectedTimeOption === 'range'}
           <div class="row">
             <label for="time-after">
               <input type="checkbox" id="time-after" name="time-after" />
@@ -111,12 +106,8 @@ let selectedTimeOption: TimeOption = 'single'
   {/if}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .content {
   display: flex;
   flex-direction: column;
@@ -127,7 +118,7 @@ let selectedTimeOption: TimeOption = 'single'
   display: flex;
   justify-content: center;
   width: 1.5rem;
-  margin-right: .8rem;
+  margin-right: 0.8rem;
 }
 
 .question {
@@ -141,7 +132,7 @@ let selectedTimeOption: TimeOption = 'single'
 }
 
 .ref-intro {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 
 .row {
@@ -151,24 +142,24 @@ let selectedTimeOption: TimeOption = 'single'
   margin-left: 1.2rem;
 }
 
-input[type="radio"] {
-  margin-right: .4rem;
+input[type='radio'] {
+  margin-right: 0.4rem;
 }
 
 .time-intro {
-  margin-top: .8rem;
-  margin-bottom: .5rem;
+  margin-top: 0.8rem;
+  margin-bottom: 0.5rem;
 }
 
-input[type="checkbox"] {
+input[type='checkbox'] {
   margin-left: 3rem;
-  margin-right: .4rem;
+  margin-right: 0.4rem;
 }
 
-input[type="number"] {
+input[type='number'] {
   width: 4rem;
-  margin-left: .3rem;
-  margin-right: .4rem;
+  margin-left: 0.3rem;
+  margin-right: 0.4rem;
 }
 
 .summary {
@@ -177,10 +168,9 @@ input[type="number"] {
 }
 
 .varname {
-  border-radius: .4rem;
-  padding: .08rem .3rem;
+  border-radius: 0.4rem;
+  padding: 0.08rem 0.3rem;
   background-color: #ddd;
   font-weight: 700;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/stats/stats-table-row.svelte
+++ b/packages/check-ui-shell/src/components/stats/stats-table-row.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 import DotPlot from '../perf/dot-plot.svelte'
 import type { StatsTableRowViewModel } from './stats-table-row-vm'
@@ -17,14 +16,10 @@ const dispatch = createEventDispatcher()
 function onShowPerf() {
   dispatch('command', { cmd: 'show-perf' })
 }
-
 </script>
 
-
-
-
 <!-- TEMPLATE -->
-<td class="name" class:dataset-color-0={modelTextClass === 'dataset-color-0'} class:dataset-color-1={modelTextClass === 'dataset-color-1'} class:row-header={modelTextClass === 'row-header'}>
+<td class={`name ${modelTextClass}`}>
   {viewModel.modelName}
 </td>
 <td>
@@ -75,12 +70,8 @@ function onShowPerf() {
   </td>
 {/if}
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 td {
   padding: 0;
   height: 1.8rem;
@@ -112,15 +103,15 @@ td {
 
 .value {
   flex: 1;
-  padding-right: .4rem;
+  padding-right: 0.4rem;
   text-align: right;
 }
 
 .change {
   flex: 1;
-  padding-left: .4rem;
+  padding-left: 0.4rem;
   text-align: left;
-  font-size: .8em;
+  font-size: 0.8em;
 }
 
 .plot {
@@ -129,5 +120,4 @@ td {
   padding-right: 2rem;
   cursor: pointer;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/stats/stats-table.svelte
+++ b/packages/check-ui-shell/src/components/stats/stats-table.svelte
@@ -1,17 +1,12 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import StatsTableRow from './stats-table-row.svelte'
 import type { StatsTableViewModel } from './stats-table-vm'
 
 export let viewModel: StatsTableViewModel
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <table class="header">
@@ -37,12 +32,8 @@ export let viewModel: StatsTableViewModel
   </tr>
 </table>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 table {
   border-collapse: collapse;
 }
@@ -57,11 +48,13 @@ th {
     color: #555;
   }
 
-  &:nth-child(2), &:nth-child(3) {
+  &:nth-child(2),
+  &:nth-child(3) {
     width: 6rem;
   }
 
-  &:nth-child(4), &:nth-child(5) {
+  &:nth-child(4),
+  &:nth-child(5) {
     width: 10rem;
   }
 
@@ -69,9 +62,9 @@ th {
     width: 8rem;
   }
 
-  &:nth-child(7), &:nth-child(8) {
+  &:nth-child(7),
+  &:nth-child(8) {
     width: 8rem;
   }
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/summary/summary.svelte
+++ b/packages/check-ui-shell/src/components/summary/summary.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import CheckSummary from '../check/summary/check-summary.svelte'
 import ComparisonSummary from '../compare/summary/comparison-summary.svelte'
 import StatsTable from '../stats/stats-table.svelte'
@@ -12,11 +11,7 @@ import type { SummaryViewModel } from './summary-vm'
 
 export let viewModel: SummaryViewModel
 const selectedTabId = viewModel.tabBarViewModel.selectedItemId
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <div class="summary-container">
@@ -28,24 +23,20 @@ const selectedTabId = viewModel.tabBarViewModel.selectedItemId
       <div class="line"></div>
     {/if}
     <TabBar on:command viewModel={viewModel.tabBarViewModel} />
-    {#if $selectedTabId === "checks"}
+    {#if $selectedTabId === 'checks'}
       <CheckSummary viewModel={viewModel.checkSummaryViewModel} />
-    {:else if $selectedTabId === "comp-views"}
+    {:else if $selectedTabId === 'comp-views'}
       <ComparisonSummary on:command viewModel={viewModel.comparisonViewsSummaryViewModel} />
-    {:else if $selectedTabId === "comps-by-scenario"}
+    {:else if $selectedTabId === 'comps-by-scenario'}
       <ComparisonSummary on:command viewModel={viewModel.comparisonsByScenarioSummaryViewModel} />
-    {:else if $selectedTabId === "comps-by-dataset"}
+    {:else if $selectedTabId === 'comps-by-dataset'}
       <ComparisonSummary on:command viewModel={viewModel.comparisonsByDatasetSummaryViewModel} />
     {/if}
   </div>
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .summary-container {
   display: flex;
   flex-direction: column;
@@ -70,8 +61,7 @@ const selectedTabId = viewModel.tabBarViewModel.selectedItemId
 
 .line {
   min-height: 1px;
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   background-color: #555;
 }
-
 </style>

--- a/packages/check-ui-shell/src/components/summary/tab-bar.svelte
+++ b/packages/check-ui-shell/src/components/summary/tab-bar.svelte
@@ -1,8 +1,7 @@
 <!-- Copyright (c) 2021-2022 Climate Interactive / New Venture Fund -->
 
 <!-- SCRIPT -->
-<script lang='ts'>
-
+<script lang="ts">
 import { createEventDispatcher } from 'svelte'
 
 import type { TabBarViewModel } from './tab-bar-vm'
@@ -32,11 +31,7 @@ function onKeyDown(event: KeyboardEvent) {
     event.preventDefault()
   }
 }
-
 </script>
-
-
-
 
 <!-- TEMPLATE -->
 <svelte:window on:keydown={onKeyDown} />
@@ -50,12 +45,8 @@ function onKeyDown(event: KeyboardEvent) {
   {/each}
 </div>
 
-
-
-
 <!-- STYLE -->
-<style lang='scss'>
-
+<style lang="scss">
 .tab-bar {
   position: sticky;
   top: 0;
@@ -68,23 +59,23 @@ function onKeyDown(event: KeyboardEvent) {
   // across, then use extra padding to compensate
   margin: 0 -1rem;
   padding: 0 1rem;
-  box-shadow: 0 1rem .5rem -.5rem rgba(0,0,0,.8);
+  box-shadow: 0 1rem 0.5rem -0.5rem rgba(0, 0, 0, 0.8);
 }
 
 .tab-item {
   display: flex;
   flex-direction: column;
-  padding: .5rem 3rem .3rem 0;
+  padding: 0.5rem 3rem 0.3rem 0;
   cursor: pointer;
   opacity: 0.7;
   border-bottom: solid 1px transparent;
 
   &:hover {
-    opacity: 1.0;
+    opacity: 1;
   }
 
   &.selected {
-    opacity: 1.0;
+    opacity: 1;
     border-bottom: solid 1px #555;
   }
 }
@@ -93,7 +84,7 @@ function onKeyDown(event: KeyboardEvent) {
   font-size: 1.6rem;
   font-weight: 700;
   color: #fff;
-  margin-bottom: .2rem;
+  margin-bottom: 0.2rem;
   cursor: pointer;
 }
 
@@ -101,5 +92,4 @@ function onKeyDown(event: KeyboardEvent) {
   font-size: 1rem;
   font-weight: 400;
 }
-
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-svelte:
+        specifier: ^3.4.0
+        version: 3.4.0(prettier@3.6.2)(svelte@4.2.19)
       tsup:
         specifier: ^8.2.4
         version: 8.2.4(postcss@8.4.41)(typescript@5.2.2)
@@ -370,8 +373,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2
       prettier-plugin-svelte:
-        specifier: ^3.3.3
-        version: 3.3.3(prettier@3.6.2)(svelte@4.2.19)
+        specifier: ^3.4.0
+        version: 3.4.0(prettier@3.6.2)(svelte@4.2.19)
       sass:
         specifier: ^1.77.8
         version: 1.77.8
@@ -3038,8 +3041,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.3.3:
-    resolution: {integrity: sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==}
+  prettier-plugin-svelte@3.4.0:
+    resolution: {integrity: sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
@@ -5809,7 +5812,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@4.2.19):
+  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@4.2.19):
     dependencies:
       prettier: 3.6.2
       svelte: 4.2.19


### PR DESCRIPTION
Fixes #654 

See issue for details.  Formatting only; no change to behavior.  I did spot a couple places where `class:foo` syntax was added incorrectly by the LLM in #648 and I fixed them as part of this branch.
