### PR TITLE
deps: require Node.js v20 as minimum supported version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       # The pnpm caching strategy in the following steps is based on:
       #   https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time
@@ -120,7 +120,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       # The pnpm caching strategy in the following steps is based on:
       #   https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time
@@ -191,7 +191,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       # The pnpm caching strategy in the following steps is based on:
       #   https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       # The pnpm caching strategy in the following steps is based on:
       #   https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For more details on all of these packages, refer to the ["Packages"](#packages) 
 
 The SDEverywhere libraries and tools can be used on any computer running macOS, Windows, or Linux.
 
-SDEverywhere requires [Node.js](https://nodejs.org) version 18 or later (the current LTS version 20 is recommended).
+SDEverywhere requires [Node.js](https://nodejs.org) version 20 or later (the current LTS version 22 is recommended).
 Node.js is a cross-platform runtime environment that allows for running JavaScript-based tools (like SDEverywhere) on macOS, Windows, and Linux computers.
 
 Note: It is not necessary to have extensive knowledge of Node.js and JavaScript in order to use SDEverywhere, but a one-time download of Node.js is necessary to get started.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "yargs": "^17.5.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/packages/create/bin/create-sde.js
+++ b/packages/create/bin/create-sde.js
@@ -3,7 +3,7 @@
 
 const currentVersion = process.versions.node
 const requiredMajorVersion = parseInt(currentVersion.split('.')[0], 10)
-const minimumMajorVersion = 18
+const minimumMajorVersion = 20
 
 if (requiredMajorVersion < minimumMajorVersion) {
   console.error(`Node.js v${currentVersion} is not supported by SDEverywhere.`)


### PR DESCRIPTION
Fixes #656 

@ToddFincannonEI: See issue for details.  I imagine you are probably already on v20 or later at this point, but let me know if this upgrade is a problem for you.  For reference, the changes are largely the same as what we did in 2024 in PR #432.

---

BEGIN_COMMIT_OVERRIDE
deps: require Node.js v20 as minimum supported version
END_COMMIT_OVERRIDE
