### PR TITLE
fix: show `<` or `>` to indicate which max diff point value is greater

### DIFF
--- a/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
+++ b/packages/check-ui-shell/src/components/compare/detail/compare-detail-box.svelte
@@ -74,7 +74,7 @@ function getMaxDiffSpan(content: CompareDetailBoxContent): string {
   if (maxDiffPoint) {
     span += '&nbsp;('
     span += `<span class="dataset-color-0">${diffPoint(maxDiffPoint.valueL)}</span>`
-    span += '&nbsp;|&nbsp;'
+    span += `&nbsp;${maxDiffPoint.valueL < maxDiffPoint.valueR ? '&lt;' : '&gt;'}&nbsp;`
     span += `<span class="dataset-color-1">${diffPoint(maxDiffPoint.valueR)}</span>`
     span += `) at ${maxDiffPoint.time}`
   }


### PR DESCRIPTION
Fixes #690 

One line change, see issue for details.  This only affects the check-ui-shell package.
