### PR TITLE
feat: include grouped and sorted arrays of variable instances in JSON listing

### DIFF
--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -2,7 +2,7 @@ import B from 'bufx'
 import yaml from 'js-yaml'
 import * as R from 'ramda'
 
-import { decanonicalize, isIterable, strlist, vlog, vsort } from '../_shared/helpers.js'
+import { canonicalVensimName, decanonicalize, isIterable, strlist, vlog, vsort } from '../_shared/helpers.js'
 import {
   addIndex,
   allAliases,
@@ -15,6 +15,7 @@ import {
 } from '../_shared/subscript.js'
 import { cName } from '../_shared/var-names.js'
 
+import { expandVar } from './expand-var-instances.js'
 import { readEquation } from './read-equations.js'
 import { readDimensionDefs } from './read-subscripts.js'
 import { readVariables } from './read-variables.js'
@@ -1090,12 +1091,13 @@ function allListedVars() {
   }
 
   // The order of execution/evaluation in the generated model is:
-  //   initConstants (vars of type `const` only)
-  //   initLookups (vars of type `lookup` only)
-  //   initData (vars of type `data` only)
-  //   initLevels (vars returned by `initVars`, a mix of initial, aux, and level vars)
-  //   evalAux (vars of type `aux` only)
-  //   evalLevels (vars of type `level` only)
+  //   initConstants (vars of type `const` only; called for t=0 only)
+  //   initLookups (vars of type `lookup` only; called for t=0 only)
+  //   initData (vars of type `data` only; called for t=0 only)
+  //   initLevels (vars returned by `initVars`, a mix of initial, aux, and level vars;
+  //     called for t=0 only)
+  //   evalAux (vars of type `aux` only; called for t>=0)
+  //   evalLevels (vars of type `level` only; called before `evalAux` for t>0)
   // So to make the ordering in the listing better match the order of evaluation,
   // we emit variables in the above order, but filter to avoid having duplicates.
   addUnique(constVars())
@@ -1136,7 +1138,7 @@ function varIndexInfoMap() {
 
   // Get the set of unique variable names, and assign a 1-based index to each.
   // This matches the index number used in `storeOutput` and `setLookup` in the
-  // generated C/JS code
+  // generated C/JS code.
   const infoMap = new Map()
   let varIndex = 1
   for (const v of sortedVars) {
@@ -1194,6 +1196,73 @@ function jsonList() {
     }
   }
 
+  //
+  // We include a `varInstances` object in the generated JSON listing that
+  // includes an array of expanded variable items (one item for every "instance"
+  // of a variable, including subscripted variables) in the same order that they
+  // are evaluated (assigned) in the generated model.
+  //
+  // Each object contains the following minimal set of fields that are needed
+  // for accessing the data for a single variable instance at runtime:
+  //   varId (e.g., '_variable_name')
+  //   varName (e.g., 'Variable Name')
+  //   varType ('const', 'data', 'lookup', 'initial', 'level', 'aux')
+  //   varIndex
+  //   subscriptIndices
+  //
+  // The order of execution/evaluation in the generated model is:
+  //   initConstants (vars of type `const` only, called for t=0 only)
+  //   initLookups (vars of type `lookup` only, called for t=0 only)
+  //   initData (vars of type `data` only, called for t=0 only)
+  //   initLevels (vars returned by `initVars`, a mix of initial, aux, and level vars,
+  //     called for t=0 only)
+  //   evalAux (vars of type `aux` only; called for t>=0)
+  //   evalLevels (vars of type `level` only; called before `evalAux` for t>0)
+  //
+  function expandedVarItems(vars) {
+    const expandedVars = []
+
+    for (const v of vars) {
+      // Filter out variables that are generated/used internally
+      if (v.includeInOutput === false) {
+        continue
+      }
+
+      const varInstances = expandVar(v)
+      for (const { varName, subscriptIndices } of varInstances) {
+        const varId = canonicalVensimName(varName)
+        const varItem = {
+          varId,
+          varName,
+          varType: v.varType
+        }
+        const varInfo = infoMap.get(v.varName)
+        if (varInfo) {
+          varItem.varIndex = varInfo.varIndex
+          if (subscriptIndices?.length > 0) {
+            varItem.subscriptIndices = subscriptIndices
+          }
+        }
+        expandedVars.push(varItem)
+      }
+    }
+
+    return expandedVars
+  }
+  const expandedConstants = expandedVarItems(constVars())
+  const expandedLookupVars = expandedVarItems(lookupVars())
+  const expandedDataVars = expandedVarItems(dataVars())
+  // The special exogenous `Time` variable may have already been removed by
+  // `removeUnusedVariables` if it is not referenced explicitly in the model,
+  // so we will only include it in the listing if it is defined here.  Note
+  // that `_time` is set to `_initial_time` as the first step in the
+  // `initLevels` function, which is why it is included in the "init" group.
+  const timeVar = varWithName('_time')
+  const specialInitVars = timeVar ? [timeVar] : []
+  const expandedInitVars = expandedVarItems([...specialInitVars, ...initVars()])
+  const expandedLevelVars = expandedVarItems(levelVars())
+  const expandedAuxVars = expandedVarItems(auxVars())
+
   // Derive minimal versions of the full arrays; these only contain the minimal
   // subset of fields that are needed by the `ModelListing` class from the
   // runtime package.  The property names in the minimal objects are slightly
@@ -1230,7 +1299,15 @@ function jsonList() {
   cachedJsonList = {
     full: {
       dimensions: sortedFullDims,
-      variables: sortedFullVars
+      variables: sortedFullVars,
+      varInstances: {
+        constants: expandedConstants,
+        lookupVars: expandedLookupVars,
+        dataVars: expandedDataVars,
+        initVars: expandedInitVars,
+        levelVars: expandedLevelVars,
+        auxVars: expandedAuxVars
+      }
     },
     minimal: {
       dimensions: sortedMinimalDims,

--- a/packages/compile/src/model/model.spec.ts
+++ b/packages/compile/src/model/model.spec.ts
@@ -71,7 +71,7 @@ function readInlineModel(
 
 describe('Model', () => {
   describe('jsonList', () => {
-    it('should expose accessible variables sorted in order of execution', () => {
+    it('should expose accessible variables sorted in order of evaluation', () => {
       const listing = readInlineModel(`
         DimA: A1, A2 ~~|
         DimB: B1, B2 ~~|
@@ -85,8 +85,12 @@ describe('Model', () => {
         b[DimA, DimB] = b data[DimA, DimB] ~~|
         c data ~~|
         c = c data ~~|
-        d[DimA] = 10, 11 ~~|
-        e = INITIAL(c) ~~|
+        d = INITIAL(c) ~~|
+        e[DimA] = 1 ~~|
+        f[DimA] = 10, 11 ~~|
+        g[DimA, DimB] = 1 ~~|
+        h[DimA, DimB] = 1, 2; 3, 4; ~~|
+        i lookup((0,0), (1,1)) ~~|
         level init = 5 ~~|
         level = INTEG(x, level init) ~~|
         w = WITH LOOKUP(x, ( [(0,0)-(2,2)], (0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3) )) ~~|
@@ -156,28 +160,98 @@ describe('Model', () => {
             varIndex: 4
           },
           {
-            refId: '_d[_a1]',
-            varName: '_d',
+            refId: '_e',
+            varName: '_e',
+            subscripts: ['_dima'],
+            families: ['_dima'],
+            hasInitValue: false,
+            varType: 'const',
+            modelLHS: 'e[DimA]',
+            modelFormula: '1',
+            varIndex: 5
+          },
+          {
+            refId: '_f[_a1]',
+            varName: '_f',
             subscripts: ['_a1'],
             families: ['_dima'],
             hasInitValue: false,
             varType: 'const',
             separationDims: ['_dima'],
-            modelLHS: 'd[DimA]',
+            modelLHS: 'f[DimA]',
             modelFormula: '10,11',
-            varIndex: 5
+            varIndex: 6
           },
           {
-            refId: '_d[_a2]',
-            varName: '_d',
+            refId: '_f[_a2]',
+            varName: '_f',
             subscripts: ['_a2'],
             families: ['_dima'],
             hasInitValue: false,
             varType: 'const',
             separationDims: ['_dima'],
-            modelLHS: 'd[DimA]',
+            modelLHS: 'f[DimA]',
             modelFormula: '10,11',
-            varIndex: 5
+            varIndex: 6
+          },
+          {
+            refId: '_g',
+            varName: '_g',
+            subscripts: ['_dima', '_dimb'],
+            families: ['_dima', '_dimb'],
+            hasInitValue: false,
+            varType: 'const',
+            modelLHS: 'g[DimA,DimB]',
+            modelFormula: '1',
+            varIndex: 7
+          },
+          {
+            refId: '_h[_a1,_b1]',
+            varName: '_h',
+            subscripts: ['_a1', '_b1'],
+            families: ['_dima', '_dimb'],
+            hasInitValue: false,
+            varType: 'const',
+            separationDims: ['_dima', '_dimb'],
+            modelLHS: 'h[DimA,DimB]',
+            modelFormula: '1,2;3,4;',
+            varIndex: 8
+          },
+          {
+            refId: '_h[_a1,_b2]',
+            varName: '_h',
+            subscripts: ['_a1', '_b2'],
+            families: ['_dima', '_dimb'],
+            hasInitValue: false,
+            varType: 'const',
+            separationDims: ['_dima', '_dimb'],
+            modelLHS: 'h[DimA,DimB]',
+            modelFormula: '1,2;3,4;',
+            varIndex: 8
+          },
+          {
+            refId: '_h[_a2,_b1]',
+            varName: '_h',
+            subscripts: ['_a2', '_b1'],
+            families: ['_dima', '_dimb'],
+            hasInitValue: false,
+            varType: 'const',
+            separationDims: ['_dima', '_dimb'],
+            modelLHS: 'h[DimA,DimB]',
+            modelFormula: '1,2;3,4;',
+            varIndex: 8
+          },
+          {
+            refId: '_h[_a2,_b2]',
+            varName: '_h',
+            subscripts: ['_a2', '_b2'],
+            families: ['_dima', '_dimb'],
+            hasInitValue: false,
+            varType: 'const',
+            separationDims: ['_dima', '_dimb'],
+            modelLHS: 'h[DimA,DimB]',
+            modelFormula: '1,2;3,4;',
+            varIndex: 8
           },
           {
             refId: '_input',
@@ -186,7 +260,7 @@ describe('Model', () => {
             varType: 'const',
             modelLHS: 'input',
             modelFormula: '1',
-            varIndex: 6
+            varIndex: 9
           },
           {
             refId: '_level_init',
@@ -195,7 +269,16 @@ describe('Model', () => {
             varType: 'const',
             modelLHS: 'level init',
             modelFormula: '5',
-            varIndex: 7
+            varIndex: 10
+          },
+          {
+            refId: '_i_lookup',
+            varName: '_i_lookup',
+            hasInitValue: false,
+            varType: 'lookup',
+            modelLHS: 'i lookup',
+            modelFormula: '',
+            varIndex: 11
           },
           {
             refId: '_a_data',
@@ -206,7 +289,7 @@ describe('Model', () => {
             varType: 'data',
             modelLHS: 'a data[DimA]',
             modelFormula: '',
-            varIndex: 8
+            varIndex: 12
           },
           {
             refId: '_b_data',
@@ -217,7 +300,7 @@ describe('Model', () => {
             varType: 'data',
             modelLHS: 'b data[DimA,DimB]',
             modelFormula: '',
-            varIndex: 9
+            varIndex: 13
           },
           {
             refId: '_c_data',
@@ -226,7 +309,7 @@ describe('Model', () => {
             varType: 'data',
             modelLHS: 'c data',
             modelFormula: '',
-            varIndex: 10
+            varIndex: 14
           },
           {
             refId: '_time',
@@ -235,7 +318,7 @@ describe('Model', () => {
             varType: 'const',
             modelLHS: 'Time',
             modelFormula: '',
-            varIndex: 11
+            varIndex: 15
           },
           {
             refId: '_c',
@@ -245,17 +328,17 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'c',
             modelFormula: 'c data',
-            varIndex: 12
+            varIndex: 16
           },
           {
-            refId: '_e',
-            varName: '_e',
+            refId: '_d',
+            varName: '_d',
             hasInitValue: true,
             initReferences: ['_c'],
             varType: 'initial',
-            modelLHS: 'e',
+            modelLHS: 'd',
             modelFormula: 'INITIAL(c)',
-            varIndex: 13
+            varIndex: 17
           },
           {
             refId: '_level',
@@ -266,7 +349,7 @@ describe('Model', () => {
             varType: 'level',
             modelLHS: 'level',
             modelFormula: 'INTEG(x,level init)',
-            varIndex: 14
+            varIndex: 18
           },
           {
             refId: '_a',
@@ -278,7 +361,7 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'a[DimA]',
             modelFormula: 'a data[DimA]',
-            varIndex: 15
+            varIndex: 19
           },
           {
             refId: '_b',
@@ -290,7 +373,7 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'b[DimA,DimB]',
             modelFormula: 'b data[DimA,DimB]',
-            varIndex: 16
+            varIndex: 20
           },
           {
             refId: '_x',
@@ -300,7 +383,7 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'x',
             modelFormula: 'input',
-            varIndex: 17
+            varIndex: 21
           },
           {
             refId: '_w',
@@ -310,7 +393,7 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'w',
             modelFormula: 'WITH LOOKUP(x,([(0,0)-(2,2)],(0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3)))',
-            varIndex: 18
+            varIndex: 22
           },
           {
             refId: '_y',
@@ -320,7 +403,7 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'y',
             modelFormula: ':NOT: x',
-            varIndex: 19
+            varIndex: 23
           },
           {
             refId: '_z',
@@ -330,9 +413,299 @@ describe('Model', () => {
             varType: 'aux',
             modelLHS: 'z',
             modelFormula: 'ABS(y)',
-            varIndex: 20
+            varIndex: 24
           }
-        ]
+        ],
+        varInstances: {
+          constants: [
+            {
+              varId: '_final_time',
+              varName: 'FINAL TIME',
+              varType: 'const',
+              varIndex: 1
+            },
+            {
+              varId: '_initial_time',
+              varName: 'INITIAL TIME',
+              varType: 'const',
+              varIndex: 2
+            },
+            {
+              varId: '_saveper',
+              varName: 'SAVEPER',
+              varType: 'const',
+              varIndex: 3
+            },
+            {
+              varId: '_time_step',
+              varName: 'TIME STEP',
+              varType: 'const',
+              varIndex: 4
+            },
+            {
+              varId: '_e[_a1]',
+              varName: 'e[A1]',
+              varType: 'const',
+              varIndex: 5,
+              subscriptIndices: [0]
+            },
+            {
+              varId: '_e[_a2]',
+              varName: 'e[A2]',
+              varType: 'const',
+              varIndex: 5,
+              subscriptIndices: [1]
+            },
+            {
+              varId: '_f[_a1]',
+              varName: 'f[A1]',
+              varType: 'const',
+              varIndex: 6,
+              subscriptIndices: [0]
+            },
+            {
+              varId: '_f[_a2]',
+              varName: 'f[A2]',
+              varType: 'const',
+              varIndex: 6,
+              subscriptIndices: [1]
+            },
+            {
+              varId: '_g[_a1,_b1]',
+              varName: 'g[A1,B1]',
+              varType: 'const',
+              varIndex: 7,
+              subscriptIndices: [0, 0]
+            },
+            {
+              varId: '_g[_a1,_b2]',
+              varName: 'g[A1,B2]',
+              varType: 'const',
+              varIndex: 7,
+              subscriptIndices: [0, 1]
+            },
+            {
+              varId: '_g[_a2,_b1]',
+              varName: 'g[A2,B1]',
+              varType: 'const',
+              varIndex: 7,
+              subscriptIndices: [1, 0]
+            },
+            {
+              varId: '_g[_a2,_b2]',
+              varName: 'g[A2,B2]',
+              varType: 'const',
+              varIndex: 7,
+              subscriptIndices: [1, 1]
+            },
+            {
+              varId: '_h[_a1,_b1]',
+              varName: 'h[A1,B1]',
+              varType: 'const',
+              varIndex: 8,
+              subscriptIndices: [0, 0]
+            },
+            {
+              varId: '_h[_a1,_b2]',
+              varName: 'h[A1,B2]',
+              varType: 'const',
+              varIndex: 8,
+              subscriptIndices: [0, 1]
+            },
+            {
+              varId: '_h[_a2,_b1]',
+              varName: 'h[A2,B1]',
+              varType: 'const',
+              varIndex: 8,
+              subscriptIndices: [1, 0]
+            },
+            {
+              varId: '_h[_a2,_b2]',
+              varName: 'h[A2,B2]',
+              varType: 'const',
+              varIndex: 8,
+              subscriptIndices: [1, 1]
+            },
+            {
+              varId: '_input',
+              varName: 'input',
+              varType: 'const',
+              varIndex: 9
+            },
+            {
+              varId: '_level_init',
+              varName: 'level init',
+              varType: 'const',
+              varIndex: 10
+            }
+          ],
+          lookupVars: [
+            {
+              varId: '_i_lookup',
+              varName: 'i lookup',
+              varType: 'lookup',
+              varIndex: 11
+            }
+          ],
+          dataVars: [
+            {
+              varId: '_a_data[_a1]',
+              varName: 'a data[A1]',
+              varType: 'data',
+              varIndex: 12,
+              subscriptIndices: [0]
+            },
+            {
+              varId: '_a_data[_a2]',
+              varName: 'a data[A2]',
+              varType: 'data',
+              varIndex: 12,
+              subscriptIndices: [1]
+            },
+            {
+              varId: '_b_data[_a1,_b1]',
+              varName: 'b data[A1,B1]',
+              varType: 'data',
+              varIndex: 13,
+              subscriptIndices: [0, 0]
+            },
+            {
+              varId: '_b_data[_a1,_b2]',
+              varName: 'b data[A1,B2]',
+              varType: 'data',
+              varIndex: 13,
+              subscriptIndices: [0, 1]
+            },
+            {
+              varId: '_b_data[_a2,_b1]',
+              varName: 'b data[A2,B1]',
+              varType: 'data',
+              varIndex: 13,
+              subscriptIndices: [1, 0]
+            },
+            {
+              varId: '_b_data[_a2,_b2]',
+              varName: 'b data[A2,B2]',
+              varType: 'data',
+              varIndex: 13,
+              subscriptIndices: [1, 1]
+            },
+            {
+              varId: '_c_data',
+              varName: 'c data',
+              varType: 'data',
+              varIndex: 14
+            }
+          ],
+          initVars: [
+            {
+              varId: '_time',
+              varName: 'Time',
+              varType: 'const',
+              varIndex: 15
+            },
+            {
+              varId: '_c',
+              varName: 'c',
+              varType: 'aux',
+              varIndex: 16
+            },
+            {
+              varId: '_d',
+              varName: 'd',
+              varType: 'initial',
+              varIndex: 17
+            },
+            {
+              varId: '_level',
+              varName: 'level',
+              varType: 'level',
+              varIndex: 18
+            }
+          ],
+          levelVars: [
+            {
+              varId: '_level',
+              varName: 'level',
+              varType: 'level',
+              varIndex: 18
+            }
+          ],
+          auxVars: [
+            {
+              varId: '_a[_a1]',
+              varName: 'a[A1]',
+              varType: 'aux',
+              varIndex: 19,
+              subscriptIndices: [0]
+            },
+            {
+              varId: '_a[_a2]',
+              varName: 'a[A2]',
+              varType: 'aux',
+              varIndex: 19,
+              subscriptIndices: [1]
+            },
+            {
+              varId: '_b[_a1,_b1]',
+              varName: 'b[A1,B1]',
+              varType: 'aux',
+              varIndex: 20,
+              subscriptIndices: [0, 0]
+            },
+            {
+              varId: '_b[_a1,_b2]',
+              varName: 'b[A1,B2]',
+              varType: 'aux',
+              varIndex: 20,
+              subscriptIndices: [0, 1]
+            },
+            {
+              varId: '_b[_a2,_b1]',
+              varName: 'b[A2,B1]',
+              varType: 'aux',
+              varIndex: 20,
+              subscriptIndices: [1, 0]
+            },
+            {
+              varId: '_b[_a2,_b2]',
+              varName: 'b[A2,B2]',
+              varType: 'aux',
+              varIndex: 20,
+              subscriptIndices: [1, 1]
+            },
+            {
+              varId: '_c',
+              varName: 'c',
+              varType: 'aux',
+              varIndex: 16
+            },
+            {
+              varId: '_x',
+              varName: 'x',
+              varType: 'aux',
+              varIndex: 21
+            },
+            {
+              varId: '_w',
+              varName: 'w',
+              varType: 'aux',
+              varIndex: 22
+            },
+            {
+              varId: '_y',
+              varName: 'y',
+              varType: 'aux',
+              varIndex: 23
+            },
+            {
+              varId: '_z',
+              varName: 'z',
+              varType: 'aux',
+              varIndex: 24
+            }
+          ]
+        }
       })
 
       expect(listing.minimal).toEqual({
@@ -364,73 +737,92 @@ describe('Model', () => {
             index: 4
           },
           {
-            id: '_d',
+            id: '_e',
             dimIds: ['_dima'],
             index: 5
           },
           {
-            id: '_input',
+            id: '_f',
+            dimIds: ['_dima'],
             index: 6
           },
           {
-            id: '_level_init',
+            id: '_g',
+            dimIds: ['_dima', '_dimb'],
             index: 7
+          },
+          {
+            id: '_h',
+            dimIds: ['_dima', '_dimb'],
+            index: 8
+          },
+          {
+            id: '_input',
+            index: 9
+          },
+          {
+            id: '_level_init',
+            index: 10
+          },
+          {
+            id: '_i_lookup',
+            index: 11
           },
           {
             id: '_a_data',
             dimIds: ['_dima'],
-            index: 8
+            index: 12
           },
           {
             id: '_b_data',
             dimIds: ['_dima', '_dimb'],
-            index: 9
-          },
-          {
-            id: '_c_data',
-            index: 10
-          },
-          {
-            id: '_time',
-            index: 11
-          },
-          {
-            id: '_c',
-            index: 12
-          },
-          {
-            id: '_e',
             index: 13
           },
           {
-            id: '_level',
+            id: '_c_data',
             index: 14
+          },
+          {
+            id: '_time',
+            index: 15
+          },
+          {
+            id: '_c',
+            index: 16
+          },
+          {
+            id: '_d',
+            index: 17
+          },
+          {
+            id: '_level',
+            index: 18
           },
           {
             id: '_a',
             dimIds: ['_dima'],
-            index: 15
+            index: 19
           },
           {
             id: '_b',
             dimIds: ['_dima', '_dimb'],
-            index: 16
+            index: 20
           },
           {
             id: '_x',
-            index: 17
+            index: 21
           },
           {
             id: '_w',
-            index: 18
+            index: 22
           },
           {
             id: '_y',
-            index: 19
+            index: 23
           },
           {
             id: '_z',
-            index: 20
+            index: 24
           }
         ]
       })


### PR DESCRIPTION
Fixes #534

@ToddFincannonEI: I'm requesting your review on this one since it's in the core of the compiler and I wanted to bring it to your attention.  It doesn't have any impact on the behavior of the compiler and doesn't affect the existing JSON listing format (it only adds a new object to that listing file).

For reference, I already merged a couple small refactoring PRs that made these changes easier, see #678 and #680.  They were low-risk and well covered by tests so I figured I'd merge those first and send this one for your review to make it easier to see the distinct sets of changes.
