### PR TITLE
fix: handle more special characters when converting variable names to canonical IDs

### DIFF
--- a/packages/parse/src/_shared/canonical-id.js
+++ b/packages/parse/src/_shared/canonical-id.js
@@ -6,10 +6,14 @@ const reTrailingMark = new RegExp('\\s+!$', 'g')
 // Detect one or more consecutive whitespace or underscore characters
 const reWhitespace = new RegExp('(\\s|_)+', 'g')
 
-// Detect special punctuation characters
-// TODO: We do not currently include '!' characters in this set; we should only replace these
-// when they don't appear at the end of a (marked) dimension
-const reSpecialChars = new RegExp(`['"\\.,\\-\\$&%\\/\\|()]`, 'g')
+// Detect characters that are not valid in C/JS identifiers.  This matches anything
+// that is not a Unicode letter (\p{L}), Unicode digit (\p{N}), underscore,
+// or '!' (which is preserved for dimension marks).
+// TODO: Note that this means that we don't currently replace '!' characters that
+// appear within a variable or dimension name.  We should replace these with underscore
+// (like we do for other special characters) except in the case where they appear at
+// the end of the dimension name to indicate a marked dimension.
+const reSpecialChars = /[^\p{L}\p{N}_!]/gu
 
 /**
  * Format a model variable or subscript/dimension name into a valid C identifier (with
@@ -37,7 +41,8 @@ export function canonicalId(name) {
       // underscore character; this matches the behavior of Vensim documented here:
       //   https://www.vensim.com/documentation/ref_variable_names.html
       .replace(reWhitespace, '_')
-      // Replace each special punctuation character with an underscore
+      // Replace any characters that are not valid in C/JS identifiers with an underscore
+      // (preserving Unicode letters/digits and the '!' mark for dimensions)
       .replace(reSpecialChars, '_')
       // Convert to lower case
       .toLowerCase()

--- a/packages/parse/src/_shared/canonical-id.spec.ts
+++ b/packages/parse/src/_shared/canonical-id.spec.ts
@@ -31,6 +31,18 @@ describe('canonicalId', () => {
     // add('bslash', '\\')
     add('lparen', '(')
     add('rparen', ')')
+    add('plus', '+')
+    add('gt', '>')
+    add('lt', '<')
+    add('eq', '=')
+    add('hash', '#')
+    add('at', '@')
+    add('caret', '^')
+    add('star', '*')
+    add('tilde', '~')
+    add('question', '?')
+    add('colon', ':')
+    add('semi', ';')
     input += ' characters"'
     expected += '_characters_'
     expect(canonicalId(input)).toBe(expected)
@@ -41,6 +53,12 @@ describe('canonicalId', () => {
     // TODO: Handle backslashes
     // expect(canonicalId('"The \\"Final\\" Frontier"')).toBe('')
     expect(canonicalId("érosion d'action")).toBe('_érosion_d_action')
+  })
+
+  it('should preserve accented and Unicode letters', () => {
+    expect(canonicalId("érosion d'action")).toBe('_érosion_d_action')
+    expect(canonicalId('café')).toBe('_café')
+    expect(canonicalId('naïve')).toBe('_naïve')
   })
 
   it('should preserve mark when preceded by whitespace', () => {


### PR DESCRIPTION
Fixes #794 

See issue for details.  Instead of handling specific characters inside a quoted variable name, we now convert anything that's not a letter or digit to an underscore.  I tested with all existing sample models, with En-ROADS and C-ROADS, and with the model from the referenced discussion.

### AI disclosure

I guided Claude Code (Opus 4.6) to investigate the issue and implement the changes.  I improved the tests that Claude wrote, updated the comments, and reviewed the changes.
