### PR TITLE
fix: dismiss bundle selector context menu on escape key or click outside

### DIFF
--- a/packages/check-ui-shell/src/components/_shared/context-menu.svelte
+++ b/packages/check-ui-shell/src/components/_shared/context-menu.svelte
@@ -15,7 +15,7 @@ export interface ContextMenuItem {
 </script>
 
 <script lang="ts">
-import { createEventDispatcher } from 'svelte'
+import { createEventDispatcher, onMount } from 'svelte'
 
 import { clickOutside } from './click-outside'
 
@@ -40,13 +40,32 @@ $: if (initialEvent) {
   showMenu = false
 }
 
-function onItemSelected(cmd: string) {
+function handleItemSelected(cmd: string) {
   dispatch('item-selected', cmd)
 }
+
+function handleClickOut() {
+  dispatch('close')
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    dispatch('close')
+  }
+}
+
+onMount(() => {
+  // Add keydown listener for Escape key
+  window.addEventListener('keydown', handleKeyDown)
+
+  return () => {
+    window.removeEventListener('keydown', handleKeyDown)
+  }
+})
 </script>
 
 {#if showMenu}
-  <nav use:clickOutside on:clickout style="position: fixed; top:{pos.y}px; left:{pos.x}px">
+  <nav use:clickOutside on:clickout={handleClickOut} style="position: fixed; top:{pos.y}px; left:{pos.x}px">
     <div class="navbar" id="navbar">
       <ul>
         {#each items as item}
@@ -54,8 +73,10 @@ function onItemSelected(cmd: string) {
             <hr />
           {:else}
             <li>
-              <button role="menuitem" class:disabled={item.disabled === true} on:click={() => onItemSelected(item.key)}
-                ><i class={item.iconClass}></i>{item.displayText}</button
+              <button
+                role="menuitem"
+                class:disabled={item.disabled === true}
+                on:click={() => handleItemSelected(item.key)}><i class={item.iconClass}></i>{item.displayText}</button
               >
             </li>
           {/if}

--- a/packages/check-ui-shell/src/components/bundle/bundle-selector-popover.stories.svelte
+++ b/packages/check-ui-shell/src/components/bundle/bundle-selector-popover.stories.svelte
@@ -1,7 +1,7 @@
 <!-- Copyright (c) 2025 Climate Interactive / New Venture Fund. All rights reserved. -->
 
 <script module lang="ts">
-import { expect, fn, waitFor } from 'storybook/test'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
 import { defineMeta, type Args } from '@storybook/addon-svelte-csf'
 
 import { bundleManagerFromBundles } from '../../_mocks/mock-bundle-manager'
@@ -60,5 +60,67 @@ const { Story } = defineMeta({
     bundleItems.forEach(async (item, index) => {
       await expect(item).toHaveTextContent(expectedOrder[index])
     })
+  }}
+></Story>
+
+<Story
+  name="Context menu - click outside to dismiss"
+  {template}
+  args={{
+    bundleManager: bundleManagerFromBundles()
+  }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for loading to complete
+    await waitFor(() => expect(canvas.queryByText('Loading...')).not.toBeInTheDocument(), { timeout: 3000 })
+
+    // Get the first bundle item
+    const bundleItems = canvas.getAllByRole('option')
+    const firstItem = bundleItems[0]
+
+    // Right-click to open context menu
+    await userEvent.pointer({ keys: '[MouseRight>]', target: firstItem })
+
+    // Verify context menu is visible
+    const contextMenu = await waitFor(() => canvas.getByRole('menuitem'))
+    await expect(contextMenu).toBeInTheDocument()
+
+    // Click outside the context menu to dismiss it
+    await userEvent.click(canvasElement)
+
+    // Verify context menu is no longer visible
+    await waitFor(() => expect(canvas.queryByRole('menuitem')).not.toBeInTheDocument())
+  }}
+></Story>
+
+<Story
+  name="Context menu - press escape to dismiss"
+  {template}
+  args={{
+    bundleManager: bundleManagerFromBundles()
+  }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for loading to complete
+    await waitFor(() => expect(canvas.queryByText('Loading...')).not.toBeInTheDocument(), { timeout: 3000 })
+
+    // Get the first bundle item
+    const bundleItems = canvas.getAllByRole('option')
+    const firstItem = bundleItems[0]
+
+    // Right-click to open context menu
+    await userEvent.pointer({ keys: '[MouseRight>]', target: firstItem })
+
+    // Verify context menu is visible
+    const contextMenu = await waitFor(() => canvas.getByRole('menuitem'))
+    await expect(contextMenu).toBeInTheDocument()
+
+    // Press Escape to dismiss the context menu
+    await userEvent.keyboard('{Escape}')
+
+    // Verify context menu is no longer visible
+    await waitFor(() => expect(canvas.queryByRole('menuitem')).not.toBeInTheDocument())
   }}
 ></Story>

--- a/packages/check-ui-shell/src/components/bundle/bundle-selector.svelte
+++ b/packages/check-ui-shell/src/components/bundle/bundle-selector.svelte
@@ -143,6 +143,11 @@ function handleSaveCopy(bundle: BundleSpec, newName: string) {
   // Copy the local bundle file using the chosen name
   bundleManager.copyBundle(bundle, newName)
 }
+
+function handleContextMenuClose() {
+  // Close the context menu
+  contextMenuEvent = undefined
+}
 </script>
 
 <!-- TEMPLATE -->
@@ -232,6 +237,7 @@ function handleSaveCopy(bundle: BundleSpec, newName: string) {
     items={contextMenuItems}
     initialEvent={contextMenuEvent}
     on:item-selected={handleContextMenuItemSelected}
+    on:close={handleContextMenuClose}
   />
 {/if}
 


### PR DESCRIPTION
Fixes #730

Simple improvement to the UI for the bundle selector.  Only affects the check-ui-shell package.
