### PR TITLE
deps!: drop support for vite <= 4 in plugin-vite

### DIFF
--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@sdeverywhere/build": "^0.3.7",
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@sdeverywhere/build": "*",


### PR DESCRIPTION
Fixes #661 

BREAKING-CHANGE: The plugin-vite package now requires vite 5.x, 6.x, or 7.x; we have dropped support for vite 3.x and 4.x in the `peerDependencies` for plugin-vite.  Most SDE users will not be affected by this change since they pick up whatever version of vite was configured in the project templates.  If you have an existing SDE project that uses an older version of vite, simply update your `package.json` file and change the vite dependency version to `^7.1.9` or later and things should continue to work just fine.

---

BEGIN_COMMIT_OVERRIDE
deps!: drop support for vite <= 4 in plugin-vite

BREAKING-CHANGE: The plugin-vite package now requires vite 5.x, 6.x, or 7.x; we have dropped support for vite 3.x and 4.x in the `peerDependencies` for plugin-vite.  Most SDE users will not be affected by this change since they pick up whatever version of vite was configured in the project templates.  If you have an existing SDE project that uses an older version of vite, simply update your `package.json` file and change the vite dependency version to `^7.1.9` or later and things should continue to work just fine.
END_COMMIT_OVERRIDE
