### PR TITLE
fix: don't include cache busting parameter for data URLs when fetching remote bundles list

### DIFF
--- a/packages/check-ui-shell/src/components/bundle/bundle-manager.svelte.ts
+++ b/packages/check-ui-shell/src/components/bundle/bundle-manager.svelte.ts
@@ -114,7 +114,10 @@ export class BundleManager {
         requestCredentials = 'include'
       }
       // Add cache busting parameter to avoid issues with servers that aggressively cache files
-      remoteBundlesUrl += `?cb=${Date.now()}`
+      // (skip for `data:` URLs, which don't support query parameters)
+      if (!remoteBundlesUrl.startsWith('data:')) {
+        remoteBundlesUrl += `?cb=${Date.now()}`
+      }
       const response = await fetch(remoteBundlesUrl, { headers, credentials: requestCredentials })
       if (!response.ok) {
         throw new Error(`Failed to fetch remote bundles: ${response.statusText}`)


### PR DESCRIPTION
Fixes #815

This fixes the failing Storybook tests.  This only affects the check-ui-shell package and is really only relevant for the tests, since most normal code wouldn't use a data URL here.
