### PR TITLE
fix: select first tab with differences by default in model-check report

### DIFF
--- a/packages/check-ui-shell/src/components/summary/summary-vm.ts
+++ b/packages/check-ui-shell/src/components/summary/summary-vm.ts
@@ -218,9 +218,9 @@ export function createSummaryViewModel(
     addTabItem('comps-by-dataset', 'Comparisons by dataset', byDatasetTabInfo)
   }
 
-  // Select the first tab that has differences by default; if no differences, show the
-  // first ("Checks") tab by default
-  const initialTabIndex = tabItems.findIndex(item => get(item.subtitle) !== 'all clear')
+  // Select the first tab that has differences by default, i.e., the first tab with a status
+  // other than "passed".  If no differences, show the first ("Checks") tab by default.
+  const initialTabIndex = tabItems.findIndex(item => get(item.subtitleClass) !== 'status-color-passed')
   const tabBarViewModel = new TabBarViewModel(tabItems, initialTabIndex >= 0 ? initialTabIndex : 0)
 
   // Create a map of all test summaries for the baseline (all inputs at default) scenario.


### PR DESCRIPTION
Fixes #779 

Small fix to restore old/ideal behavior that was accidentally removed in model-check report.
