### PR TITLE
fix: update i18n code in template-svelte to handle HMR events correctly

### DIFF
--- a/examples/template-svelte/packages/app/src/_shared/i18n.ts
+++ b/examples/template-svelte/packages/app/src/_shared/i18n.ts
@@ -1,0 +1,79 @@
+import { derived, writable, type Readable, type Writable } from 'svelte/store'
+
+// NOTE: This file implements a simple i18n (internationalization) library for the app.
+// It is not intended to be a complete i18n library, but rather a simple implementation
+// that is easy to understand.  It supports setting a "dictionary" of (key, string) pairs
+// for each language.  It exports a global `_` store that can be used to get a translated
+// string for a given key.  In a Svelte file, you can use `$_(key)` to get the translated
+// string for the active language.  (We use a reactive Svelte property so that the text
+// automatically updates in the UI when the active language changes.)  The API here is very
+// close to that of the `svelte-i18n` library, so you could replace this implementation with
+// that library, or use it as a starting point for your own implementation (maybe using
+// the FormatJS libraries for string formatting).
+
+export type LangCode = string
+export type StringDictionary = Record<string, string>
+export type LangStringDictionaries = Record<LangCode, StringDictionary>
+export type Formatter = (key: string, values?: { [key: string]: string }) => string
+
+const langStrings: LangStringDictionaries = {}
+const writableLangStrings: Writable<LangStringDictionaries> = writable(langStrings)
+const writableCurrentLang: Writable<LangCode | undefined> = writable('en')
+
+// Derive a formatter function when the active language or translated strings change
+const formatter: Readable<Formatter> = derived(
+  [writableLangStrings, writableCurrentLang],
+  ([$langStrings, $currentLang]) => {
+    const strings = $langStrings[$currentLang]
+    return createFormatter(strings || {})
+  }
+)
+
+/**
+ * The global store that returns a function that can be used to get a translated string for a given key.
+ */
+export const _: Readable<Formatter> = formatter
+
+/**
+ * Initialize the i18n library with the given strings and default language.  This must
+ * be called once at app initialization time.
+ */
+export function initI18n(initialStrings: LangStringDictionaries, initialLang: LangCode) {
+  // TODO: You could initialize a proper i18n library here (such as svelte-i18n), but
+  // for now we will use a simple custom implementation
+  for (const lang of Object.keys(initialStrings)) {
+    addMessages(lang, initialStrings[lang])
+  }
+  setActiveLang(initialLang)
+}
+
+/**
+ * Add messages (i.e., translated strings) for the given language.
+ */
+export function addMessages(lang: LangCode, messages: StringDictionary) {
+  // TODO: You could initialize a proper i18n library here (such as svelte-i18n), but
+  // for now we will use a simple custom implementation
+  langStrings[lang] = messages
+  writableLangStrings.set(langStrings)
+}
+
+/**
+ * Set the active language.
+ */
+export function setActiveLang(lang: LangCode) {
+  writableCurrentLang.set(lang)
+}
+
+function createFormatter(strings: StringDictionary): Formatter {
+  return (key: string, values?: { [key: string]: string }) => {
+    if (values) {
+      throw new Error(
+        'String parameters not yet supported (you could implement this yourself using FormatJS or similar libraries)'
+      )
+    }
+    // TODO: Fall back on strings for the default language if a string is not
+    // defined in the given language strings.  For now, if the string is not
+    // defined for the active language, return the key itself.
+    return strings[key] || key
+  }
+}

--- a/examples/template-svelte/packages/app/src/_shared/strings.ts
+++ b/examples/template-svelte/packages/app/src/_shared/strings.ts
@@ -1,23 +1,18 @@
-import { writable, type Readable, type Writable } from 'svelte/store'
-// import { addMessages, init as initSvelteIntl } from 'svelte-i18n'
-
 import enStrings from '@core-strings/en'
 
-export type Formatter = (key: string, values?: { [key: string]: string }) => string
+import { addMessages, initI18n } from './i18n'
+
+// NOTE: This file works in conjunction with `i18n.ts` to provide access
+// to translated strings for the app.  This file must be kept separate from
+// `i18n.ts` so that the HMR events are handled correctly in local dev mode.
+// When strings are updated in the `<lang>.js` files, the HMR event will be
+// handled by this file so that strings are updated immediately in the UI.
 
 // NOTE: This constant is exported only for HMR handling within this file;
 // it is not intended to be consumed by outside modules.
 export const strings = {
   en: enStrings
 }
-
-const currentLang = 'en'
-const writableFormatter: Writable<Formatter> = writable(createFormatter(strings[currentLang]))
-
-/**
- * The global store that returns a function that can be used to get a translated string for a given key.
- */
-export const _: Readable<Formatter> = writableFormatter
 
 // In dev mode (with HMR enabled), when strings are updated in the `<lang>.js`
 // files, reload them into the i18n library here instead of having the change
@@ -27,13 +22,7 @@ export const _: Readable<Formatter> = writableFormatter
 if (import.meta.hot) {
   import.meta.hot.accept(newModule => {
     for (const key of Object.keys(newModule.strings)) {
-      // TODO: You could initialize a proper i18n library here (such as svelte-i18n), but
-      // for now we will use a simple custom implementation
-      // addMessages(key, newModule.strings[key])
-      strings[key] = newModule.strings[key]
-      if (key === currentLang) {
-        writableFormatter.set(createFormatter(strings[key]))
-      }
+      addMessages(key, newModule.strings[key])
     }
   })
 }
@@ -42,21 +31,6 @@ if (import.meta.hot) {
  * Initialize the strings for the available languages.
  */
 export function initStrings() {
-  // TODO: You could initialize a proper i18n library here (such as svelte-i18n), but
-  // for now we will use a simple custom implementation
-  // addMessages('en', strings['en'])
-  // initSvelteIntl({
-  //   initialLocale: 'en',
-  //   fallbackLocale: 'en'
-  // })
-  writableFormatter.set(createFormatter(strings[currentLang]))
-}
-
-function createFormatter(strings: Record<string, string>): Formatter {
-  return (key: string, values?: { [key: string]: string }) => {
-    if (values) {
-      throw new Error('String parameters not yet supported (add your own i18n library for this)')
-    }
-    return strings[key] || key
-  }
+  const defaultLang = 'en'
+  initI18n(strings, defaultLang)
 }

--- a/examples/template-svelte/packages/app/src/app-vm.ts
+++ b/examples/template-svelte/packages/app/src/app-vm.ts
@@ -2,8 +2,8 @@ import { derived, get, writable, type Readable } from 'svelte/store'
 
 import type { Config as CoreConfig, GraphSpec, SourceName } from '@core'
 
+import { _ } from '@shared/i18n'
 import { syncWritable } from '@shared/stores'
-import { _ } from '@shared/strings'
 
 import { type AppModel, type AppModelContext, createAppModel } from '@model/app-model'
 import type { WritableSliderInput } from '@model/app-model-inputs'

--- a/examples/template-svelte/packages/app/src/components/graphs/legend.svelte
+++ b/examples/template-svelte/packages/app/src/components/graphs/legend.svelte
@@ -1,7 +1,7 @@
 <!-- SCRIPT -->
 <script lang="ts">
 import type { GraphSpec } from '@core'
-import { _ } from '@shared/strings'
+import { _ } from '@shared/i18n'
 
 export let graphSpec: GraphSpec
 </script>

--- a/examples/template-svelte/packages/app/src/components/inputs/input-row.svelte
+++ b/examples/template-svelte/packages/app/src/components/inputs/input-row.svelte
@@ -1,6 +1,6 @@
 <!-- SCRIPT -->
 <script lang="ts">
-import { _ } from '@shared/strings'
+import { _ } from '@shared/i18n'
 import type { WritableSliderInput } from '@model/app-model-inputs'
 import Slider from './slider.svelte'
 

--- a/examples/template-svelte/packages/app/src/components/selector/selector.svelte
+++ b/examples/template-svelte/packages/app/src/components/selector/selector.svelte
@@ -1,6 +1,6 @@
 <!-- SCRIPT -->
 <script lang="ts">
-import { _ } from '@shared/strings'
+import { _ } from '@shared/i18n'
 
 import type { SelectorViewModel } from './selector-vm'
 


### PR DESCRIPTION
Fixes #720 

This updates template-svelte to address an issue in local dev mode that was introduced in my hasty change to remove the svelte-i18n dependency.  The HMR events are now handled correctly, and I added code comments to give a bit more guidance on how to update the code if anyone wants to have a more full-featured i18n layer for their app.
