### PR TITLE
refactor: rename namesForVar to expandVar + move it to a separate file

### DIFF
--- a/packages/compile/src/generate/expand-var-names.js
+++ b/packages/compile/src/generate/expand-var-names.js
@@ -1,17 +1,17 @@
 import * as R from 'ramda'
 
-import { cartesianProductOf, canonicalName } from '../_shared/helpers.js'
-import { sub, isDimension } from '../_shared/subscript.js'
 import { cName } from '../_shared/var-names.js'
 
+import { expandVar } from '../model/expand-var-instances.js'
 import Model from '../model/model.js'
 
 /**
- * Return an array of names for all variable in the model, sorted alphabetically and expanded to
+ * Return an array of names for all accessible variables, sorted alphabetically and expanded to
  * include the full set of subscripted variants for variables that include subscripts.
  *
- * @param canonical If true, convert names to canonical representation (variable identifiers), otherwise
- * return the original name of each variable as it appears in the model.
+ * @param {*} variables The `Variable` objects to process.
+ * @param {boolean} canonical If true, convert names to canonical representation (variable identifiers),
+ * otherwise return the original name of each variable as it appears in the model.
  * @returns {string[]} An array of variable names or identifiers.
  */
 export function expandVarNames(canonical) {
@@ -20,10 +20,12 @@ export function expandVarNames(canonical) {
     R.reduce(
       (a, v) => {
         if (v.varType !== 'lookup' && v.varType !== 'data' && v.includeInOutput) {
+          const varInstances = expandVar(v)
+          const varNames = varInstances.map(instance => instance.varName)
           if (canonical) {
-            return R.concat(a, R.map(cName, namesForVar(v)))
+            return R.concat(a, R.map(cName, varNames))
           } else {
-            return R.concat(a, namesForVar(v))
+            return R.concat(a, varNames)
           }
         } else {
           return a
@@ -33,74 +35,4 @@ export function expandVarNames(canonical) {
       sortedVars
     )
   )
-}
-
-/**
- * Return an array of names for the given variable including all subscript variants.
- *
- * @param {*} v A `Variable` instance.
- * @returns {string[]} An array of expanded names for the given variable.
- */
-function namesForVar(v) {
-  if (v.parsedEqn === undefined) {
-    // XXX: The special `Time` variable does not have a `parsedEqn`, so use the raw LHS
-    return [v.modelLHS]
-  }
-
-  // Expand each variable to get the names of all subscripted variants
-  const lhsVarDef = v.parsedEqn.lhs.varDef
-  const lhsSubRefs = lhsVarDef.subscriptRefs
-  if (lhsSubRefs?.length > 0) {
-    // At each position, expand any dimensions or use a subscript (index) directly
-    const subOrDimNames = lhsSubRefs.map(subRef => subRef.subName)
-    return expandDims(lhsVarDef.varName, subOrDimNames)
-  } else {
-    // No subscripts, so include a single variable name
-    return [lhsVarDef.varName]
-  }
-}
-
-/**
- * Return an array of all expanded subscript combinations.
- *
- * @param {string} baseVarName The base name of the variable.
- * @param {string[]} subOrDimNames The array of subscript or dimension names.
- * @returns {string[]} An array of string representations of subscripted references,
- * e.g., `'x[A1,B1]' ,'x[A1,B2]', ...]`.
- */
-function expandDims(baseVarName, subOrDimNames) {
-  // Expand the dimension for each position
-  const expanded = subOrDimNames.map(name => expandDim(name).flat(Infinity))
-
-  // Expand these into the set of all combinations of subscripts for the variable
-  const origCombos = cartesianProductOf(expanded)
-  return origCombos.map(combo => {
-    const subs = combo.join(',')
-    return `${baseVarName}[${subs}]`
-  })
-}
-
-/**
- * Return an array containing all subscript (index) names in the given dimension.  If
- * the given name is a subscript, it will return a single-element array with that
- * subscript name.
- *
- * @param {string} subOrDimName A subscript or dimension name.
- * @returns {string[]} A (possibly nested) array of subscript names.
- */
-function expandDim(subOrDimName) {
-  // Convert the name to an ID
-  const subOrDimId = canonicalName(subOrDimName)
-
-  if (isDimension(subOrDimId)) {
-    // Get the object for the dimension
-    const dimObj = sub(subOrDimId)
-
-    // The dimension may contain a mix of individual subscripts (indices) and/or subdimensions,
-    // so recursively expand them
-    return dimObj.modelValue.map(expandDim)
-  } else {
-    // This is an individual subscript (index), so return it directly
-    return [subOrDimName]
-  }
 }

--- a/packages/compile/src/generate/expand-var-names.spec.ts
+++ b/packages/compile/src/generate/expand-var-names.spec.ts
@@ -30,15 +30,13 @@ describe('expandVarNames', () => {
     expect(expandVarNames(true)).toEqual(['__x_y_z_', '_time'])
   })
 
-  // TODO: Perhaps we should take the exceptions into account, but right now we do not
-  // so it will expand all variants of DimA
   it('should return names for a subscripted 1D variable that uses an EXCEPT clause', () => {
     readInlineModel(`
       DimA: A1, A2, A3 ~~|
       X[DimA] :EXCEPT: [A1] = 1 ~~|
     `)
-    expect(expandVarNames(false)).toEqual(['Time', 'X[A1]', 'X[A2]', 'X[A3]'])
-    expect(expandVarNames(true)).toEqual(['_time', '_x[0]', '_x[1]', '_x[2]'])
+    expect(expandVarNames(false)).toEqual(['Time', 'X[A2]', 'X[A3]'])
+    expect(expandVarNames(true)).toEqual(['_time', '_x[1]', '_x[2]'])
   })
 
   it('should return names for a subscripted 1D variable that uses a disjoint EXCEPT clause', () => {

--- a/packages/compile/src/model/expand-var-instances.js
+++ b/packages/compile/src/model/expand-var-instances.js
@@ -1,0 +1,139 @@
+import { cartesianProductOf, canonicalName } from '../_shared/helpers.js'
+import { isDimension, sub } from '../_shared/subscript.js'
+
+/**
+ * A single instance of a variable.
+ * @typedef {Object} VarInstance
+ * @property {string} varName The full name of the variable instance, e.g., "Variable Name[SubA, SubB]".
+ * @property {number[]} [subscriptIndices] The array of subscript indices; only defined if this variable
+ * has subscripts.
+ */
+
+/**
+ * Return an array of names and subscript indices for the given variable, expanded to
+ * include all subscript variants.
+ *
+ * @param {*} v A `Variable` object.
+ * @returns {VarInstance[]} An array of `VarInstance` objects corresponding to the expanded variable.
+ */
+export function expandVar(v) {
+  if (v.parsedEqn === undefined) {
+    // XXX: The special `Time` variable does not have a `parsedEqn`, so use the raw LHS
+    return [
+      {
+        varName: v.modelLHS
+      }
+    ]
+  }
+
+  // Expand each subscript position to get the names of all subscripted variants
+  const lhsVarDef = v.parsedEqn.lhs.varDef
+  const lhsSubOrDimIds = v.subscripts
+  if (lhsSubOrDimIds === undefined || lhsSubOrDimIds.length === 0) {
+    // No subscripts, so include a single variable name
+    return [
+      {
+        varName: lhsVarDef.varName
+      }
+    ]
+  }
+
+  // At each position, expand any dimensions or use a subscript (index) directly
+  return expandDims(lhsVarDef.varName, lhsSubOrDimIds)
+}
+
+/**
+ * Return an array of all expanded subscript combinations.
+ *
+ * @param {string} baseVarName The base name of the variable.
+ * @param {string[]} subOrDimIds The array of subscript or dimension IDs.
+ * @returns {VarInstance[]} An array of `VarInstance` objects with string representations of
+ * subscripted references, e.g., `'x[A1,B1]', 'x[A1,B2]', ...`.
+ */
+function expandDims(baseVarName, subOrDimIds) {
+  // Expand the dimension for each position
+  const expanded = subOrDimIds.map(id => expandSubSpecs(id).flat(Infinity))
+
+  // Expand these into the set of all combinations of subscripts for the variable
+  const origCombos = cartesianProductOf(expanded)
+  return origCombos.map(combo => {
+    const subNames = combo.map(spec => spec.name).join(',')
+    const subIndices = combo.map(spec => spec.index)
+    return {
+      varName: `${baseVarName}[${subNames}]`,
+      subscriptIndices: subIndices
+    }
+  })
+}
+
+/**
+ * Pairs a subscript name with its index.
+ * @typedef {Object} SubSpec
+ * @property {string} name The name of the subscript, e.g., "A1".
+ * @property {number} index The subscript index relative to its parent dimension.
+ */
+
+/**
+ * Return an array containing all subscript specs in the given dimension.  If
+ * the given ID is a subscript, it will return a single-element array with that
+ * subscript name and index.
+ *
+ * @param {string} subOrDimId A subscript or dimension ID (e.g., '_a1', '_dima').
+ * @returns {SubSpec[]} A (possibly nested) array of `SubSpec` objects.
+ */
+function expandSubSpecs(subOrDimId) {
+  if (isDimension(subOrDimId)) {
+    // Get the object for the dimension
+    const dimObj = sub(subOrDimId)
+
+    // The dimension may contain a mix of individual subscripts (indices) and/or subdimensions,
+    // so recursively expand them
+    return dimObj.value.map(expandSubSpecs)
+  } else {
+    // This is an individual subscript (index), so return its name and index value
+    // XXX: Currently, the object returned by `sub` will not include the `modelName`
+    // for subscripts (it's only defined for dimensions?), so if we don't have the
+    // `modelName`, find it using the parent dimension object.  This could be avoided
+    // if subscript objects maintained their original model name.
+    const subObj = sub(subOrDimId)
+    const dimSubNames = expandSubNamesForDim(subObj.family).flat(Infinity)
+    const subName = dimSubNames[subObj.value]
+    if (subName === undefined) {
+      throw new Error(`Failed to resolve name of subscript ${subOrDimId} in dimension ${subObj.family}`)
+    }
+    return [
+      {
+        name: subName,
+        index: subObj.value
+      }
+    ]
+  }
+}
+
+/**
+ * Return an array containing all subscript (index) names in the given dimension,
+ * expanding subdimensions as needed.  If the given ID is a subscript, it will return
+ * single-element array with that subscript name.
+ *
+ * @param {string} dimId A dimension ID (e.g., '_dima').
+ * @returns {string[]} A (possibly nested) array of subscript names (e.g., 'A1').
+ */
+function expandSubNamesForDim(dimId) {
+  if (!isDimension(dimId)) {
+    throw new Error('expandSubNames should only be called with a dimension ID')
+  }
+
+  // Get the object for the dimension
+  const dimObj = sub(dimId)
+
+  // The dimension may contain a mix of individual subscripts (indices) and/or
+  // subdimensions, so recursively expand them
+  return dimObj.modelValue.map(subOrDimName => {
+    const subOrDimId = canonicalName(subOrDimName)
+    if (isDimension(subOrDimId)) {
+      return expandSubNamesForDim(subOrDimId)
+    } else {
+      return [subOrDimName]
+    }
+  })
+}

--- a/packages/compile/src/model/expand-var-instances.spec.ts
+++ b/packages/compile/src/model/expand-var-instances.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import { resetHelperState } from '../_shared/helpers'
+import { resetSubscriptsAndDimensions } from '../_shared/subscript'
+
+import Model from './model'
+
+import { parseInlineVensimModel } from '../_tests/test-support'
+
+import { expandVar } from './expand-var-instances'
+
+function readInlineModel(mdlContent: string) {
+  // XXX: These steps are needed due to subs/dims and variables being in module-level storage
+  resetHelperState()
+  resetSubscriptsAndDimensions()
+  Model.resetModelState()
+
+  const parsedModel = parseInlineVensimModel(mdlContent)
+  Model.read(parsedModel, /*spec=*/ {}, /*extData=*/ undefined, /*directData=*/ undefined, /*modelDir=*/ undefined, {
+    reduceVariables: false
+  })
+
+  return Model.variables
+}
+
+const instance = (varName: string, subscriptIndices?: number[]) => {
+  return {
+    varName,
+    subscriptIndices
+  }
+}
+
+describe('expandVar', () => {
+  it('should return a single instance for a non-subscripted variable', () => {
+    const vars = readInlineModel(`
+      "X Y Z" = 10 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('"X Y Z"')])
+  })
+
+  it('should return instances for a simple subscripted non-apply-to-all 1D variable', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2 ~~|
+      X[DimA] = 1, 2 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A1]', [0])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A2]', [1])])
+  })
+
+  it('should return instances for a simple subscripted apply-to-all 1D variable', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2 ~~|
+      X[DimA] = 1 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A1]', [0]), instance('X[A2]', [1])])
+  })
+
+  it('should return instances for a subscripted 1D variable that uses an EXCEPT clause', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2, A3 ~~|
+      X[DimA] :EXCEPT: [A1] = 1 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A2]', [1])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A3]', [2])])
+  })
+
+  it('should return instances for a subscripted 1D variable that uses a disjoint EXCEPT clause', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2, A3 ~~|
+      SubA: A2, A3 ~~|
+      X[SubA] :EXCEPT: [A1] = 1 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A2]', [1])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A3]', [2])])
+  })
+
+  it('should return instances for a subscripted 1D variable that refers to subdimensions', () => {
+    const vars = readInlineModel(`
+      DimA: A1, SubA, A6 ~~|
+      SubA: SubA1, SubA2 ~~|
+      SubA1: A2, A3 ~~|
+      SubA2: A4, A5 ~~|
+      X[DimA] = 1 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([
+      instance('X[A1]', [0]),
+      instance('X[A2]', [1]),
+      instance('X[A3]', [2]),
+      instance('X[A4]', [3]),
+      instance('X[A5]', [4]),
+      instance('X[A6]', [5])
+    ])
+  })
+
+  it('should return instances for a subscripted 1D variable that refers to a mapped dimension', () => {
+    const vars = readInlineModel(`
+      DimA: SubA, A3 -> DimB ~~|
+      SubA: A1, A2 ~~|
+      DimB: B1, B2, B3 ~~|
+      X[DimA] = 1, 2, 3 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A1]', [0])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A2]', [1])])
+    expect(expandVar(vars[2])).toEqual([instance('X[A3]', [2])])
+  })
+
+  it('should return instances for a subscripted 1D variable that refers to an aliased dimension', () => {
+    const vars = readInlineModel(`
+      DimA <-> DimB ~~|
+      DimB: B1, B2, B3 ~~|
+      X[DimA] = 1, 2, 3 ~~|
+      Y[DimB] = 1, 2, 3 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[B1]', [0])])
+    expect(expandVar(vars[1])).toEqual([instance('X[B2]', [1])])
+    expect(expandVar(vars[2])).toEqual([instance('X[B3]', [2])])
+    expect(expandVar(vars[3])).toEqual([instance('Y[B1]', [0])])
+    expect(expandVar(vars[4])).toEqual([instance('Y[B2]', [1])])
+    expect(expandVar(vars[5])).toEqual([instance('Y[B3]', [2])])
+  })
+
+  it('should return instances for a subscripted 2D non-apply-to-all variable (const list)', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2 ~~|
+      DimB: B1, B2 ~~|
+      X[DimA, DimB] = 1, 2; 3, 4; ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A1,B1]', [0, 0])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A1,B2]', [0, 1])])
+    expect(expandVar(vars[2])).toEqual([instance('X[A2,B1]', [1, 0])])
+    expect(expandVar(vars[3])).toEqual([instance('X[A2,B2]', [1, 1])])
+  })
+
+  it('should return instances for a subscripted 2D non-apply-to-all variable (separate constant definitions)', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2 ~~|
+      DimB: B1, B2 ~~|
+      X[A1, DimB] = 1, 2 ~~|
+      X[A2, B1] = 3 ~~|
+      X[A2, B2] = 4 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([instance('X[A1,B1]', [0, 0])])
+    expect(expandVar(vars[1])).toEqual([instance('X[A1,B2]', [0, 1])])
+    expect(expandVar(vars[2])).toEqual([instance('X[A2,B1]', [1, 0])])
+    expect(expandVar(vars[3])).toEqual([instance('X[A2,B2]', [1, 1])])
+  })
+
+  it('should return instances for a subscripted 2D apply-to-all variable', () => {
+    const vars = readInlineModel(`
+      DimA: A1, A2 ~~|
+      From DimA: DimA ~~|
+      To DimA: DimA ~~|
+      X[From DimA, To DimA] = 0 ~~|
+    `)
+    expect(expandVar(vars[0])).toEqual([
+      instance('X[A1,A1]', [0, 0]),
+      instance('X[A1,A2]', [0, 1]),
+      instance('X[A2,A1]', [1, 0]),
+      instance('X[A2,A2]', [1, 1])
+    ])
+  })
+})

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -61,12 +61,12 @@ function resetModelState() {
  * TODO: FIX TYPE
  * @param {*} parsedModel The parsed model structure.
  * @param {*} spec The parsed `spec.json` object.
- * @param {Map<string, any>} extData The map of datasets from external `.dat` files.
- * @param {Map<string, any>} directData The mapping of dataset name used in a `GET DIRECT DATA`
+ * @param {Map<string, any>} [extData] The map of datasets from external `.dat` files.
+ * @param {Map<string, any>} [directData] The mapping of dataset name used in a `GET DIRECT DATA`
  * call (e.g., `?data`) to the tabular data contained in the loaded data file.
- * @param {string} modelDirname The path to the directory containing the model (used for resolving data
+ * @param {string} [modelDirname] The path to the directory containing the model (used for resolving data
  * files for `GET DIRECT SUBSCRIPT`).
- * @param {*} opts An optional object used by tests to stop the read process after a specific phase.
+ * @param {*} [opts] An optional object used by tests to stop the read process after a specific phase.
  */
 function read(parsedModel, spec, extData, directData, modelDirname, opts) {
   // Some arrays need to be separated into variables with individual indices to
@@ -426,7 +426,13 @@ function removeUnusedVariables(spec) {
   }
 
   // Filter out unneeded variables so we're left with the minimal set of variables to emit
-  variables = R.filter(v => referencedVarNames.has(v.varName), variables)
+  const filteredVariables = R.filter(v => referencedVarNames.has(v.varName), variables)
+  // TODO: Note that we reuse the same `variables` array instance here instead of reassigning
+  // to it because some code (like in `code-gen/expand-var-names.js` and in some tests) uses
+  // the `variables` array (from module-level storage) directly.  We need to fix those uses
+  // to use accessors to avoid these subtle issues.
+  variables.length = 0
+  variables.push(...filteredVariables)
 
   // Rebuild the variables-by-name map
   variablesByName.clear()


### PR DESCRIPTION
Fixes #679 

This is another small refactoring that I split out from the other changes for #534.  There is increased test coverage for this code after moving it into a separate file, and also a small change to the way it was implemented resolved a TODO, so behavior is unchanged or slightly better for some edge cases.  All tests are passing.
