### PR TITLE
fix: convert InputVar type to a discriminated union with slider and switch variants

### DIFF
--- a/examples/sample-check-bundle/src/inputs.ts
+++ b/examples/sample-check-bundle/src/inputs.ts
@@ -31,6 +31,7 @@ export function getInputs(modelVersion: number): Inputs {
     const varId = `_${varName.toLowerCase().replace(/\s/g, '_')}`
 
     inputVars.set(varId, {
+      kind: 'slider',
       inputId,
       varId,
       varName,

--- a/packages/check-core/src/bundle/var-types.ts
+++ b/packages/check-core/src/bundle/var-types.ts
@@ -16,14 +16,11 @@ export interface RelatedItem {
 export type InputId = string
 
 /**
- * Holds information about an input variable used in the model.
+ * Holds information about an input variable that is controlled by a continuous range/slider.
  */
-export interface InputVar {
-  /**
-   * Whether this input is controlled by a continuous range/slider or a discrete on/off switch.
-   * If undefined, 'slider' will be assumed.
-   */
-  kind?: 'slider' | 'switch'
+export interface SliderInputVar {
+  /** Indicates that this input is controlled by a continuous range/slider. */
+  kind: 'slider'
   /**
    * A unique, stable identifier string for this input.
    *
@@ -46,9 +43,54 @@ export interface InputVar {
   minValue: number
   /** The maximum value of the input. */
   maxValue: number
+  /** The size of each step/increment between stops. */
+  step?: number
+  /** Whether to display the slider with the endpoints reversed. */
+  reversed?: boolean
+  /** The units string. */
+  units?: string
+  /** The string used to format the slider value. */
+  format?: string
   /** The metadata for the related input control. */
   relatedItem?: RelatedItem
 }
+
+/**
+ * Holds information about an input variable that is controlled by a discrete on/off switch.
+ */
+export interface SwitchInputVar {
+  /** Indicates that this input is controlled by a discrete on/off switch. */
+  kind: 'switch'
+  /**
+   * A unique, stable identifier string for this input.
+   *
+   * This can be used to identify an input variable in a way that is resilient
+   * to the variable's name being changed between two versions of the model.
+   */
+  inputId: InputId
+  /** The variable identifier (typically a simplified/canonical ID, like the form used in SDE). */
+  varId: VarId
+  /** The full variable name as used in the modeling tool. */
+  varName: string
+  /** The default value of the input. */
+  defaultValue: number
+  /** The value of the variable when this switch is in an "off" state. */
+  offValue: number
+  /** The value of the variable when this switch is in an "on" state. */
+  onValue: number
+  /** The set of input IDs for sliders that will be active/enabled when this switch is "off". */
+  slidersActiveWhenOff?: InputId[]
+  /** The set of input IDs for sliders that will be active/enabled when this switch is "on". */
+  slidersActiveWhenOn?: InputId[]
+  /** The metadata for the related input control. */
+  relatedItem?: RelatedItem
+}
+
+/**
+ * Holds information about an input variable used in the model.  This is a discriminated
+ * union; use the `kind` field to determine the underlying variant.
+ */
+export type InputVar = SliderInputVar | SwitchInputVar
 
 /**
  * Holds information about an output variable used in the model.

--- a/packages/check-core/src/bundle/var-types.ts
+++ b/packages/check-core/src/bundle/var-types.ts
@@ -43,14 +43,6 @@ export interface SliderInputVar {
   minValue: number
   /** The maximum value of the input. */
   maxValue: number
-  /** The size of each step/increment between stops. */
-  step?: number
-  /** Whether to display the slider with the endpoints reversed. */
-  reversed?: boolean
-  /** The units string. */
-  units?: string
-  /** The string used to format the slider value. */
-  format?: string
   /** The metadata for the related input control. */
   relatedItem?: RelatedItem
 }
@@ -78,10 +70,6 @@ export interface SwitchInputVar {
   offValue: number
   /** The value of the variable when this switch is in an "on" state. */
   onValue: number
-  /** The set of input IDs for sliders that will be active/enabled when this switch is "off". */
-  slidersActiveWhenOff?: InputId[]
-  /** The set of input IDs for sliders that will be active/enabled when this switch is "on". */
-  slidersActiveWhenOn?: InputId[]
   /** The metadata for the related input control. */
   relatedItem?: RelatedItem
 }

--- a/packages/check-core/src/check/_mocks/mock-check-scenario.ts
+++ b/packages/check-core/src/check/_mocks/mock-check-scenario.ts
@@ -99,7 +99,8 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
             value = inputVar.minValue
             break
           case 'switch':
-            throw new Error(`Cannot resolve 'at-minimum' for switch input '${inputVar.varName}'`)
+            value = inputVar.offValue
+            break
         }
         break
       case 'at-maximum':
@@ -108,7 +109,8 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
             value = inputVar.maxValue
             break
           case 'switch':
-            throw new Error(`Cannot resolve 'at-maximum' for switch input '${inputVar.varName}'`)
+            value = inputVar.onValue
+            break
         }
         break
       default:

--- a/packages/check-core/src/check/_mocks/mock-check-scenario.ts
+++ b/packages/check-core/src/check/_mocks/mock-check-scenario.ts
@@ -9,6 +9,7 @@ import type { CheckScenario, CheckScenarioInputDesc } from '../check-scenario'
 export function inputVar(inputId: string, varName: string): [VarId, InputVar] {
   const varId = `_${varName.toLowerCase()}`
   const v: InputVar = {
+    kind: 'slider',
     inputId,
     varId,
     varName,
@@ -93,10 +94,22 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
         value = inputVar.defaultValue
         break
       case 'at-minimum':
-        value = inputVar.minValue
+        switch (inputVar.kind) {
+          case 'slider':
+            value = inputVar.minValue
+            break
+          case 'switch':
+            throw new Error(`Cannot resolve 'at-minimum' for switch input '${inputVar.varName}'`)
+        }
         break
       case 'at-maximum':
-        value = inputVar.maxValue
+        switch (inputVar.kind) {
+          case 'slider':
+            value = inputVar.maxValue
+            break
+          case 'switch':
+            throw new Error(`Cannot resolve 'at-maximum' for switch input '${inputVar.varName}'`)
+        }
         break
       default:
         break

--- a/packages/check-core/src/check/check-scenario.ts
+++ b/packages/check-core/src/check/check-scenario.ts
@@ -301,10 +301,6 @@ function checkScenarioMatrix(modelSpec: ModelSpec, simplify: boolean): CheckScen
     checkScenarios.push(checkScenarioWithAllInputsAtPosition('at-minimum'))
     checkScenarios.push(checkScenarioWithAllInputsAtPosition('at-maximum'))
     for (const inputVar of modelSpec.inputVars.values()) {
-      // Only include slider inputs in the matrix; switches are excluded for now
-      if (inputVar.kind !== 'slider') {
-        continue
-      }
       checkScenarios.push(checkScenarioWithInputAtPosition(inputVar, 'at-minimum'))
       checkScenarios.push(checkScenarioWithInputAtPosition(inputVar, 'at-maximum'))
     }

--- a/packages/check-core/src/check/check-scenario.ts
+++ b/packages/check-core/src/check/check-scenario.ts
@@ -93,23 +93,34 @@ function inputPosition(position: CheckScenarioPosition): InputPosition | undefin
 }
 
 /**
- * Get the value of the input at the given position.
+ * Get the value of the input at the given position.  For switch inputs,
+ * `at-minimum` maps to the switch's `offValue` and `at-maximum` maps to its
+ * `onValue`.
  */
 function inputValueAtPosition(inputVar: InputVar, position: InputPosition): number {
-  if (position === 'at-default') {
-    return inputVar.defaultValue
-  }
-  if (inputVar.kind === 'switch') {
-    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
-    // these to "off" and "on" respectively, but that could be confusing so we will treat
-    // this as an error for now
-    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
-  }
   switch (position) {
+    case 'at-default':
+      return inputVar.defaultValue
     case 'at-minimum':
-      return inputVar.minValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.minValue
+        case 'switch':
+          return inputVar.offValue
+        default:
+          assertNever(inputVar)
+      }
+    // eslint-disable-next-line no-fallthrough
     case 'at-maximum':
-      return inputVar.maxValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.maxValue
+        case 'switch':
+          return inputVar.onValue
+        default:
+          assertNever(inputVar)
+      }
+    // eslint-disable-next-line no-fallthrough
     default:
       assertNever(position)
   }

--- a/packages/check-core/src/check/check-scenario.ts
+++ b/packages/check-core/src/check/check-scenario.ts
@@ -96,9 +96,16 @@ function inputPosition(position: CheckScenarioPosition): InputPosition | undefin
  * Get the value of the input at the given position.
  */
 function inputValueAtPosition(inputVar: InputVar, position: InputPosition): number {
+  if (position === 'at-default') {
+    return inputVar.defaultValue
+  }
+  if (inputVar.kind === 'switch') {
+    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
+    // these to "off" and "on" respectively, but that could be confusing so we will treat
+    // this as an error for now
+    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
+  }
   switch (position) {
-    case 'at-default':
-      return inputVar.defaultValue
     case 'at-minimum':
       return inputVar.minValue
     case 'at-maximum':
@@ -283,6 +290,10 @@ function checkScenarioMatrix(modelSpec: ModelSpec, simplify: boolean): CheckScen
     checkScenarios.push(checkScenarioWithAllInputsAtPosition('at-minimum'))
     checkScenarios.push(checkScenarioWithAllInputsAtPosition('at-maximum'))
     for (const inputVar of modelSpec.inputVars.values()) {
+      // Only include slider inputs in the matrix; switches are excluded for now
+      if (inputVar.kind !== 'slider') {
+        continue
+      }
       checkScenarios.push(checkScenarioWithInputAtPosition(inputVar, 'at-minimum'))
       checkScenarios.push(checkScenarioWithInputAtPosition(inputVar, 'at-maximum'))
     }

--- a/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
@@ -58,6 +58,7 @@ export function dataset(key: DatasetKey, outputVarL: OutputVar, outputVarR: Outp
 export function inputVar(inputId: InputId, varName: string, maxValue = 100): [VarId, InputVar] {
   const varId = `_${varName.toLowerCase()}`
   const v: InputVar = {
+    kind: 'slider',
     inputId,
     varId,
     varName,
@@ -82,9 +83,13 @@ export function nameForPos(position: InputPosition): string {
 }
 
 export function valueForPos(inputVar: InputVar, position: InputPosition): number | undefined {
+  if (position === 'at-default') {
+    return inputVar.defaultValue
+  }
+  if (inputVar.kind === 'switch') {
+    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
+  }
   switch (position) {
-    case 'at-default':
-      return inputVar.defaultValue
     case 'at-minimum':
       return inputVar.minValue
     case 'at-maximum':

--- a/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
+++ b/packages/check-core/src/comparison/_shared/_mocks/mock-resolved-types.ts
@@ -83,17 +83,27 @@ export function nameForPos(position: InputPosition): string {
 }
 
 export function valueForPos(inputVar: InputVar, position: InputPosition): number | undefined {
-  if (position === 'at-default') {
-    return inputVar.defaultValue
-  }
-  if (inputVar.kind === 'switch') {
-    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
-  }
   switch (position) {
+    case 'at-default':
+      return inputVar.defaultValue
     case 'at-minimum':
-      return inputVar.minValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.minValue
+        case 'switch':
+          return inputVar.offValue
+        default:
+          return undefined
+      }
     case 'at-maximum':
-      return inputVar.maxValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.maxValue
+        case 'switch':
+          return inputVar.onValue
+        default:
+          return undefined
+      }
     default:
       return undefined
   }

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
@@ -374,8 +374,18 @@ function resolveScenarioMatrix(
   const addSliderAliases = (modelInputs: ModelInputs) => {
     for (const alias of modelInputs.getAllInputIdAliases()) {
       const inputVar = modelInputs.getInputVarForName(alias)
-      if (inputVar?.kind === 'slider') {
-        inputIdAliases.add(alias)
+      if (inputVar === undefined) {
+        continue
+      }
+      switch (inputVar.kind) {
+        case 'slider':
+          inputIdAliases.add(alias)
+          break
+        case 'switch':
+          // Switches are excluded from the matrix for now
+          break
+        default:
+          assertNever(inputVar)
       }
     }
   }
@@ -849,23 +859,34 @@ function inputPosition(position: ComparisonScenarioInputPosition): InputPosition
 }
 
 /**
- * Get the value of the input at the given position.
+ * Get the value of the input at the given position.  For switch inputs,
+ * `at-minimum` maps to the switch's `offValue` and `at-maximum` maps to its
+ * `onValue`.
  */
 function inputValueAtPosition(inputVar: InputVar, position: InputPosition): number {
-  if (position === 'at-default') {
-    return inputVar.defaultValue
-  }
-  if (inputVar.kind === 'switch') {
-    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
-    // these to "off" and "on" respectively, but that could be confusing so we will treat
-    // this as an error for now
-    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
-  }
   switch (position) {
+    case 'at-default':
+      return inputVar.defaultValue
     case 'at-minimum':
-      return inputVar.minValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.minValue
+        case 'switch':
+          return inputVar.offValue
+        default:
+          assertNever(inputVar)
+      }
+    // eslint-disable-next-line no-fallthrough
     case 'at-maximum':
-      return inputVar.maxValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.maxValue
+        case 'switch':
+          return inputVar.onValue
+        default:
+          assertNever(inputVar)
+      }
+    // eslint-disable-next-line no-fallthrough
     default:
       assertNever(position)
   }

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
@@ -368,29 +368,10 @@ function resolveScenarioMatrix(
     resolveScenarioWithAllInputsAtPosition(genKey(), undefined, undefined, undefined, 'at-default')
   )
 
-  // Get the union of all input IDs appearing on either side.  Only include slider
-  // inputs in the matrix; switch inputs are excluded for now.
+  // Get the union of all input IDs appearing on either side
   const inputIdAliases: Set<InputId> = new Set()
-  const addSliderAliases = (modelInputs: ModelInputs) => {
-    for (const alias of modelInputs.getAllInputIdAliases()) {
-      const inputVar = modelInputs.getInputVarForName(alias)
-      if (inputVar === undefined) {
-        continue
-      }
-      switch (inputVar.kind) {
-        case 'slider':
-          inputIdAliases.add(alias)
-          break
-        case 'switch':
-          // Switches are excluded from the matrix for now
-          break
-        default:
-          assertNever(inputVar)
-      }
-    }
-  }
-  addSliderAliases(modelInputsL)
-  addSliderAliases(modelInputsR)
+  modelInputsL.getAllInputIdAliases().forEach(alias => inputIdAliases.add(alias))
+  modelInputsR.getAllInputIdAliases().forEach(alias => inputIdAliases.add(alias))
 
   // Create two scenarios for each input, one with the input at its minimum, and one
   // with the input at its maximum.  If the input only exists on one side, we still

--- a/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
+++ b/packages/check-core/src/comparison/config/resolve/comparison-resolver.ts
@@ -368,10 +368,19 @@ function resolveScenarioMatrix(
     resolveScenarioWithAllInputsAtPosition(genKey(), undefined, undefined, undefined, 'at-default')
   )
 
-  // Get the union of all input IDs appearing on either side
+  // Get the union of all input IDs appearing on either side.  Only include slider
+  // inputs in the matrix; switch inputs are excluded for now.
   const inputIdAliases: Set<InputId> = new Set()
-  modelInputsL.getAllInputIdAliases().forEach(alias => inputIdAliases.add(alias))
-  modelInputsR.getAllInputIdAliases().forEach(alias => inputIdAliases.add(alias))
+  const addSliderAliases = (modelInputs: ModelInputs) => {
+    for (const alias of modelInputs.getAllInputIdAliases()) {
+      const inputVar = modelInputs.getInputVarForName(alias)
+      if (inputVar?.kind === 'slider') {
+        inputIdAliases.add(alias)
+      }
+    }
+  }
+  addSliderAliases(modelInputsL)
+  addSliderAliases(modelInputsR)
 
   // Create two scenarios for each input, one with the input at its minimum, and one
   // with the input at its maximum.  If the input only exists on one side, we still
@@ -796,9 +805,18 @@ function resolveInputVarAtPosition(inputVar: InputVar, position: InputPosition):
  * Return a `ComparisonScenarioInputState` for the input at the given value.
  */
 function resolveInputVarAtValue(inputVar: InputVar, value: number): ComparisonScenarioInputState {
-  // Check that the value is in the valid range
-  // TODO: This may not be valid for switch inputs
-  if (value >= inputVar.minValue && value <= inputVar.maxValue) {
+  let inRange: boolean
+  switch (inputVar.kind) {
+    case 'slider':
+      inRange = value >= inputVar.minValue && value <= inputVar.maxValue
+      break
+    case 'switch':
+      inRange = value === inputVar.offValue || value === inputVar.onValue
+      break
+    default:
+      assertNever(inputVar)
+  }
+  if (inRange) {
     return {
       inputVar,
       value
@@ -834,9 +852,16 @@ function inputPosition(position: ComparisonScenarioInputPosition): InputPosition
  * Get the value of the input at the given position.
  */
 function inputValueAtPosition(inputVar: InputVar, position: InputPosition): number {
+  if (position === 'at-default') {
+    return inputVar.defaultValue
+  }
+  if (inputVar.kind === 'switch') {
+    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
+    // these to "off" and "on" respectively, but that could be confusing so we will treat
+    // this as an error for now
+    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
+  }
   switch (position) {
-    case 'at-default':
-      return inputVar.defaultValue
     case 'at-minimum':
       return inputVar.minValue
     case 'at-maximum':

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -33,7 +33,15 @@ export type {
   NamedBundle
 } from './bundle/bundle-types'
 
-export type { ImplVar, InputId, InputVar, OutputVar, RelatedItem } from './bundle/var-types'
+export type {
+  ImplVar,
+  InputId,
+  InputVar,
+  OutputVar,
+  RelatedItem,
+  SliderInputVar,
+  SwitchInputVar
+} from './bundle/var-types'
 
 export type {
   EncodedImplVars,

--- a/packages/check-ui-shell/src/_mocks/mock-check-scenario.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-check-scenario.ts
@@ -109,10 +109,8 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
             value = inputVar.minValue
             break
           case 'switch':
-            // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
-            // these to "off" and "on" respectively, but that could be confusing so we will treat
-            // this as an error for now
-            throw new Error(`Cannot resolve 'at-minimum' for switch input '${inputVar.varName}'`)
+            value = inputVar.offValue
+            break
         }
         break
       case 'at-maximum':
@@ -121,10 +119,8 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
             value = inputVar.maxValue
             break
           case 'switch':
-            // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
-            // these to "off" and "on" respectively, but that could be confusing so we will treat
-            // this as an error for now
-            throw new Error(`Cannot resolve 'at-maximum' for switch input '${inputVar.varName}'`)
+            value = inputVar.onValue
+            break
         }
         break
       default:

--- a/packages/check-ui-shell/src/_mocks/mock-check-scenario.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-check-scenario.ts
@@ -15,6 +15,7 @@ import { varIdForName } from './mock-vars'
 export function inputVar(inputId: string, varName: string): [VarId, InputVar] {
   const varId = varIdForName(varName)
   const v: InputVar = {
+    kind: 'slider',
     inputId,
     varId,
     varName,
@@ -103,10 +104,28 @@ export function inputDesc(inputVar: InputVar, at: InputPosition | number): Check
         value = inputVar.defaultValue
         break
       case 'at-minimum':
-        value = inputVar.minValue
+        switch (inputVar.kind) {
+          case 'slider':
+            value = inputVar.minValue
+            break
+          case 'switch':
+            // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
+            // these to "off" and "on" respectively, but that could be confusing so we will treat
+            // this as an error for now
+            throw new Error(`Cannot resolve 'at-minimum' for switch input '${inputVar.varName}'`)
+        }
         break
       case 'at-maximum':
-        value = inputVar.maxValue
+        switch (inputVar.kind) {
+          case 'slider':
+            value = inputVar.maxValue
+            break
+          case 'switch':
+            // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
+            // these to "off" and "on" respectively, but that could be confusing so we will treat
+            // this as an error for now
+            throw new Error(`Cannot resolve 'at-maximum' for switch input '${inputVar.varName}'`)
+        }
         break
       default:
         break

--- a/packages/check-ui-shell/src/_mocks/mock-comparison-scenario.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-comparison-scenario.ts
@@ -50,20 +50,27 @@ export function nameForPos(position: InputPosition): string {
 }
 
 export function valueForPos(inputVar: InputVar, position: InputPosition): number | undefined {
-  if (position === 'at-default') {
-    return inputVar.defaultValue
-  }
-  if (inputVar.kind === 'switch') {
-    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
-    // these to "off" and "on" respectively, but that could be confusing so we will treat
-    // this as an error for now
-    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
-  }
   switch (position) {
+    case 'at-default':
+      return inputVar.defaultValue
     case 'at-minimum':
-      return inputVar.minValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.minValue
+        case 'switch':
+          return inputVar.offValue
+        default:
+          return undefined
+      }
     case 'at-maximum':
-      return inputVar.maxValue
+      switch (inputVar.kind) {
+        case 'slider':
+          return inputVar.maxValue
+        case 'switch':
+          return inputVar.onValue
+        default:
+          return undefined
+      }
     default:
       return undefined
   }

--- a/packages/check-ui-shell/src/_mocks/mock-comparison-scenario.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-comparison-scenario.ts
@@ -25,6 +25,7 @@ import { varIdForName } from './mock-vars'
 export function inputVar(inputId: InputId, varName: string, minValue = 0, maxValue = 100): [VarId, InputVar] {
   const varId = varIdForName(varName)
   const v: InputVar = {
+    kind: 'slider',
     inputId,
     varId,
     varName,
@@ -49,9 +50,16 @@ export function nameForPos(position: InputPosition): string {
 }
 
 export function valueForPos(inputVar: InputVar, position: InputPosition): number | undefined {
+  if (position === 'at-default') {
+    return inputVar.defaultValue
+  }
+  if (inputVar.kind === 'switch') {
+    // TODO: Currently we do not allow setting a switch to "min" or "max"; we could map
+    // these to "off" and "on" respectively, but that could be confusing so we will treat
+    // this as an error for now
+    throw new Error(`Cannot resolve '${position}' for switch input '${inputVar.varName}'`)
+  }
   switch (position) {
-    case 'at-default':
-      return inputVar.defaultValue
     case 'at-minimum':
       return inputVar.minValue
     case 'at-maximum':

--- a/packages/check-ui-shell/src/_mocks/mock-vars.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-vars.ts
@@ -5,6 +5,7 @@ import type { DatasetKey, ImplVar, InputVar, OutputVar, VarId } from '@sdeverywh
 export function inputVar(inputId: string, varName: string): [VarId, InputVar] {
   const varId = varIdForName(varName)
   const v: InputVar = {
+    kind: 'slider',
     inputId,
     varId,
     varName,

--- a/packages/plugin-check/template-bundle/src/bundle.ts
+++ b/packages/plugin-check/template-bundle/src/bundle.ts
@@ -2,11 +2,9 @@
 
 import type {
   Bundle,
-  BundleGraphData,
   BundleModel as CheckBundleModel,
   DatasetKey,
   DatasetsResult,
-  LinkItem,
   ModelSpec,
   ScenarioSpec
 } from '@sdeverywhere/check-core'

--- a/packages/plugin-check/template-bundle/src/inputs.ts
+++ b/packages/plugin-check/template-bundle/src/inputs.ts
@@ -28,6 +28,14 @@ export interface InputSpec {
   maxValue: number
 }
 
+// TODO: For now we always treat each input as a slider, because the `InputSpec`
+// type in the `@sdeverywhere/build` package only carries slider-style fields
+// (defaultValue/minValue/maxValue) and doesn't distinguish sliders from
+// switches.  In practice, plugin-config-driven builds map a switch's
+// `offValue`/`onValue` onto `minValue`/`maxValue` here, so things work well
+// enough through the model-check pipeline, but it's not ideal.  Developers can
+// implement their own bundle (rather than using this template) if they need to
+// expose true switch inputs.
 export type Input = SliderInputVar & {
   value: InputValue
 }
@@ -39,6 +47,9 @@ export function getInputVars(inputSpecs: InputSpec[]): Map<InputVarId, Input> {
   const inputs: Map<InputVarId, Input> = new Map()
   for (const inputSpec of inputSpecs) {
     const varId = inputSpec.varId
+    // TODO: We always construct a slider-kind input here; see the note on the
+    // `Input` type above.  Switches reach this point with their off/on values
+    // already mapped onto `minValue`/`maxValue`.
     const input: Input = {
       kind: 'slider',
       inputId: inputSpec.inputId,

--- a/packages/plugin-check/template-bundle/src/inputs.ts
+++ b/packages/plugin-check/template-bundle/src/inputs.ts
@@ -2,7 +2,7 @@
 
 import { assertNever } from 'assert-never'
 
-import type { InputVar, ScenarioSpec } from '@sdeverywhere/check-core'
+import type { ScenarioSpec, SliderInputVar } from '@sdeverywhere/check-core'
 import type { InputValue, InputVarId } from '@sdeverywhere/runtime'
 import { createInputValue } from '@sdeverywhere/runtime'
 
@@ -28,7 +28,7 @@ export interface InputSpec {
   maxValue: number
 }
 
-export interface Input extends InputVar {
+export type Input = SliderInputVar & {
   value: InputValue
 }
 
@@ -40,6 +40,7 @@ export function getInputVars(inputSpecs: InputSpec[]): Map<InputVarId, Input> {
   for (const inputSpec of inputSpecs) {
     const varId = inputSpec.varId
     const input: Input = {
+      kind: 'slider',
       inputId: inputSpec.inputId,
       varId,
       varName: inputSpec.varName,

--- a/packages/plugin-check/template-tests/src/index.ts
+++ b/packages/plugin-check/template-tests/src/index.ts
@@ -10,7 +10,7 @@ import type {
   ConfigOptions,
   DatasetKey,
   InputId,
-  InputVar
+  SliderInputVar
 } from '@sdeverywhere/check-core'
 
 // Load the yaml files containing model check test definitions.  The
@@ -100,16 +100,21 @@ export async function getConfigOptions(
 }
 
 function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): ComparisonSpecs {
-  // Get the union of all input IDs appearing in left and/or right
+  // Get the union of all input IDs appearing in left and/or right.  Only include
+  // slider inputs here; switch inputs are excluded from the base comparison matrix
+  // for now.
   const allInputIds: Set<InputId> = new Set()
-  const addInputs = (bundle: Bundle, inputsMap: Map<InputId, InputVar>) => {
+  const addInputs = (bundle: Bundle, inputsMap: Map<InputId, SliderInputVar>) => {
     for (const inputVar of bundle.modelSpec.inputVars.values()) {
+      if (inputVar.kind !== 'slider') {
+        continue
+      }
       allInputIds.add(inputVar.inputId)
       inputsMap.set(inputVar.inputId, inputVar)
     }
   }
-  const inputsByIdL: Map<InputId, InputVar> = new Map()
-  const inputsByIdR: Map<InputId, InputVar> = new Map()
+  const inputsByIdL: Map<InputId, SliderInputVar> = new Map()
+  const inputsByIdR: Map<InputId, SliderInputVar> = new Map()
   addInputs(bundleL, inputsByIdL)
   addInputs(bundleR, inputsByIdR)
 

--- a/packages/plugin-check/template-tests/src/index.ts
+++ b/packages/plugin-check/template-tests/src/index.ts
@@ -106,11 +106,15 @@ function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): Comparison
   const allInputIds: Set<InputId> = new Set()
   const addInputs = (bundle: Bundle, inputsMap: Map<InputId, SliderInputVar>) => {
     for (const inputVar of bundle.modelSpec.inputVars.values()) {
-      if (inputVar.kind !== 'slider') {
-        continue
+      switch (inputVar.kind) {
+        case 'slider':
+          allInputIds.add(inputVar.inputId)
+          inputsMap.set(inputVar.inputId, inputVar)
+          break
+        case 'switch':
+          // Switches are excluded from the base comparison matrix for now
+          break
       }
-      allInputIds.add(inputVar.inputId)
-      inputsMap.set(inputVar.inputId, inputVar)
     }
   }
   const inputsByIdL: Map<InputId, SliderInputVar> = new Map()

--- a/packages/plugin-check/template-tests/src/index.ts
+++ b/packages/plugin-check/template-tests/src/index.ts
@@ -10,7 +10,7 @@ import type {
   ConfigOptions,
   DatasetKey,
   InputId,
-  SliderInputVar
+  InputVar
 } from '@sdeverywhere/check-core'
 
 // Load the yaml files containing model check test definitions.  The
@@ -100,27 +100,30 @@ export async function getConfigOptions(
 }
 
 function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): ComparisonSpecs {
-  // Get the union of all input IDs appearing in left and/or right.  Only include
-  // slider inputs here; switch inputs are excluded from the base comparison matrix
-  // for now.
+  // Get the union of all input IDs appearing in left and/or right
   const allInputIds: Set<InputId> = new Set()
-  const addInputs = (bundle: Bundle, inputsMap: Map<InputId, SliderInputVar>) => {
+  const addInputs = (bundle: Bundle, inputsMap: Map<InputId, InputVar>) => {
     for (const inputVar of bundle.modelSpec.inputVars.values()) {
-      switch (inputVar.kind) {
-        case 'slider':
-          allInputIds.add(inputVar.inputId)
-          inputsMap.set(inputVar.inputId, inputVar)
-          break
-        case 'switch':
-          // Switches are excluded from the base comparison matrix for now
-          break
-      }
+      allInputIds.add(inputVar.inputId)
+      inputsMap.set(inputVar.inputId, inputVar)
     }
   }
-  const inputsByIdL: Map<InputId, SliderInputVar> = new Map()
-  const inputsByIdR: Map<InputId, SliderInputVar> = new Map()
+  const inputsByIdL: Map<InputId, InputVar> = new Map()
+  const inputsByIdR: Map<InputId, InputVar> = new Map()
   addInputs(bundleL, inputsByIdL)
   addInputs(bundleR, inputsByIdR)
+
+  // Get the value of an input at the requested matrix position.  For sliders,
+  // this is `minValue`/`maxValue`; for switches, this is `offValue`/`onValue`
+  // (matching the convention used by check-core's position resolution).
+  const valueAtPos = (iv: InputVar, position: 'min' | 'max'): number => {
+    switch (iv.kind) {
+      case 'slider':
+        return position === 'min' ? iv.minValue : iv.maxValue
+      case 'switch':
+        return position === 'min' ? iv.offValue : iv.onValue
+    }
+  }
 
   // Create an "all inputs at default" scenario
   const scenarios: ComparisonScenarioSpec[] = []
@@ -140,16 +143,12 @@ function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): Comparison
       return
     }
 
-    // Don't add a scenario if the input's min or max is equal to its default (this is already
-    // covered by the `all_inputs_at_default` scenario from above)
-    if (position === 'min') {
-      if (inputL.minValue === inputL.defaultValue && inputR.minValue === inputR.defaultValue) {
-        return
-      }
-    } else {
-      if (inputL.maxValue === inputL.defaultValue && inputR.maxValue === inputR.defaultValue) {
-        return
-      }
+    // Don't add a scenario if the input's value at the requested position is equal to its default
+    // value(this is already covered by the `all_inputs_at_default` scenario from above)
+    const valL = valueAtPos(inputL, position)
+    const valR = valueAtPos(inputR, position)
+    if (valL === inputL.defaultValue && valR === inputR.defaultValue) {
+      return
     }
 
     // Derive the scenario name from the related slider name (or if not defined, the variable name)

--- a/packages/plugin-check/template-tests/src/index.ts
+++ b/packages/plugin-check/template-tests/src/index.ts
@@ -144,7 +144,7 @@ function createBaseComparisonSpecs(bundleL: Bundle, bundleR: Bundle): Comparison
     }
 
     // Don't add a scenario if the input's value at the requested position is equal to its default
-    // value(this is already covered by the `all_inputs_at_default` scenario from above)
+    // value (this is already covered by the `all_inputs_at_default` scenario from above)
     const valL = valueAtPos(inputL, position)
     const valR = valueAtPos(inputR, position)
     if (valL === inputL.defaultValue && valR === inputR.defaultValue) {

--- a/packages/plugin-config/src/gen-inputs.ts
+++ b/packages/plugin-config/src/gen-inputs.ts
@@ -176,8 +176,11 @@ function inputSpecFromCsv(r: CsvRow, context: ConfigContext): InputSpec | undefi
       )
     }
 
-    const minValue = Math.min(offValue, onValue)
-    const maxValue = Math.max(offValue, onValue)
+    // By convention, we map switch off/on values to min/max respectively (these
+    // are mainly used by plugin-check when configuring "at-min" and "at-max"
+    // scenarios)
+    const minValue = offValue
+    const maxValue = onValue
     context.addInputVariable(inputId, varName, defaultValue, minValue, maxValue)
 
     // The `controlled input ids` field dictates which rows are active


### PR DESCRIPTION
Fixes #819

See issue for details.  This only affects the model-check packages.  I also made a small related change in the plugin-config package to correct the mapping for switch off/on values to follow the conventions we use elsewhere.
