### PR TITLE
fix: update SuiteRunner to correctly handle task errors + display errors in CLI and UI

### DIFF
--- a/packages/check-core/src/suite/suite-runner.spec.ts
+++ b/packages/check-core/src/suite/suite-runner.spec.ts
@@ -389,4 +389,30 @@ describe('runSuite', () => {
 
     expect(sawOnError).toBe(true)
   })
+
+  it('should notify error callback if a task throws during model run', async () => {
+    const config = await mockConfig({ throwInCurrentGetDatasets: true })
+    const taskQueue = mockTaskQueue(config)
+
+    const error: Error = await new Promise((resolve, reject) => {
+      const callbacks: RunSuiteCallbacks = {
+        onComplete: () => {
+          reject(new Error('onComplete should not be called'))
+        },
+        onError: e => {
+          resolve(e)
+        }
+      }
+      runSuiteWithTaskQueue(config, taskQueue, callbacks)
+
+      // Fail the test (instead of hanging) if onError is not called within
+      // a reasonable amount of time
+      setTimeout(() => {
+        reject(new Error('Timed out waiting for onError'))
+      }, 1000)
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe('Fake error')
+  })
 })

--- a/packages/check-core/src/suite/suite-runner.ts
+++ b/packages/check-core/src/suite/suite-runner.ts
@@ -59,6 +59,9 @@ class SuiteRunner {
   private readonly pendingTaskKeys: Set<TaskKey> = new Set()
   private stopped = false
 
+  /** The idle listener that propagates `TaskQueue` errors to `onError`. */
+  private idleListener?: (error?: Error) => void
+
   constructor(
     private readonly config: Config,
     private readonly taskQueue: TaskQueue,
@@ -72,11 +75,38 @@ class SuiteRunner {
       }
       this.stopped = true
     }
+    this.removeIdleListener()
+  }
+
+  /**
+   * Remove the idle listener from the task queue, if one is registered.
+   */
+  private removeIdleListener(): void {
+    if (this.idleListener) {
+      this.taskQueue.removeIdleListener(this.idleListener)
+      this.idleListener = undefined
+    }
   }
 
   start(options?: RunSuiteOptions): void {
     // Send the initial progress update
     this.callbacks.onProgress?.(0)
+
+    // Listen for errors emitted by the task queue.  If a task fails (for
+    // example, a `getDatasetsForScenario` call rejects), the task queue
+    // catches the error and notifies its idle listeners.  Without this
+    // listener, the error would be silently dropped and the suite would
+    // hang waiting for tasks that will never complete.
+    this.idleListener = error => {
+      if (error) {
+        this.removeIdleListener()
+        if (!this.stopped) {
+          this.stopped = true
+          this.callbacks.onError?.(error)
+        }
+      }
+    }
+    this.taskQueue.onIdle(this.idleListener)
 
     // Create a data planner to map out the model runs that are needed to
     // efficiently fetch the data to perform both the checks and comparisons
@@ -136,24 +166,21 @@ class SuiteRunner {
     }
 
     // When all tasks have been processed, build the report and notify the completion callback
-    const buildReport = (error?: Error) => {
-      if (error) {
-        this.callbacks.onError?.(error)
-      } else {
-        const checkReport = buildCheckReport()
-        let comparisonReport: ComparisonReport
-        if (this.config.comparison) {
-          comparisonReport = {
-            testReports: buildComparisonTestReports(),
-            perfReportL: this.perfStatsL.toReport(),
-            perfReportR: this.perfStatsR.toReport()
-          }
+    const buildReport = () => {
+      this.removeIdleListener()
+      const checkReport = buildCheckReport()
+      let comparisonReport: ComparisonReport
+      if (this.config.comparison) {
+        comparisonReport = {
+          testReports: buildComparisonTestReports(),
+          perfReportL: this.perfStatsL.toReport(),
+          perfReportR: this.perfStatsR.toReport()
         }
-        this.callbacks.onComplete?.({
-          checkReport,
-          comparisonReport
-        })
       }
+      this.callbacks.onComplete?.({
+        checkReport,
+        comparisonReport
+      })
     }
 
     // Schedule a task for each data request

--- a/packages/check-ui-shell/src/_mocks/mock-bundle.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-bundle.ts
@@ -14,6 +14,7 @@ export function mockBundleModel(
   datasetsForScenario: (scenarioSpec: ScenarioSpec, datasetKeys: DatasetKey[]) => DatasetMap,
   options?: {
     delayInGetDatasets?: number
+    throwInGetDatasets?: string
   }
 ): BundleModel {
   return {
@@ -21,6 +22,9 @@ export function mockBundleModel(
     getDatasetsForScenario: async (scenarioSpec, datasetKeys) => {
       if (options?.delayInGetDatasets) {
         await new Promise(resolve => setTimeout(resolve, options.delayInGetDatasets))
+      }
+      if (options?.throwInGetDatasets) {
+        throw new Error(options.throwInGetDatasets)
       }
       return {
         datasetMap: datasetsForScenario(scenarioSpec, datasetKeys)

--- a/packages/check-ui-shell/src/app-shell.stories.svelte
+++ b/packages/check-ui-shell/src/app-shell.stories.svelte
@@ -85,6 +85,7 @@ function createBundleModel(
     //         - Output 10: 10
     dataOffset?: 'fixed' | 'variable-baseline-changed' | 'variable-baseline-unchanged'
     delayInGetDatasets?: number
+    throwInGetDatasets?: string
   }
 ): BundleModel {
   let datasetsForScenario: (scenarioSpec: ScenarioSpec, datasetKeys: DatasetKey[]) => DatasetMap
@@ -131,7 +132,8 @@ function createBundleModel(
     }
   }
   return mockBundleModel(modelSpec, datasetsForScenario, {
-    delayInGetDatasets: options?.delayInGetDatasets
+    delayInGetDatasets: options?.delayInGetDatasets,
+    throwInGetDatasets: options?.throwInGetDatasets
   })
 }
 
@@ -202,6 +204,7 @@ async function createAppViewModel(options?: {
   rightDataOffset?: 'fixed' | 'variable-baseline-changed' | 'variable-baseline-unchanged'
   delayInGetDatasets?: number
   groupScenarios?: boolean
+  throwInGetDatasets?: string
 }): Promise<AppViewModel> {
   const modelSpec = mockModelSpec()
   const bundleL = mockNamedBundle(
@@ -214,7 +217,8 @@ async function createAppViewModel(options?: {
     'current',
     createBundleModel(modelSpec, {
       dataOffset: options?.rightDataOffset,
-      delayInGetDatasets: options?.delayInGetDatasets
+      delayInGetDatasets: options?.delayInGetDatasets,
+      throwInGetDatasets: options?.throwInGetDatasets
     })
   )
   const configOptions = mockConfigOptions(bundleL, bundleR, options)
@@ -1263,6 +1267,33 @@ const { Story } = defineMeta({
     await expect(datasetRowTitles[9]).toHaveTextContent('Output 10')
 
     // TODO: Verify the detail box ordering
+  }}
+></Story>
+
+<Story
+  name="Error During Test Suite"
+  {template}
+  beforeEach={async ({ args }) => {
+    args.appViewModel = await createAppViewModel({
+      throwInGetDatasets: "Cannot read properties of undefined (reading 'varId')"
+    })
+  }}
+  play={async ({ canvasElement }) => {
+    // Wait for the error message to appear in place of the progress percent
+    await waitFor(() => {
+      const errorMessage = canvasElement.querySelector('.progress-container .error-message')
+      expect(errorMessage).not.toBeNull()
+    })
+
+    // Verify that the error message includes the thrown error's message
+    const errorMessage = canvasElement.querySelector('.progress-container .error-message')
+    await expect(errorMessage).toHaveTextContent(
+      "Error running test suite: Cannot read properties of undefined (reading 'varId')"
+    )
+
+    // Verify that the progress percent is no longer shown
+    const progress = canvasElement.querySelector('.progress-container .progress')
+    await expect(progress).toBeNull()
   }}
 ></Story>
 

--- a/packages/check-ui-shell/src/app-vm.ts
+++ b/packages/check-ui-shell/src/app-vm.ts
@@ -58,6 +58,8 @@ export class AppViewModel {
   public readonly checksInProgress: Readable<boolean>
   private readonly writableProgress: Writable<string>
   public readonly progress: Readable<string>
+  private readonly writableErrorMessage: Writable<string | undefined>
+  public readonly errorMessage: Readable<string | undefined>
   private readonly writableGeneratedDateString: Writable<string | undefined>
   public readonly userPrefs: UserPrefs
   public readonly headerViewModel: HeaderViewModel
@@ -85,6 +87,8 @@ export class AppViewModel {
     this.checksInProgress = this.writableChecksInProgress
     this.writableProgress = writable('0%')
     this.progress = this.writableProgress
+    this.writableErrorMessage = writable(undefined)
+    this.errorMessage = this.writableErrorMessage
 
     // Create the `UserPrefs` object that is passed down to the component hierarchy
     const zoom = localStorageWritableNumber('sde-check-graph-zoom', 1)
@@ -136,6 +140,7 @@ export class AppViewModel {
     // Reset the progress state
     this.writableChecksInProgress.set(true)
     this.writableProgress.set('0%')
+    this.writableErrorMessage.set(undefined)
 
     const comparisonConfig = this.appModel.config.comparison
     if (this.suiteSummary) {
@@ -195,8 +200,15 @@ export class AppViewModel {
             this.writableChecksInProgress.set(false)
           },
           onError: error => {
-            // TODO: Show error message in browser
+            // Log the error to the console
             console.error(error)
+
+            // Display the error message in the UI in place of the progress
+            // indicator.  We leave `checksInProgress` set to `true` so that the
+            // app continues to show the centered overlay (which now contains
+            // the error message instead of the percent text).
+            const message = error?.message ? error.message : String(error)
+            this.writableErrorMessage.set(`Error running test suite: ${message}`)
           }
         },
         {

--- a/packages/check-ui-shell/src/app.svelte
+++ b/packages/check-ui-shell/src/app.svelte
@@ -35,6 +35,7 @@ export let viewModel: AppViewModel
 
 const checksInProgress = viewModel.checksInProgress
 const progress = viewModel.progress
+const errorMessage = viewModel.errorMessage
 const zoom = viewModel.headerViewModel.zoom
 
 let compareDetailViewModel: CompareDetailViewModel
@@ -234,7 +235,11 @@ function onKeyDown(event: KeyboardEvent) {
     <Header on:command={onCommand} viewModel={viewModel.headerViewModel} />
     {#if $checksInProgress}
       <div class="progress-container">
-        <div class="progress">{$progress}</div>
+        {#if $errorMessage}
+          <div class="error-message">{$errorMessage}</div>
+        {:else}
+          <div class="progress">{$progress}</div>
+        {/if}
       </div>
     {:else if viewMode === 'comparison-detail'}
       <ComparisonDetail on:command={onCommand} viewModel={compareDetailViewModel} />
@@ -306,6 +311,14 @@ function onKeyDown(event: KeyboardEvent) {
   align-items: center;
   justify-content: center;
   font-size: 2em;
+}
+
+.error-message {
+  max-width: 80%;
+  text-align: center;
+  color: red;
+  font-size: 1em;
+  white-space: pre-wrap;
 }
 
 .popover-overlay {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1019,6 +1019,30 @@ importers:
         specifier: ^20.14.8
         version: 20.19.19
 
+  tests/integration/model-check-error:
+    dependencies:
+      '@sdeverywhere/build':
+        specifier: workspace:*
+        version: link:../../../packages/build
+      '@sdeverywhere/check-core':
+        specifier: workspace:*
+        version: link:../../../packages/check-core
+      '@sdeverywhere/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@sdeverywhere/plugin-check':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-check
+      '@sdeverywhere/plugin-worker':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-worker
+      '@sdeverywhere/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime
+      '@sdeverywhere/runtime-async':
+        specifier: workspace:*
+        version: link:../../../packages/runtime-async
+
   tests/integration/override-constants:
     dependencies:
       '@sdeverywhere/build':

--- a/tests/integration/model-check-error/model-check-error.mdl
+++ b/tests/integration/model-check-error/model-check-error.mdl
@@ -1,0 +1,17 @@
+{UTF-8}
+
+Production slope = 1
+  ~ [0,10,1]
+  ~
+  |
+
+Initial inventory = 1000
+  ~~|
+
+Total inventory = Initial inventory + RAMP(Production slope, 2020, 2030)
+  ~~|
+
+INITIAL TIME = 2000 ~~|
+FINAL TIME = 2100 ~~|
+TIME STEP = 1 ~~|
+SAVEPER = TIME STEP ~~|

--- a/tests/integration/model-check-error/package.json
+++ b/tests/integration/model-check-error/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "model-check-error",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf sde-prep",
+    "dev-js": "GEN_FORMAT=js sde dev",
+    "dev-wasm": "GEN_FORMAT=c sde dev",
+    "build-js": "GEN_FORMAT=js sde bundle",
+    "build-wasm": "GEN_FORMAT=c sde bundle",
+    "test-js": "./run-tests.sh js",
+    "test-wasm": "./run-tests.sh wasm",
+    "ci:int-test": "run-s clean test-js clean test-wasm"
+  },
+  "dependencies": {
+    "@sdeverywhere/build": "workspace:*",
+    "@sdeverywhere/cli": "workspace:*",
+    "@sdeverywhere/check-core": "workspace:*",
+    "@sdeverywhere/plugin-check": "workspace:*",
+    "@sdeverywhere/plugin-worker": "workspace:*",
+    "@sdeverywhere/runtime": "workspace:*",
+    "@sdeverywhere/runtime-async": "workspace:*"
+  }
+}

--- a/tests/integration/model-check-error/run-tests.sh
+++ b/tests/integration/model-check-error/run-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#
+# This script verifies that:
+#  1. The `sde bundle` command does not hang indefinitely if the model-check
+#     SuiteRunner encounters an unhandled error during a model run.
+#  2. The exit code is non-zero when the SuiteRunner reports an error.
+#  3. The error message is reported in the build output.
+#
+
+set +e # don't fail on error
+
+# The first argument selects the build variant: "js" or "wasm"
+variant="$1"
+if [ "$variant" != "js" ] && [ "$variant" != "wasm" ]; then
+  echo "Usage: $0 <js|wasm>"
+  exit 1
+fi
+
+# Run the build and capture stdout/stderr to a log file.  The build should
+# complete (or fail) within a few seconds; if it hangs, the timeout will
+# kill it and we'll fail the test.
+log_file=$(mktemp)
+trap "rm -f $log_file" EXIT
+
+echo "Running 'sde bundle' (expecting a runtime error)..."
+echo
+
+# Use perl as a portable timeout that works on macOS too
+perl -e 'alarm shift; exec @ARGV' 60 pnpm "build-$variant" > "$log_file" 2>&1
+exit_code=$?
+
+# Print the build output for context
+cat "$log_file"
+echo
+
+# Check 1: The build did not hang (exit code 142 is what perl alarm uses on SIGALRM)
+if [ $exit_code -eq 142 ] || [ $exit_code -eq 14 ]; then
+  echo "Test failed: 'sde bundle' did not complete within 60s (suite-runner is hanging)"
+  echo
+  exit 1
+fi
+
+# Check 2: The exit code is non-zero
+if [ $exit_code -eq 0 ]; then
+  echo "Test failed: 'sde bundle' reported exit code 0, but a non-zero exit code was expected"
+  echo
+  exit 1
+fi
+
+# Check 3: The error message appears in the output
+if ! grep -q "Simulated runtime error from getDatasetsForScenario" "$log_file"; then
+  echo "Test failed: expected error message was not found in the build output"
+  echo
+  exit 1
+fi
+
+echo "Test passed: 'sde bundle' completed quickly with exit code $exit_code and reported the runtime error"
+echo

--- a/tests/integration/model-check-error/sde.config.js
+++ b/tests/integration/model-check-error/sde.config.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+import { dirname, join as joinPath, resolve as resolvePath } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { checkPlugin } from '@sdeverywhere/plugin-check'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export async function config() {
+  return {
+    modelFiles: ['model-check-error.mdl'],
+
+    modelSpec: async () => {
+      return {
+        inputs: [{ varName: 'Production slope', defaultValue: 1, minValue: 0, maxValue: 10 }],
+        outputs: [{ varName: 'Total inventory' }]
+      }
+    },
+
+    plugins: [
+      // Generate a `worker.js` file that runs the generated model in a worker
+      workerPlugin(),
+
+      // Run model check, using a custom test config that wraps the bundle so
+      // that it throws a runtime error during `getDatasetsForScenario`
+      checkPlugin({
+        testConfigPath: resolvePath(joinPath(__dirname, 'test-config.js'))
+      })
+    ]
+  }
+}

--- a/tests/integration/model-check-error/test-config.js
+++ b/tests/integration/model-check-error/test-config.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+// This is a custom test config used by the bundle-runtime-error integration test.
+// It wraps the right-hand bundle's `initModel` so that `getDatasetsForScenario`
+// always throws, which exercises the error path in the SuiteRunner (i.e., the
+// `onError` callback should fire and the CLI should report a non-zero exit code).
+
+export async function getConfigOptions(bundleL, bundleR, opts) {
+  // Wrap the bundle so that `getDatasetsForScenario` throws on every call
+  function wrapBundle(bundle) {
+    return {
+      version: bundle.version,
+      modelSpec: bundle.modelSpec,
+      initModel: async () => {
+        const model = await bundle.initModel()
+        return {
+          ...model,
+          getDatasetsForScenario: async () => {
+            throw new Error('Simulated runtime error from getDatasetsForScenario')
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    current: {
+      name: opts?.bundleNameR || 'current',
+      bundle: wrapBundle(bundleR)
+    },
+    check: {
+      tests: [
+        `
+- describe: Force a runtime error
+  tests:
+    - it: should always run getDatasetsForScenario
+      scenarios:
+        - with_inputs: all
+          at: default
+      datasets:
+        - name: Total inventory
+      predicates:
+        - eq: 0
+        `
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #812 

This addresses an issue in the model-check packages.  See issue for details.  No impact on other parts of SDE.

**AI disclosure:** I used Claude Code (Opus 4.7) to track down this issue in the En-ROADS app repo.  I guided Claude on implementing the fixes in the check-core and check-ui-shell packages.
