### PR TITLE
fix: correct renamed variable handling so that check tests are unaffected by rename mappings

### DIFF
--- a/examples/sample-check-bundle/src/outputs.ts
+++ b/examples/sample-check-bundle/src/outputs.ts
@@ -126,7 +126,15 @@ export function getOutputs(modelVersion: number): Outputs {
   }
   const datasetGroups: Map<DatasetGroupName, DatasetKey[]> = new Map([
     ['All Outputs', keysForVarsWithSource(undefined)],
-    ['Basic Outputs', [keyForVarWithName('Output X'), keyForVarWithName('Output Y'), keyForVarWithName('Output Z')]],
+    [
+      'Basic Outputs',
+      [
+        keyForVarWithName(`Output W v${modelVersion}`),
+        keyForVarWithName('Output X'),
+        keyForVarWithName('Output Y'),
+        keyForVarWithName('Output Z')
+      ]
+    ],
     ['Static', keysForVarsWithSource('StaticData')]
   ])
 

--- a/packages/check-core/src/config/config.ts
+++ b/packages/check-core/src/config/config.ts
@@ -139,20 +139,34 @@ function handleRenames(
     return {
       modelSpec: origBundleModelR.modelSpec,
       getDatasetsForScenario: async (scenarioSpec: ScenarioSpec, datasetKeys: DatasetKey[]) => {
-        // The given dataset keys are for the "left" bundle, so convert to the "right" keys
-        const rightKeys = datasetKeys.map(rightKeyForLeftKey)
+        // The given dataset keys may be in "left" (old) or "right" (new) format depending
+        // on whether the caller is a comparison test or a check test.  Translate any old
+        // keys to new keys for the actual model call (new keys pass through unchanged).
+        const rightKeySet: Set<DatasetKey> = new Set()
+        for (const key of datasetKeys) {
+          rightKeySet.add(rightKeyForLeftKey(key))
+        }
 
-        // The returned dataset map has the "right" keys, so convert back to the "left" keys
-        const result = await origBundleModelR.getDatasetsForScenario(scenarioSpec, rightKeys)
-        const mapWithRightKeys = result.datasetMap
-        const mapWithLeftKeys: DatasetMap = new Map()
-        for (const [rightKey, dataset] of mapWithRightKeys.entries()) {
+        // Fetch from the underlying model using the "right" (new) keys
+        const result = await origBundleModelR.getDatasetsForScenario(scenarioSpec, [...rightKeySet])
+
+        // Build a result map that includes both old and new keys so that both comparison
+        // tests (which look up by old key) and check tests (which look up by new key) can
+        // find the data
+        const resultMap: DatasetMap = new Map()
+        for (const [rightKey, dataset] of result.datasetMap.entries()) {
+          // Always include the new (right) key
+          resultMap.set(rightKey, dataset)
+
+          // Also include the old (left) key alias if this variable was renamed
           const leftKey = leftKeyForRightKey(rightKey)
-          mapWithLeftKeys.set(leftKey, dataset)
+          if (leftKey !== rightKey) {
+            resultMap.set(leftKey, dataset)
+          }
         }
 
         return {
-          datasetMap: mapWithLeftKeys,
+          datasetMap: resultMap,
           modelRunTime: result.modelRunTime
         }
       },


### PR DESCRIPTION
Fixes #807 

See issue for details.  This only affects the model-check packages.

### AI disclosure

I manually wrote the test cases first. I then used Claude Code (Opus 4.6) to investigate a fix.  Claude's first solution was insufficient (documented in the issue).  The second one (including the old and new keys in the result map) was better.  I made some small adjustments and improved the comments.
