### PR TITLE
refactor: move cName function to separate file

### DIFF
--- a/packages/compile/src/_shared/var-names.js
+++ b/packages/compile/src/_shared/var-names.js
@@ -1,0 +1,31 @@
+import { canonicalName } from './helpers.js'
+import { isIndex, sub } from './subscript.js'
+
+/**
+ * Convert a Vensim variable name to a C name.
+ *
+ * WARNING: This function requires model analysis to be completed first when the variable
+ * has subscripts.
+ *
+ * @param {string} vensimVarName The full Vensim variable name (can contain subscripts).
+ * @returns {string} A canonical C representation of the variable name (e.g., '_variable_name').
+ */
+export function cName(vensimVarName) {
+  // Split the variable name from the subscripts
+  let matches = vensimVarName.match(/([^[]+)(?:\[([^\]]+)\])?/)
+  if (!matches) {
+    throw new Error(`Invalid variable name '${vensimVarName}' found when converting to C representation`)
+  }
+  let cVarName = canonicalName(matches[1])
+  if (matches[2]) {
+    // The variable name includes subscripts, so split them into individual IDs
+    let cSubIds = matches[2].split(',').map(x => canonicalName(x))
+    // If a subscript is an index, convert it to an index number to match Vensim data exports
+    let cSubIdParts = cSubIds.map(cSubId => {
+      return isIndex(cSubId) ? `[${sub(cSubId).value}]` : `[${cSubId}]`
+    })
+    // Append the subscript parts to the base variable name to create the full reference
+    cVarName += cSubIdParts.join('')
+  }
+  return cVarName
+}

--- a/packages/compile/src/generate/expand-var-names.js
+++ b/packages/compile/src/generate/expand-var-names.js
@@ -2,6 +2,7 @@ import * as R from 'ramda'
 
 import { cartesianProductOf, canonicalName } from '../_shared/helpers.js'
 import { sub, isDimension } from '../_shared/subscript.js'
+import { cName } from '../_shared/var-names.js'
 
 import Model from '../model/model.js'
 
@@ -20,7 +21,7 @@ export function expandVarNames(canonical) {
       (a, v) => {
         if (v.varType !== 'lookup' && v.varType !== 'data' && v.includeInOutput) {
           if (canonical) {
-            return R.concat(a, R.map(Model.cName, namesForVar(v)))
+            return R.concat(a, R.map(cName, namesForVar(v)))
           } else {
             return R.concat(a, namesForVar(v))
           }

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -2,7 +2,7 @@ import B from 'bufx'
 import yaml from 'js-yaml'
 import * as R from 'ramda'
 
-import { canonicalName, decanonicalize, isIterable, /*listConcat,*/ strlist, vlog, vsort } from '../_shared/helpers.js'
+import { decanonicalize, isIterable, strlist, vlog, vsort } from '../_shared/helpers.js'
 import {
   addIndex,
   allAliases,
@@ -13,6 +13,7 @@ import {
   sub,
   subscriptFamilies
 } from '../_shared/subscript.js'
+import { cName } from '../_shared/var-names.js'
 
 import { readEquation } from './read-equations.js'
 import { readDimensionDefs } from './read-subscripts.js'
@@ -732,28 +733,6 @@ function vensimName(cVarName) {
   }
   return result
 }
-function cName(vensimVarName) {
-  // Convert a Vensim variable name to a C name.
-  // This function requires model analysis to be completed first when the variable has subscripts.
-
-  // Split the variable name from the subscripts
-  let matches = vensimVarName.match(/([^[]+)(?:\[([^\]]+)\])?/)
-  if (!matches) {
-    throw new Error(`Invalid variable name '${vensimVarName}' found when converting to C representation`)
-  }
-  let cVarName = canonicalName(matches[1])
-  if (matches[2]) {
-    // The variable name includes subscripts, so split them into individual IDs
-    let cSubIds = matches[2].split(',').map(x => canonicalName(x))
-    // If a subscript is an index, convert it to an index number to match Vensim data exports
-    let cSubIdParts = cSubIds.map(cSubId => {
-      return isIndex(cSubId) ? `[${sub(cSubId).value}]` : `[${cSubId}]`
-    })
-    // Append the subscript parts to the base variable name to create the full reference
-    cVarName += cSubIdParts.join('')
-  }
-  return cVarName
-}
 function isInputVar(varName) {
   // Return true if the given variable (in canonical form) is included in the list of
   // input variables in the spec file.
@@ -1261,7 +1240,6 @@ export default {
   addVariable,
   allVars,
   auxVars,
-  cName,
   constVars,
   dataVars,
   expansionFlags,

--- a/packages/compile/src/parse-and-generate.js
+++ b/packages/compile/src/parse-and-generate.js
@@ -120,7 +120,7 @@ export function printNames(namesPathname, operation) {
   for (let line of lines) {
     if (line.length > 0) {
       if (operation === 'to-c') {
-        B.emitLine(Model.cName(line))
+        B.emitLine(cName(line))
       } else {
         B.emitLine(Model.vensimName(line))
       }


### PR DESCRIPTION
Fixes #677 

See issue for the rationale.  The `cName` function has been moved to a separate file but its implementation is unchanged.  The only difference is that I rewrote the function docs in JSDoc style like we use elsewhere and added a warning.  Callers have been updated to import from the new location.  All tests are passing.
