### PR TITLE
fix: replace SheetJS dependency with custom XLSX file reader

### DIFF
--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -19,6 +19,7 @@
     "@sdeverywhere/parse": "^0.1.4",
     "byline": "^5.0.0",
     "csv-parse": "^5.3.3",
+    "fflate": "^0.8.3",
     "ramda": "^0.27.0",
     "strip-bom": "^5.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -21,8 +21,7 @@
     "csv-parse": "^5.3.3",
     "fflate": "^0.8.3",
     "ramda": "^0.27.0",
-    "strip-bom": "^5.0.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    "strip-bom": "^5.0.0"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/packages/compile/src/_shared/helpers.js
+++ b/packages/compile/src/_shared/helpers.js
@@ -1,9 +1,9 @@
-import * as fs from 'node:fs'
 import util from 'util'
 import { parse as parseCsv } from 'csv-parse/sync'
 import * as R from 'ramda'
-import XLSX from 'xlsx'
+
 import B from './bufx.js'
+import { readXlsx as readXlsxFile, resetXlsxCache } from './xlsx.js'
 
 import { canonicalId, canonicalVarId } from '@sdeverywhere/parse'
 
@@ -24,12 +24,6 @@ let nextLevelVarSeq = 1
 let nextAuxVarSeq = 1
 // parsed csv data cache
 let csvData = new Map()
-// parsed xlsx data cache
-let xlsxData = new Map()
-
-// Newer versions of the xlsx package require manually setting the `fs` instance
-// before using the `XLSX.readFile` function
-XLSX.set_fs(fs)
 
 // XXX: This is needed for tests due to sequence numbers being in module-level storage
 export function resetHelperState() {
@@ -40,7 +34,7 @@ export function resetHelperState() {
   nextLevelVarSeq = 1
   nextAuxVarSeq = 1
   csvData.clear()
-  xlsxData.clear()
+  resetXlsxCache()
 }
 
 export let canonicalName = name => {
@@ -203,15 +197,10 @@ export let isIterable = obj => {
 }
 // Command helpers
 export let readXlsx = pathname => {
-  // Read the XLSX file at the pathname and parse it.
-  // Return a `XLSX.WorkBook` object that can be used to access the data.
-  // Cache parsed files to support multiple reads from different equations.
-  let xlsx = xlsxData.get(pathname)
-  if (!xlsx) {
-    xlsx = XLSX.readFile(pathname, { cellDates: true })
-    xlsxData.set(pathname, xlsx)
-  }
-  return xlsx
+  // Read the XLSX file at the pathname and parse it. Return a workbook
+  // object ({ SheetNames, Sheets }) that can be used to access the data.
+  // The underlying reader caches parsed files by path.
+  return readXlsxFile(pathname)
 }
 export let readCsv = (pathname, delimiter = ',') => {
   // Read the CSV file at the pathname and parse it with the given delimiter.

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -258,7 +258,7 @@ function parseSheetXml(xml, sharedStrings) {
 
     let value
     if (t === 's') {
-      // Shared string: <v>N</v> where N indexes sharedStrings.
+      // Shared string: <v>N</v> where N indexes sharedStrings
       const vStart = body.indexOf('<v>')
       if (vStart < 0) {
         continue
@@ -396,7 +396,7 @@ export function readXlsx(pathname) {
     if (!target) {
       continue
     }
-    // Targets are workbook-relative; normalize to the zip entry path.
+    // Targets are workbook-relative; normalize to the zip entry path
     target = target.startsWith('/') ? target.slice(1) : 'xl/' + target
     const bytes = unzipped[target]
     if (!bytes) {
@@ -406,7 +406,7 @@ export function readXlsx(pathname) {
     sheetXmls[name] = bytes
   }
 
-  // Lazy materialization: parse a sheet only when first accessed.
+  // Lazy materialization: parse a sheet only when first accessed
   const parsedSheets = Object.create(null)
   const sheetsProxy = new Proxy(
     {},

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+/**
+ * Minimal xlsx reader and cell-address utilities used by the `GET DIRECT ...`
+ * code paths in the compile pipeline. We read numeric cell values only; strings,
+ * dates, and formula source text are surfaced where present but are not the
+ * focus of this module.
+ */
+
+const A_UPPER = 65 // 'A'
+const A_LOWER = 97 // 'a'
+
+/**
+ * Decode an A1-style cell ref to a zero-indexed `{c, r}`.
+ *
+ * Returns `{c: -1, r: -1}` for invalid input, matching the behavior of
+ * `XLSX.utils.decode_cell` from SheetJS.
+ *
+ * @param {string} ref The cell reference (e.g. 'A1', 'AZ100').
+ * @returns The zero-indexed column and row.
+ */
+export function decodeCell(ref) {
+  let c = 0
+  let i = 0
+  const len = ref.length
+  while (i < len) {
+    const code = ref.charCodeAt(i)
+    if (code >= 65 && code <= 90) {
+      c = c * 26 + (code - A_UPPER + 1)
+    } else if (code >= 97 && code <= 122) {
+      c = c * 26 + (code - A_LOWER + 1)
+    } else {
+      break
+    }
+    i++
+  }
+  if (i === 0) return { c: -1, r: -1 }
+  const r = parseInt(ref.slice(i), 10)
+  if (!Number.isFinite(r) || r < 1) return { c: -1, r: -1 }
+  return { c: c - 1, r: r - 1 }
+}
+
+/**
+ * Encode a zero-indexed `{c, r}` to an A1-style cell ref.
+ *
+ * @param {{c: number, r: number}} addr The zero-indexed column and row.
+ * @returns The A1-style cell reference (e.g. 'B7').
+ */
+export function encodeCell({ c, r }) {
+  let col = ''
+  let n = c + 1
+  while (n > 0) {
+    const rem = (n - 1) % 26
+    col = String.fromCharCode(A_UPPER + rem) + col
+    n = Math.floor((n - 1) / 26)
+  }
+  return col + (r + 1)
+}
+
+/**
+ * Decode a column ref (e.g. 'AB') to a zero-indexed column number.
+ *
+ * @param {string} ref The column reference.
+ * @returns The zero-indexed column number, or -1 if the input is invalid.
+ */
+export function decodeCol(ref) {
+  if (ref.length === 0) return -1
+  let c = 0
+  for (let i = 0; i < ref.length; i++) {
+    const code = ref.charCodeAt(i)
+    if (code >= 65 && code <= 90) c = c * 26 + (code - A_UPPER + 1)
+    else if (code >= 97 && code <= 122) c = c * 26 + (code - A_LOWER + 1)
+    else return -1
+  }
+  return c - 1
+}
+
+/**
+ * Decode a row ref (e.g. '13') to a zero-indexed row number.
+ *
+ * @param {string} ref The row reference.
+ * @returns The zero-indexed row number, or -1 if the input is invalid.
+ */
+export function decodeRow(ref) {
+  const r = parseInt(ref, 10)
+  return Number.isFinite(r) && r >= 1 ? r - 1 : -1
+}

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -93,8 +93,14 @@ export function decodeRow(ref) {
 // XML helpers
 //
 
-// Pull one attribute value out of a tag's attribute list. Cheaper than a full
-// attribute parser when we only need a few specific keys.
+/**
+ * Pull one attribute value out of a tag's attribute list. Cheaper than a full
+ * attribute parser when we only need a few specific keys.
+ *
+ * @param {string} attrs The portion of a start tag containing the attributes.
+ * @param {string} name The attribute name to look up.
+ * @returns The attribute value, or undefined if the attribute is not present.
+ */
 function getAttr(attrs, name) {
   const i = attrs.indexOf(name + '="')
   if (i < 0) return undefined
@@ -103,6 +109,14 @@ function getAttr(attrs, name) {
   return end < 0 ? undefined : attrs.slice(start, end)
 }
 
+/**
+ * Decode the standard XML entities (`&lt;`, `&gt;`, `&amp;`, `&quot;`,
+ * `&apos;`) along with numeric character references (`&#NN;` and `&#xNN;`)
+ * in the given text. Returns the input unchanged when no entities are present.
+ *
+ * @param {string} s The raw text from an XML element body or attribute.
+ * @returns The decoded string.
+ */
 function decodeXmlText(s) {
   if (s.indexOf('&') === -1) return s
   return s
@@ -119,10 +133,16 @@ function decodeXmlText(s) {
 // Parsers
 //
 
+/**
+ * Parse the contents of `xl/sharedStrings.xml` into a positional array of
+ * decoded strings. A shared string may contain rich-text runs
+ * (`<si><r><t>foo</t></r><r><t>bar</t></r></si>`); concatenate all `<t>`
+ * elements within each `<si>` so the result comes back as a single string.
+ *
+ * @param {string} xml The contents of the `xl/sharedStrings.xml` file.
+ * @returns An array indexed by shared-string position.
+ */
 function parseSharedStrings(xml) {
-  // <sst><si><t>foo</t></si>...<si><r><t>part</t></r><r><t>part2</t></r></si></sst>
-  // Concatenate all <t> elements within each <si> so rich-text runs come back
-  // as a single string.
   const strings = []
   const siRe = /<si\b[^>]*>([\s\S]*?)<\/si>/g
   const tRe = /<t\b[^>]*>([\s\S]*?)<\/t>/g
@@ -140,10 +160,17 @@ function parseSharedStrings(xml) {
   return strings
 }
 
+/**
+ * Parse the contents of `xl/workbook.xml` into the list of sheet definitions,
+ * each with the user-visible sheet name and the relationship id that maps to
+ * the sheet's XML part. Attribute spans can contain `/` (in URLs), so the
+ * regex matches up to the self-closing `/>` non-greedily rather than excluding
+ * `/` from the attribute span.
+ *
+ * @param {string} xml The contents of the `xl/workbook.xml` file.
+ * @returns An array of `{ name, rid }` objects in workbook order.
+ */
 function parseWorkbookXml(xml) {
-  // Match <sheet name="..." sheetId="..." r:id="..."/>. Attribute spans can
-  // contain `/` (in URLs), so we match up to the self-closing `/>` non-greedily
-  // rather than excluding `/` from the attribute span.
   const sheets = []
   const re = /<sheet\b([\s\S]*?)\/>/g
   let m
@@ -156,6 +183,13 @@ function parseWorkbookXml(xml) {
   return sheets
 }
 
+/**
+ * Parse the contents of `xl/_rels/workbook.xml.rels` into a map from
+ * relationship id to its target path (the part within the xlsx zip).
+ *
+ * @param {string} xml The contents of the `xl/_rels/workbook.xml.rels` file.
+ * @returns An object mapping relationship id to target path.
+ */
 function parseWorkbookRels(xml) {
   const rels = Object.create(null)
   const re = /<Relationship\b([\s\S]*?)\/>/g
@@ -169,7 +203,16 @@ function parseWorkbookRels(xml) {
   return rels
 }
 
-// Scan a worksheet's XML and build the sparse cell map.
+/**
+ * Scan a worksheet's XML and build a sparse cell map shaped like the SheetJS
+ * worksheet object: `{ [cellRef]: { v }, '!ref': 'A1:Z99' }`. Skips empty
+ * cells, error cells (`t='e'`), and numeric cells whose cached `<v>` value
+ * is missing.
+ *
+ * @param {string} xml The contents of a `xl/worksheets/sheet*.xml` file.
+ * @param {string[]} sharedStrings The shared-string table for resolving `t='s'` cells.
+ * @returns The sparse cell map, including a `!ref` key if any cells were read.
+ */
 function parseSheetXml(xml, sharedStrings) {
   const cells = Object.create(null)
   // Match each <c .../> or <c ...>...</c> block. The attribute span is

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -37,9 +37,13 @@ export function decodeCell(ref) {
     }
     i++
   }
-  if (i === 0) return { c: -1, r: -1 }
+  if (i === 0) {
+    return { c: -1, r: -1 }
+  }
   const r = parseInt(ref.slice(i), 10)
-  if (!Number.isFinite(r) || r < 1) return { c: -1, r: -1 }
+  if (!Number.isFinite(r) || r < 1) {
+    return { c: -1, r: -1 }
+  }
   return { c: c - 1, r: r - 1 }
 }
 
@@ -67,13 +71,19 @@ export function encodeCell({ c, r }) {
  * @returns The zero-indexed column number, or -1 if the input is invalid.
  */
 export function decodeCol(ref) {
-  if (ref.length === 0) return -1
+  if (ref.length === 0) {
+    return -1
+  }
   let c = 0
   for (let i = 0; i < ref.length; i++) {
     const code = ref.charCodeAt(i)
-    if (code >= 65 && code <= 90) c = c * 26 + (code - A_UPPER + 1)
-    else if (code >= 97 && code <= 122) c = c * 26 + (code - A_LOWER + 1)
-    else return -1
+    if (code >= 65 && code <= 90) {
+      c = c * 26 + (code - A_UPPER + 1)
+    } else if (code >= 97 && code <= 122) {
+      c = c * 26 + (code - A_LOWER + 1)
+    } else {
+      return -1
+    }
   }
   return c - 1
 }
@@ -103,7 +113,9 @@ export function decodeRow(ref) {
  */
 function getAttr(attrs, name) {
   const i = attrs.indexOf(name + '="')
-  if (i < 0) return undefined
+  if (i < 0) {
+    return undefined
+  }
   const start = i + name.length + 2
   const end = attrs.indexOf('"', start)
   return end < 0 ? undefined : attrs.slice(start, end)
@@ -118,7 +130,9 @@ function getAttr(attrs, name) {
  * @returns The decoded string.
  */
 function decodeXmlText(s) {
-  if (s.indexOf('&') === -1) return s
+  if (s.indexOf('&') === -1) {
+    return s
+  }
   return s
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
@@ -178,7 +192,9 @@ function parseWorkbookXml(xml) {
     const attrs = m[1]
     const name = getAttr(attrs, 'name')
     const rid = getAttr(attrs, 'r:id') ?? getAttr(attrs, 'r:Id')
-    if (name && rid) sheets.push({ name, rid })
+    if (name && rid) {
+      sheets.push({ name, rid })
+    }
   }
   return sheets
 }
@@ -198,7 +214,9 @@ function parseWorkbookRels(xml) {
     const attrs = m[1]
     const id = getAttr(attrs, 'Id')
     const target = getAttr(attrs, 'Target')
-    if (id && target) rels[id] = target
+    if (id && target) {
+      rels[id] = target
+    }
   }
   return rels
 }
@@ -225,59 +243,85 @@ function parseSheetXml(xml, sharedStrings) {
   while ((m = cRe.exec(xml)) !== null) {
     const attrs = m[1]
     const ref = getAttr(attrs, 'r')
-    if (!ref) continue
-    if (m[2] === '/>') continue // empty cell
+    if (!ref) {
+      continue
+    }
+    if (m[2] === '/>') {
+      // empty cell
+      continue
+    }
     const body = m[3]
-    if (!body) continue
+    if (!body) {
+      continue
+    }
     const t = getAttr(attrs, 't')
 
     let value
     if (t === 's') {
       // Shared string: <v>N</v> where N indexes sharedStrings.
       const vStart = body.indexOf('<v>')
-      if (vStart < 0) continue
+      if (vStart < 0) {
+        continue
+      }
       const vEnd = body.indexOf('</v>', vStart + 3)
       const idx = parseInt(body.slice(vStart + 3, vEnd), 10)
       value = sharedStrings[idx]
     } else if (t === 'inlineStr') {
       // Inline string: <is><t>...</t></is>
       const tStart = body.indexOf('<t')
-      if (tStart < 0) continue
+      if (tStart < 0) {
+        continue
+      }
       const tOpenEnd = body.indexOf('>', tStart)
       const tEnd = body.indexOf('</t>', tOpenEnd)
       value = decodeXmlText(body.slice(tOpenEnd + 1, tEnd))
     } else if (t === 'str') {
       // Formula result as string: <v>...</v>
       const vStart = body.indexOf('<v>')
-      if (vStart < 0) continue
+      if (vStart < 0) {
+        continue
+      }
       const vEnd = body.indexOf('</v>', vStart + 3)
       value = decodeXmlText(body.slice(vStart + 3, vEnd))
     } else if (t === 'b') {
       const vStart = body.indexOf('<v>')
-      if (vStart < 0) continue
+      if (vStart < 0) {
+        continue
+      }
       value = body.charCodeAt(vStart + 3) === 49 // '1'
     } else if (t === 'e') {
-      continue // error cell, skip
+      // error cell, skip
+      continue
     } else {
       // Numeric (t === 'n' or absent). Skip any <f> formula tag and read the
       // cached <v> value. If <v> is missing (e.g. an uncalculated formula),
       // skip the cell so the caller's missing-cell handling kicks in.
       const vStart = body.indexOf('<v>')
-      if (vStart < 0) continue
+      if (vStart < 0) {
+        continue
+      }
       const vEnd = body.indexOf('</v>', vStart + 3)
       const num = +body.slice(vStart + 3, vEnd)
-      if (Number.isNaN(num)) continue
+      if (Number.isNaN(num)) {
+        continue
+      }
       value = num
     }
 
     cells[ref] = { v: value }
 
     const addr = decodeCell(ref)
-    if (addr.r > maxRow) maxRow = addr.r
-    if (addr.c > maxCol) maxCol = addr.c
+    if (addr.r > maxRow) {
+      maxRow = addr.r
+    }
+    if (addr.c > maxCol) {
+      maxCol = addr.c
+    }
   }
 
-  if (maxRow >= 0) cells['!ref'] = `A1:${encodeCell({ c: maxCol, r: maxRow })}`
+  if (maxRow >= 0) {
+    cells['!ref'] = `A1:${encodeCell({ c: maxCol, r: maxRow })}`
+  }
   return cells
 }
 
@@ -315,7 +359,9 @@ export function resetXlsxCache() {
  */
 export function readXlsx(pathname) {
   const cached = workbookCache.get(pathname)
-  if (cached) return cached
+  if (cached) {
+    return cached
+  }
 
   const buf = fs.readFileSync(pathname)
   const unzipped = unzipSync(buf, {
@@ -347,11 +393,15 @@ export function readXlsx(pathname) {
   const sheetXmls = Object.create(null)
   for (const { name, rid } of sheetDefs) {
     let target = rels[rid]
-    if (!target) continue
+    if (!target) {
+      continue
+    }
     // Targets are workbook-relative; normalize to the zip entry path.
     target = target.startsWith('/') ? target.slice(1) : 'xl/' + target
     const bytes = unzipped[target]
-    if (!bytes) continue
+    if (!bytes) {
+      continue
+    }
     sheetNames.push(name)
     sheetXmls[name] = bytes
   }
@@ -362,10 +412,16 @@ export function readXlsx(pathname) {
     {},
     {
       get(_, name) {
-        if (typeof name !== 'string') return undefined
-        if (parsedSheets[name]) return parsedSheets[name]
+        if (typeof name !== 'string') {
+          return undefined
+        }
+        if (parsedSheets[name]) {
+          return parsedSheets[name]
+        }
         const bytes = sheetXmls[name]
-        if (!bytes) return undefined
+        if (!bytes) {
+          return undefined
+        }
         const parsed = parseSheetXml(strFromU8(bytes), sharedStrings)
         parsedSheets[name] = parsed
         return parsed
@@ -377,7 +433,9 @@ export function readXlsx(pathname) {
         return sheetNames.slice()
       },
       getOwnPropertyDescriptor(_, name) {
-        if (typeof name !== 'string' || !(name in sheetXmls)) return undefined
+        if (typeof name !== 'string' || !(name in sheetXmls)) {
+          return undefined
+        }
         const bytes = sheetXmls[name]
         if (!parsedSheets[name]) {
           parsedSheets[name] = parseSheetXml(strFromU8(bytes), sharedStrings)

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -13,6 +13,131 @@ import { strFromU8, unzipSync } from 'fflate'
 const A_UPPER = 65 // 'A'
 const A_LOWER = 97 // 'a'
 
+// Workbook cache, mirroring the previous SheetJS readXlsx behavior in
+// helpers.js. Each xlsx file is parsed at most once per process.
+const workbookCache = new Map()
+
+/**
+ * Reset the workbook cache. Intended for tests that load the same path with
+ * different contents across runs.
+ */
+export function resetXlsxCache() {
+  workbookCache.clear()
+}
+
+/**
+ * Read the xlsx file at the given path and return a workbook shaped like the
+ * SheetJS `WorkBook`:
+ *
+ * ```
+ * { SheetNames: string[],
+ *   Sheets: { [name]: { [cellRef]: { v }, '!ref': 'A1:Z99' } } }
+ * ```
+ *
+ * Sheets are materialized lazily — the first time a sheet name is read from
+ * `Sheets`, its XML is parsed; subsequent reads of the same sheet return the
+ * cached map. Workbooks are also cached by path.
+ *
+ * @param {string} pathname The absolute path to the xlsx file.
+ * @returns The parsed workbook.
+ */
+export function readXlsx(pathname) {
+  const cached = workbookCache.get(pathname)
+  if (cached) {
+    return cached
+  }
+
+  const buf = fs.readFileSync(pathname)
+  const unzipped = unzipSync(buf, {
+    filter: file => {
+      const n = file.name
+      return (
+        n === 'xl/workbook.xml' ||
+        n === 'xl/sharedStrings.xml' ||
+        n === 'xl/_rels/workbook.xml.rels' ||
+        (n.startsWith('xl/worksheets/sheet') && n.endsWith('.xml'))
+      )
+    }
+  })
+
+  const wbBytes = unzipped['xl/workbook.xml']
+  const relsBytes = unzipped['xl/_rels/workbook.xml.rels']
+  if (!wbBytes || !relsBytes) {
+    throw new Error(`Failed to read xlsx file (missing workbook or rels): ${pathname}`)
+  }
+  const wbXml = strFromU8(wbBytes)
+  const relsXml = strFromU8(relsBytes)
+  const ssBytes = unzipped['xl/sharedStrings.xml']
+
+  const sheetDefs = parseWorkbookXml(wbXml)
+  const rels = parseWorkbookRels(relsXml)
+  const sharedStrings = ssBytes ? parseSharedStrings(strFromU8(ssBytes)) : []
+
+  const sheetNames = []
+  const sheetXmls = Object.create(null)
+  for (const { name, rid } of sheetDefs) {
+    let target = rels[rid]
+    if (!target) {
+      continue
+    }
+    // Targets are workbook-relative; normalize to the zip entry path
+    target = target.startsWith('/') ? target.slice(1) : 'xl/' + target
+    const bytes = unzipped[target]
+    if (!bytes) {
+      continue
+    }
+    sheetNames.push(name)
+    sheetXmls[name] = bytes
+  }
+
+  // Lazy materialization: parse a sheet only when first accessed
+  const parsedSheets = Object.create(null)
+  const sheetsProxy = new Proxy(
+    {},
+    {
+      get(_, name) {
+        if (typeof name !== 'string') {
+          return undefined
+        }
+        if (parsedSheets[name]) {
+          return parsedSheets[name]
+        }
+        const bytes = sheetXmls[name]
+        if (!bytes) {
+          return undefined
+        }
+        const parsed = parseSheetXml(strFromU8(bytes), sharedStrings)
+        parsedSheets[name] = parsed
+        return parsed
+      },
+      has(_, name) {
+        return typeof name === 'string' && name in sheetXmls
+      },
+      ownKeys() {
+        return sheetNames.slice()
+      },
+      getOwnPropertyDescriptor(_, name) {
+        if (typeof name !== 'string' || !(name in sheetXmls)) {
+          return undefined
+        }
+        const bytes = sheetXmls[name]
+        if (!parsedSheets[name]) {
+          parsedSheets[name] = parseSheetXml(strFromU8(bytes), sharedStrings)
+        }
+        return { enumerable: true, configurable: true, value: parsedSheets[name], writable: false }
+      }
+    }
+  )
+
+  const workbook = { SheetNames: sheetNames, Sheets: sheetsProxy }
+  workbookCache.set(pathname, workbook)
+  return workbook
+}
+
+//
+// Cell address utilities
+//
+
 /**
  * Decode an A1-style cell ref to a zero-indexed `{c, r}`.
  *
@@ -324,129 +449,4 @@ function parseSheetXml(xml, sharedStrings) {
     cells['!ref'] = `A1:${encodeCell({ c: maxCol, r: maxRow })}`
   }
   return cells
-}
-
-//
-// Public API
-//
-
-// Workbook cache, mirroring the previous SheetJS readXlsx behavior in
-// helpers.js. Each xlsx file is parsed at most once per process.
-const workbookCache = new Map()
-
-/**
- * Reset the workbook cache. Intended for tests that load the same path with
- * different contents across runs.
- */
-export function resetXlsxCache() {
-  workbookCache.clear()
-}
-
-/**
- * Read the xlsx file at the given path and return a workbook shaped like the
- * SheetJS `WorkBook`:
- *
- * ```
- * { SheetNames: string[],
- *   Sheets: { [name]: { [cellRef]: { v }, '!ref': 'A1:Z99' } } }
- * ```
- *
- * Sheets are materialized lazily — the first time a sheet name is read from
- * `Sheets`, its XML is parsed; subsequent reads of the same sheet return the
- * cached map. Workbooks are also cached by path.
- *
- * @param {string} pathname The absolute path to the xlsx file.
- * @returns The parsed workbook.
- */
-export function readXlsx(pathname) {
-  const cached = workbookCache.get(pathname)
-  if (cached) {
-    return cached
-  }
-
-  const buf = fs.readFileSync(pathname)
-  const unzipped = unzipSync(buf, {
-    filter: file => {
-      const n = file.name
-      return (
-        n === 'xl/workbook.xml' ||
-        n === 'xl/sharedStrings.xml' ||
-        n === 'xl/_rels/workbook.xml.rels' ||
-        (n.startsWith('xl/worksheets/sheet') && n.endsWith('.xml'))
-      )
-    }
-  })
-
-  const wbBytes = unzipped['xl/workbook.xml']
-  const relsBytes = unzipped['xl/_rels/workbook.xml.rels']
-  if (!wbBytes || !relsBytes) {
-    throw new Error(`Failed to read xlsx file (missing workbook or rels): ${pathname}`)
-  }
-  const wbXml = strFromU8(wbBytes)
-  const relsXml = strFromU8(relsBytes)
-  const ssBytes = unzipped['xl/sharedStrings.xml']
-
-  const sheetDefs = parseWorkbookXml(wbXml)
-  const rels = parseWorkbookRels(relsXml)
-  const sharedStrings = ssBytes ? parseSharedStrings(strFromU8(ssBytes)) : []
-
-  const sheetNames = []
-  const sheetXmls = Object.create(null)
-  for (const { name, rid } of sheetDefs) {
-    let target = rels[rid]
-    if (!target) {
-      continue
-    }
-    // Targets are workbook-relative; normalize to the zip entry path
-    target = target.startsWith('/') ? target.slice(1) : 'xl/' + target
-    const bytes = unzipped[target]
-    if (!bytes) {
-      continue
-    }
-    sheetNames.push(name)
-    sheetXmls[name] = bytes
-  }
-
-  // Lazy materialization: parse a sheet only when first accessed
-  const parsedSheets = Object.create(null)
-  const sheetsProxy = new Proxy(
-    {},
-    {
-      get(_, name) {
-        if (typeof name !== 'string') {
-          return undefined
-        }
-        if (parsedSheets[name]) {
-          return parsedSheets[name]
-        }
-        const bytes = sheetXmls[name]
-        if (!bytes) {
-          return undefined
-        }
-        const parsed = parseSheetXml(strFromU8(bytes), sharedStrings)
-        parsedSheets[name] = parsed
-        return parsed
-      },
-      has(_, name) {
-        return typeof name === 'string' && name in sheetXmls
-      },
-      ownKeys() {
-        return sheetNames.slice()
-      },
-      getOwnPropertyDescriptor(_, name) {
-        if (typeof name !== 'string' || !(name in sheetXmls)) {
-          return undefined
-        }
-        const bytes = sheetXmls[name]
-        if (!parsedSheets[name]) {
-          parsedSheets[name] = parseSheetXml(strFromU8(bytes), sharedStrings)
-        }
-        return { enumerable: true, configurable: true, value: parsedSheets[name], writable: false }
-      }
-    }
-  )
-
-  const workbook = { SheetNames: sheetNames, Sheets: sheetsProxy }
-  workbookCache.set(pathname, workbook)
-  return workbook
 }

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -42,11 +42,13 @@ export function resetXlsxCache() {
  * @returns The parsed workbook.
  */
 export function readXlsx(pathname) {
+  // Return the cached workbook if we've already parsed this file
   const cached = workbookCache.get(pathname)
   if (cached) {
     return cached
   }
 
+  // Decompress the file, keeping only the entries we actually read from
   const buf = readFileSync(pathname)
   const unzipped = unzipSync(buf, {
     filter: file => {
@@ -60,6 +62,7 @@ export function readXlsx(pathname) {
     }
   })
 
+  // Pull out the workbook, rels, and (optional) sharedStrings parts as text
   const wbBytes = unzipped['xl/workbook.xml']
   const relsBytes = unzipped['xl/_rels/workbook.xml.rels']
   if (!wbBytes || !relsBytes) {
@@ -69,10 +72,16 @@ export function readXlsx(pathname) {
   const relsXml = strFromU8(relsBytes)
   const ssBytes = unzipped['xl/sharedStrings.xml']
 
+  // Build the sheet definitions
   const sheetDefs = parseWorkbookXml(wbXml)
+
+  // Build the rid-to-target map
   const rels = parseWorkbookRels(relsXml)
+
+  // Build the shared-string table
   const sharedStrings = ssBytes ? parseSharedStrings(strFromU8(ssBytes)) : []
 
+  // Resolve each sheet's rid to its worksheet XML bytes in the zip
   const sheetNames = []
   const sheetXmls = Object.create(null)
   for (const { name, rid } of sheetDefs) {
@@ -129,6 +138,7 @@ export function readXlsx(pathname) {
     }
   )
 
+  // Cache the workbook by path so subsequent reads are free
   const workbook = { SheetNames: sheetNames, Sheets: sheetsProxy }
   workbookCache.set(pathname, workbook)
   return workbook
@@ -148,6 +158,8 @@ export function readXlsx(pathname) {
  * @returns The zero-indexed column and row.
  */
 export function decodeCell(ref) {
+  // Walk the leading run of letters, accumulating the 1-based column index
+  // in bijective base 26 (A=1, B=2, ..., Z=26, AA=27, AB=28, ...)
   let c = 0
   let i = 0
   const len = ref.length
@@ -162,13 +174,19 @@ export function decodeCell(ref) {
     }
     i++
   }
+
+  // Reject input that didn't start with at least one letter
   if (i === 0) {
     return { c: -1, r: -1 }
   }
+
+  // Parse the trailing row digits; rows are 1-based, so reject 0/non-numeric
   const r = parseInt(ref.slice(i), 10)
   if (!Number.isFinite(r) || r < 1) {
     return { c: -1, r: -1 }
   }
+
+  // Convert column and row to the zero-indexed form callers expect
   return { c: c - 1, r: r - 1 }
 }
 
@@ -179,6 +197,8 @@ export function decodeCell(ref) {
  * @returns The A1-style cell reference (e.g. 'B7').
  */
 export function encodeCell({ c, r }) {
+  // Convert the 1-based column index to bijective base-26 letters, building
+  // the string right-to-left (one letter per iteration, least-significant first)
   let col = ''
   let n = c + 1
   while (n > 0) {
@@ -186,6 +206,8 @@ export function encodeCell({ c, r }) {
     col = String.fromCharCode(A_UPPER + rem) + col
     n = Math.floor((n - 1) / 26)
   }
+
+  // Rows in A1 notation are 1-based
   return col + (r + 1)
 }
 
@@ -196,9 +218,13 @@ export function encodeCell({ c, r }) {
  * @returns The zero-indexed column number, or -1 if the input is invalid.
  */
 export function decodeCol(ref) {
+  // Empty input has no valid column
   if (ref.length === 0) {
     return -1
   }
+
+  // Same bijective base-26 walk as decodeCell, but every character must be a
+  // letter — anything else (including a row digit) is rejected
   let c = 0
   for (let i = 0; i < ref.length; i++) {
     const code = ref.charCodeAt(i)
@@ -210,6 +236,8 @@ export function decodeCol(ref) {
       return -1
     }
   }
+
+  // Convert from 1-based to zero-indexed
   return c - 1
 }
 
@@ -220,6 +248,7 @@ export function decodeCol(ref) {
  * @returns The zero-indexed row number, or -1 if the input is invalid.
  */
 export function decodeRow(ref) {
+  // Parse the 1-based row number and convert to zero-indexed; -1 on invalid input
   const r = parseInt(ref, 10)
   return Number.isFinite(r) && r >= 1 ? r - 1 : -1
 }
@@ -237,10 +266,13 @@ export function decodeRow(ref) {
  * @returns The attribute value, or undefined if the attribute is not present.
  */
 function getAttr(attrs, name) {
+  // Look for `name="` — every attribute we care about uses double quotes
   const i = attrs.indexOf(name + '="')
   if (i < 0) {
     return undefined
   }
+
+  // Slice out everything between the opening and closing quote
   const start = i + name.length + 2
   const end = attrs.indexOf('"', start)
   return end < 0 ? undefined : attrs.slice(start, end)
@@ -255,9 +287,14 @@ function getAttr(attrs, name) {
  * @returns The decoded string.
  */
 function decodeXmlText(s) {
+  // Fast path: most cell text contains no entities, so skip the regex chain
   if (s.indexOf('&') === -1) {
     return s
   }
+
+  // Decode the named entities, then decimal and hex numeric refs, and finally
+  // `&amp;` — leaving `&amp;` last avoids accidentally producing `&lt;` etc.
+  // from a literal `&amp;lt;` in the source
   return s
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
@@ -282,11 +319,15 @@ function decodeXmlText(s) {
  * @returns An array indexed by shared-string position.
  */
 function parseSharedStrings(xml) {
+  // Outer regex finds each <si> entry; inner regex finds <t> runs within it.
+  // The two are stateful (global) regexes, so reset the inner one per <si>.
   const strings = []
   const siRe = /<si\b[^>]*>([\s\S]*?)<\/si>/g
   const tRe = /<t\b[^>]*>([\s\S]*?)<\/t>/g
   let m
   while ((m = siRe.exec(xml)) !== null) {
+    // Concatenate every <t> chunk inside this <si> — rich-text runs collapse
+    // into a single plain string
     const inner = m[1]
     let s = ''
     let tm
@@ -310,10 +351,13 @@ function parseSharedStrings(xml) {
  * @returns An array of `{ name, rid }` objects in workbook order.
  */
 function parseWorkbookXml(xml) {
+  // Iterate every <sheet .../> element in workbook order
   const sheets = []
   const re = /<sheet\b([\s\S]*?)\/>/g
   let m
   while ((m = re.exec(xml)) !== null) {
+    // Each sheet is identified by its user-visible name and its rid pointer;
+    // the rid attribute is conventionally lowercase but accept both forms
     const attrs = m[1]
     const name = getAttr(attrs, 'name')
     const rid = getAttr(attrs, 'r:id') ?? getAttr(attrs, 'r:Id')
@@ -332,10 +376,12 @@ function parseWorkbookXml(xml) {
  * @returns An object mapping relationship id to target path.
  */
 function parseWorkbookRels(xml) {
+  // Iterate every <Relationship .../> element
   const rels = Object.create(null)
   const re = /<Relationship\b([\s\S]*?)\/>/g
   let m
   while ((m = re.exec(xml)) !== null) {
+    // Record the Id -> Target mapping; ignore the Type and other attributes
     const attrs = m[1]
     const id = getAttr(attrs, 'Id')
     const target = getAttr(attrs, 'Target')
@@ -358,6 +404,7 @@ function parseWorkbookRels(xml) {
  */
 function parseSheetXml(xml, sharedStrings) {
   const cells = Object.create(null)
+
   // Match each <c .../> or <c ...>...</c> block. The attribute span is
   // non-greedy so self-closing cells (e.g. <c r="I4" s="1"/>) don't accidentally
   // swallow following cells.
@@ -434,8 +481,10 @@ function parseSheetXml(xml, sharedStrings) {
       value = num
     }
 
+    // Store the cell under its A1 ref, matching the SheetJS sheet shape
     cells[ref] = { v: value }
 
+    // Track the bounding row/col so we can synthesize the !ref range below
     const addr = decodeCell(ref)
     if (addr.r > maxRow) {
       maxRow = addr.r
@@ -445,6 +494,7 @@ function parseSheetXml(xml, sharedStrings) {
     }
   }
 
+  // Expose the sheet's bounding range as !ref when any cells were read
   if (maxRow >= 0) {
     cells['!ref'] = `A1:${encodeCell({ c: maxCol, r: maxRow })}`
   }

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Climate Interactive / New Venture Fund
 
-import fs from 'node:fs'
+import { readFileSync } from 'node:fs'
 
 import { strFromU8, unzipSync } from 'fflate'
 
@@ -47,7 +47,7 @@ export function readXlsx(pathname) {
     return cached
   }
 
-  const buf = fs.readFileSync(pathname)
+  const buf = readFileSync(pathname)
   const unzipped = unzipSync(buf, {
     filter: file => {
       const n = file.name

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -4,11 +4,11 @@ import fs from 'node:fs'
 
 import { strFromU8, unzipSync } from 'fflate'
 
-/**
- * Minimal xlsx reader and cell-address utilities used by the `GET DIRECT ...`
- * code paths in the compile pipeline. We read numeric cell values only; strings
- * are surfaced where present but are not the focus of this module.
- */
+//
+// Minimal xlsx reader and cell-address utilities used by the `GET DIRECT ...`
+// code paths in the compile pipeline. We read numeric cell values only; strings
+// are surfaced where present but are not the focus of this module.
+//
 
 const A_UPPER = 65 // 'A'
 const A_LOWER = 97 // 'a'
@@ -89,7 +89,9 @@ export function decodeRow(ref) {
   return Number.isFinite(r) && r >= 1 ? r - 1 : -1
 }
 
-// --- XML helpers ---
+//
+// XML helpers
+//
 
 // Pull one attribute value out of a tag's attribute list. Cheaper than a full
 // attribute parser when we only need a few specific keys.
@@ -113,7 +115,9 @@ function decodeXmlText(s) {
     .replace(/&amp;/g, '&')
 }
 
-// --- parsers ---
+//
+// Parsers
+//
 
 function parseSharedStrings(xml) {
   // <sst><si><t>foo</t></si>...<si><r><t>part</t></r><r><t>part2</t></r></si></sst>
@@ -234,7 +238,9 @@ function parseSheetXml(xml, sharedStrings) {
   return cells
 }
 
-// --- public API ---
+//
+// Public API
+//
 
 // Workbook cache, mirroring the previous SheetJS readXlsx behavior in
 // helpers.js. Each xlsx file is parsed at most once per process.

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -284,13 +284,14 @@ function parseSheetXml(xml, sharedStrings) {
       const vEnd = body.indexOf('</v>', vStart + 3)
       value = decodeXmlText(body.slice(vStart + 3, vEnd))
     } else if (t === 'b') {
+      // Boolean: <v>0</v> or <v>1</v>
       const vStart = body.indexOf('<v>')
       if (vStart < 0) {
         continue
       }
       value = body.charCodeAt(vStart + 3) === 49 // '1'
     } else if (t === 'e') {
-      // error cell, skip
+      // Error cell, skip
       continue
     } else {
       // Numeric (t === 'n' or absent). Skip any <f> formula tag and read the

--- a/packages/compile/src/_shared/xlsx.js
+++ b/packages/compile/src/_shared/xlsx.js
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Climate Interactive / New Venture Fund
 
+import fs from 'node:fs'
+
+import { strFromU8, unzipSync } from 'fflate'
+
 /**
  * Minimal xlsx reader and cell-address utilities used by the `GET DIRECT ...`
- * code paths in the compile pipeline. We read numeric cell values only; strings,
- * dates, and formula source text are surfaced where present but are not the
- * focus of this module.
+ * code paths in the compile pipeline. We read numeric cell values only; strings
+ * are surfaced where present but are not the focus of this module.
  */
 
 const A_UPPER = 65 // 'A'
@@ -84,4 +87,258 @@ export function decodeCol(ref) {
 export function decodeRow(ref) {
   const r = parseInt(ref, 10)
   return Number.isFinite(r) && r >= 1 ? r - 1 : -1
+}
+
+// --- XML helpers ---
+
+// Pull one attribute value out of a tag's attribute list. Cheaper than a full
+// attribute parser when we only need a few specific keys.
+function getAttr(attrs, name) {
+  const i = attrs.indexOf(name + '="')
+  if (i < 0) return undefined
+  const start = i + name.length + 2
+  const end = attrs.indexOf('"', start)
+  return end < 0 ? undefined : attrs.slice(start, end)
+}
+
+function decodeXmlText(s) {
+  if (s.indexOf('&') === -1) return s
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&amp;/g, '&')
+}
+
+// --- parsers ---
+
+function parseSharedStrings(xml) {
+  // <sst><si><t>foo</t></si>...<si><r><t>part</t></r><r><t>part2</t></r></si></sst>
+  // Concatenate all <t> elements within each <si> so rich-text runs come back
+  // as a single string.
+  const strings = []
+  const siRe = /<si\b[^>]*>([\s\S]*?)<\/si>/g
+  const tRe = /<t\b[^>]*>([\s\S]*?)<\/t>/g
+  let m
+  while ((m = siRe.exec(xml)) !== null) {
+    const inner = m[1]
+    let s = ''
+    let tm
+    tRe.lastIndex = 0
+    while ((tm = tRe.exec(inner)) !== null) {
+      s += decodeXmlText(tm[1])
+    }
+    strings.push(s)
+  }
+  return strings
+}
+
+function parseWorkbookXml(xml) {
+  // Match <sheet name="..." sheetId="..." r:id="..."/>. Attribute spans can
+  // contain `/` (in URLs), so we match up to the self-closing `/>` non-greedily
+  // rather than excluding `/` from the attribute span.
+  const sheets = []
+  const re = /<sheet\b([\s\S]*?)\/>/g
+  let m
+  while ((m = re.exec(xml)) !== null) {
+    const attrs = m[1]
+    const name = getAttr(attrs, 'name')
+    const rid = getAttr(attrs, 'r:id') ?? getAttr(attrs, 'r:Id')
+    if (name && rid) sheets.push({ name, rid })
+  }
+  return sheets
+}
+
+function parseWorkbookRels(xml) {
+  const rels = Object.create(null)
+  const re = /<Relationship\b([\s\S]*?)\/>/g
+  let m
+  while ((m = re.exec(xml)) !== null) {
+    const attrs = m[1]
+    const id = getAttr(attrs, 'Id')
+    const target = getAttr(attrs, 'Target')
+    if (id && target) rels[id] = target
+  }
+  return rels
+}
+
+// Scan a worksheet's XML and build the sparse cell map.
+function parseSheetXml(xml, sharedStrings) {
+  const cells = Object.create(null)
+  // Match each <c .../> or <c ...>...</c> block. The attribute span is
+  // non-greedy so self-closing cells (e.g. <c r="I4" s="1"/>) don't accidentally
+  // swallow following cells.
+  const cRe = /<c\b([^>]*?)(\/>|>([\s\S]*?)<\/c>)/g
+  let maxRow = -1
+  let maxCol = -1
+  let m
+  while ((m = cRe.exec(xml)) !== null) {
+    const attrs = m[1]
+    const ref = getAttr(attrs, 'r')
+    if (!ref) continue
+    if (m[2] === '/>') continue // empty cell
+    const body = m[3]
+    if (!body) continue
+    const t = getAttr(attrs, 't')
+
+    let value
+    if (t === 's') {
+      // Shared string: <v>N</v> where N indexes sharedStrings.
+      const vStart = body.indexOf('<v>')
+      if (vStart < 0) continue
+      const vEnd = body.indexOf('</v>', vStart + 3)
+      const idx = parseInt(body.slice(vStart + 3, vEnd), 10)
+      value = sharedStrings[idx]
+    } else if (t === 'inlineStr') {
+      // Inline string: <is><t>...</t></is>
+      const tStart = body.indexOf('<t')
+      if (tStart < 0) continue
+      const tOpenEnd = body.indexOf('>', tStart)
+      const tEnd = body.indexOf('</t>', tOpenEnd)
+      value = decodeXmlText(body.slice(tOpenEnd + 1, tEnd))
+    } else if (t === 'str') {
+      // Formula result as string: <v>...</v>
+      const vStart = body.indexOf('<v>')
+      if (vStart < 0) continue
+      const vEnd = body.indexOf('</v>', vStart + 3)
+      value = decodeXmlText(body.slice(vStart + 3, vEnd))
+    } else if (t === 'b') {
+      const vStart = body.indexOf('<v>')
+      if (vStart < 0) continue
+      value = body.charCodeAt(vStart + 3) === 49 // '1'
+    } else if (t === 'e') {
+      continue // error cell, skip
+    } else {
+      // Numeric (t === 'n' or absent). Skip any <f> formula tag and read the
+      // cached <v> value. If <v> is missing (e.g. an uncalculated formula),
+      // skip the cell so the caller's missing-cell handling kicks in.
+      const vStart = body.indexOf('<v>')
+      if (vStart < 0) continue
+      const vEnd = body.indexOf('</v>', vStart + 3)
+      const num = +body.slice(vStart + 3, vEnd)
+      if (Number.isNaN(num)) continue
+      value = num
+    }
+
+    cells[ref] = { v: value }
+
+    const addr = decodeCell(ref)
+    if (addr.r > maxRow) maxRow = addr.r
+    if (addr.c > maxCol) maxCol = addr.c
+  }
+
+  if (maxRow >= 0) cells['!ref'] = `A1:${encodeCell({ c: maxCol, r: maxRow })}`
+  return cells
+}
+
+// --- public API ---
+
+// Workbook cache, mirroring the previous SheetJS readXlsx behavior in
+// helpers.js. Each xlsx file is parsed at most once per process.
+const workbookCache = new Map()
+
+/**
+ * Reset the workbook cache. Intended for tests that load the same path with
+ * different contents across runs.
+ */
+export function resetXlsxCache() {
+  workbookCache.clear()
+}
+
+/**
+ * Read the xlsx file at the given path and return a workbook shaped like the
+ * SheetJS `WorkBook`:
+ *
+ * ```
+ * { SheetNames: string[],
+ *   Sheets: { [name]: { [cellRef]: { v }, '!ref': 'A1:Z99' } } }
+ * ```
+ *
+ * Sheets are materialized lazily — the first time a sheet name is read from
+ * `Sheets`, its XML is parsed; subsequent reads of the same sheet return the
+ * cached map. Workbooks are also cached by path.
+ *
+ * @param {string} pathname The absolute path to the xlsx file.
+ * @returns The parsed workbook.
+ */
+export function readXlsx(pathname) {
+  const cached = workbookCache.get(pathname)
+  if (cached) return cached
+
+  const buf = fs.readFileSync(pathname)
+  const unzipped = unzipSync(buf, {
+    filter: file => {
+      const n = file.name
+      return (
+        n === 'xl/workbook.xml' ||
+        n === 'xl/sharedStrings.xml' ||
+        n === 'xl/_rels/workbook.xml.rels' ||
+        (n.startsWith('xl/worksheets/sheet') && n.endsWith('.xml'))
+      )
+    }
+  })
+
+  const wbBytes = unzipped['xl/workbook.xml']
+  const relsBytes = unzipped['xl/_rels/workbook.xml.rels']
+  if (!wbBytes || !relsBytes) {
+    throw new Error(`Failed to read xlsx file (missing workbook or rels): ${pathname}`)
+  }
+  const wbXml = strFromU8(wbBytes)
+  const relsXml = strFromU8(relsBytes)
+  const ssBytes = unzipped['xl/sharedStrings.xml']
+
+  const sheetDefs = parseWorkbookXml(wbXml)
+  const rels = parseWorkbookRels(relsXml)
+  const sharedStrings = ssBytes ? parseSharedStrings(strFromU8(ssBytes)) : []
+
+  const sheetNames = []
+  const sheetXmls = Object.create(null)
+  for (const { name, rid } of sheetDefs) {
+    let target = rels[rid]
+    if (!target) continue
+    // Targets are workbook-relative; normalize to the zip entry path.
+    target = target.startsWith('/') ? target.slice(1) : 'xl/' + target
+    const bytes = unzipped[target]
+    if (!bytes) continue
+    sheetNames.push(name)
+    sheetXmls[name] = bytes
+  }
+
+  // Lazy materialization: parse a sheet only when first accessed.
+  const parsedSheets = Object.create(null)
+  const sheetsProxy = new Proxy(
+    {},
+    {
+      get(_, name) {
+        if (typeof name !== 'string') return undefined
+        if (parsedSheets[name]) return parsedSheets[name]
+        const bytes = sheetXmls[name]
+        if (!bytes) return undefined
+        const parsed = parseSheetXml(strFromU8(bytes), sharedStrings)
+        parsedSheets[name] = parsed
+        return parsed
+      },
+      has(_, name) {
+        return typeof name === 'string' && name in sheetXmls
+      },
+      ownKeys() {
+        return sheetNames.slice()
+      },
+      getOwnPropertyDescriptor(_, name) {
+        if (typeof name !== 'string' || !(name in sheetXmls)) return undefined
+        const bytes = sheetXmls[name]
+        if (!parsedSheets[name]) {
+          parsedSheets[name] = parseSheetXml(strFromU8(bytes), sharedStrings)
+        }
+        return { enumerable: true, configurable: true, value: parsedSheets[name], writable: false }
+      }
+    }
+  )
+
+  const workbook = { SheetNames: sheetNames, Sheets: sheetsProxy }
+  workbookCache.set(pathname, workbook)
+  return workbook
 }

--- a/packages/compile/src/_shared/xlsx.spec.ts
+++ b/packages/compile/src/_shared/xlsx.spec.ts
@@ -105,7 +105,7 @@ interface XlsxParts {
   sheets: { name: string; sheetData: string }[]
   sharedStrings?: string[]
   // Raw override for xl/sharedStrings.xml — used when we need <r>/<t> rich text
-  // or other shapes that the `sharedStrings` shorthand can't express.
+  // or other shapes that the `sharedStrings` shorthand can't express
   sharedStringsXml?: string
 }
 
@@ -113,7 +113,7 @@ function buildXlsx(parts: XlsxParts): string {
   const sheets = parts.sheets
   const files: Record<string, Uint8Array> = {}
 
-  // Minimal required files for SheetJS-compatible workbook structure.
+  // Minimal required files for SheetJS-compatible workbook structure
   files['[Content_Types].xml'] = strToU8(
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -288,7 +288,7 @@ describe('readXlsx', () => {
         }
       ],
       // We can't express rich-text runs through the buildXlsx convenience, so
-      // construct the sharedStrings part as a raw override.
+      // construct the sharedStrings part as a raw override
       sharedStringsXml: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
 <si><r><t>foo</t></r><r><t> </t></r><r><t>bar</t></r></si>
@@ -337,7 +337,7 @@ describe('readXlsx', () => {
   it('should not let self-closing empty cells shift subsequent cells', () => {
     // Regression for a bug found in the prototype: a greedy regex matched
     // across <c r="I4" s="1"/><c r="J4" s="1"/><c r="BC4"><v>1840</v></c>
-    // and recorded BC4's value at I4.
+    // and recorded BC4's value at I4
     const file = buildXlsx({
       sheets: [
         {
@@ -380,7 +380,7 @@ describe('readXlsx', () => {
     })
     const wb1 = readXlsx(file)
     const wb2 = readXlsx(file)
-    // Same instance — workbook-level cache mirrors the previous SheetJS path.
+    // Same instance — workbook-level cache mirrors the previous SheetJS path
     expect(wb1).toBe(wb2)
   })
 })

--- a/packages/compile/src/_shared/xlsx.spec.ts
+++ b/packages/compile/src/_shared/xlsx.spec.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+import { describe, expect, it } from 'vitest'
+
+import { decodeCell, decodeCol, decodeRow, encodeCell } from './xlsx.js'
+
+describe('decodeCell', () => {
+  it('should decode a single-letter column ref', () => {
+    expect(decodeCell('A1')).toEqual({ c: 0, r: 0 })
+    expect(decodeCell('B2')).toEqual({ c: 1, r: 1 })
+    expect(decodeCell('Z1')).toEqual({ c: 25, r: 0 })
+  })
+
+  it('should decode a two-letter column ref', () => {
+    expect(decodeCell('AA1')).toEqual({ c: 26, r: 0 })
+    expect(decodeCell('AB1')).toEqual({ c: 27, r: 0 })
+    expect(decodeCell('AZ100')).toEqual({ c: 51, r: 99 })
+    expect(decodeCell('ZZ999')).toEqual({ c: 701, r: 998 })
+  })
+
+  it('should decode a three-letter column ref', () => {
+    expect(decodeCell('AAA1')).toEqual({ c: 702, r: 0 })
+  })
+
+  it('should accept lowercase column letters', () => {
+    expect(decodeCell('a1')).toEqual({ c: 0, r: 0 })
+    expect(decodeCell('ab1')).toEqual({ c: 27, r: 0 })
+  })
+
+  it('should return {-1, -1} for invalid input', () => {
+    expect(decodeCell('')).toEqual({ c: -1, r: -1 })
+    expect(decodeCell('1')).toEqual({ c: -1, r: -1 })
+    expect(decodeCell('A')).toEqual({ c: -1, r: -1 })
+    expect(decodeCell('A0')).toEqual({ c: -1, r: -1 })
+  })
+})
+
+describe('encodeCell', () => {
+  it('should round-trip with decodeCell', () => {
+    const cases = ['A1', 'B2', 'Z1', 'AA1', 'AZ100', 'ZZ999', 'AAA1']
+    for (const ref of cases) {
+      expect(encodeCell(decodeCell(ref))).toBe(ref)
+    }
+  })
+
+  it('should encode {0, 0} as A1', () => {
+    expect(encodeCell({ c: 0, r: 0 })).toBe('A1')
+  })
+
+  it('should encode {25, 0} as Z1', () => {
+    expect(encodeCell({ c: 25, r: 0 })).toBe('Z1')
+  })
+
+  it('should encode {26, 0} as AA1', () => {
+    expect(encodeCell({ c: 26, r: 0 })).toBe('AA1')
+  })
+})
+
+describe('decodeCol', () => {
+  it('should decode a single-letter column', () => {
+    expect(decodeCol('A')).toBe(0)
+    expect(decodeCol('Z')).toBe(25)
+  })
+
+  it('should decode a multi-letter column', () => {
+    expect(decodeCol('AA')).toBe(26)
+    expect(decodeCol('AB')).toBe(27)
+    expect(decodeCol('ZZ')).toBe(701)
+  })
+
+  it('should accept lowercase input', () => {
+    expect(decodeCol('ab')).toBe(27)
+  })
+
+  it('should return -1 for invalid input', () => {
+    expect(decodeCol('')).toBe(-1)
+    expect(decodeCol('A1')).toBe(-1)
+  })
+})
+
+describe('decodeRow', () => {
+  it('should decode a row to zero-indexed', () => {
+    expect(decodeRow('1')).toBe(0)
+    expect(decodeRow('13')).toBe(12)
+    expect(decodeRow('100')).toBe(99)
+  })
+
+  it('should return -1 for invalid input', () => {
+    expect(decodeRow('')).toBe(-1)
+    expect(decodeRow('0')).toBe(-1)
+    expect(decodeRow('abc')).toBe(-1)
+  })
+})

--- a/packages/compile/src/_shared/xlsx.spec.ts
+++ b/packages/compile/src/_shared/xlsx.spec.ts
@@ -1,8 +1,13 @@
 // Copyright (c) 2026 Climate Interactive / New Venture Fund
 
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
-import { decodeCell, decodeCol, decodeRow, encodeCell } from './xlsx.js'
+import { strToU8, zipSync } from 'fflate'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { decodeCell, decodeCol, decodeRow, encodeCell, readXlsx } from './xlsx.js'
 
 describe('decodeCell', () => {
   it('should decode a single-letter column ref', () => {
@@ -89,5 +94,293 @@ describe('decodeRow', () => {
     expect(decodeRow('')).toBe(-1)
     expect(decodeRow('0')).toBe(-1)
     expect(decodeRow('abc')).toBe(-1)
+  })
+})
+
+// Build a minimal xlsx zip from a parts map and write it to a temp file.
+// Sheets is a record mapping sheet name -> inner XML (the contents of <sheetData>).
+// sharedStrings, if provided, is an array of strings to include in the
+// xl/sharedStrings.xml file.
+interface XlsxParts {
+  sheets: { name: string; sheetData: string }[]
+  sharedStrings?: string[]
+  // Raw override for xl/sharedStrings.xml — used when we need <r>/<t> rich text
+  // or other shapes that the `sharedStrings` shorthand can't express.
+  sharedStringsXml?: string
+}
+
+function buildXlsx(parts: XlsxParts): string {
+  const sheets = parts.sheets
+  const files: Record<string, Uint8Array> = {}
+
+  // Minimal required files for SheetJS-compatible workbook structure.
+  files['[Content_Types].xml'] = strToU8(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+${sheets
+  .map(
+    (_, i) =>
+      `<Override PartName="/xl/worksheets/sheet${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`
+  )
+  .join('\n')}
+<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>`
+  )
+
+  files['_rels/.rels'] = strToU8(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`
+  )
+
+  files['xl/workbook.xml'] = strToU8(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<sheets>
+${sheets.map((s, i) => `<sheet name="${s.name}" sheetId="${i + 1}" r:id="rId${i + 1}"/>`).join('\n')}
+</sheets>
+</workbook>`
+  )
+
+  files['xl/_rels/workbook.xml.rels'] = strToU8(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+${sheets
+  .map(
+    (_, i) =>
+      `<Relationship Id="rId${i + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${i + 1}.xml"/>`
+  )
+  .join('\n')}
+</Relationships>`
+  )
+
+  for (let i = 0; i < sheets.length; i++) {
+    files[`xl/worksheets/sheet${i + 1}.xml`] = strToU8(
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>${sheets[i].sheetData}</sheetData>
+</worksheet>`
+    )
+  }
+
+  if (parts.sharedStringsXml) {
+    files['xl/sharedStrings.xml'] = strToU8(parts.sharedStringsXml)
+  } else if (parts.sharedStrings) {
+    files['xl/sharedStrings.xml'] = strToU8(
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="${parts.sharedStrings.length}" uniqueCount="${parts.sharedStrings.length}">
+${parts.sharedStrings.map(s => `<si><t>${s}</t></si>`).join('\n')}
+</sst>`
+    )
+  }
+
+  const buf = zipSync(files)
+  const out = path.join(tmpDir, `test-${nextId++}.xlsx`)
+  fs.writeFileSync(out, buf)
+  return out
+}
+
+let tmpDir: string
+let nextId = 0
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xlsx-spec-'))
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('readXlsx', () => {
+  it('should expose sheet names in workbook order', () => {
+    const file = buildXlsx({
+      sheets: [
+        { name: 'Alpha', sheetData: '' },
+        { name: 'Beta', sheetData: '' }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.SheetNames).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('should read numeric cells with and without explicit t attribute', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1"><v>42</v></c><c r="B1" t="n"><v>3.14</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    const sheet = wb.Sheets['s']
+    expect(sheet['A1']).toEqual({ v: 42 })
+    expect(sheet['B1']).toEqual({ v: 3.14 })
+  })
+
+  it('should read the cached value of a formula cell', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1"><f>+B1*2</f><v>0.0015189876</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: 0.0015189876 })
+  })
+
+  it('should skip formula cells with no cached value (uncalculated)', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1"><f>+B1*2</f></c><c r="B1"><v>7</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toBeUndefined()
+    expect(wb.Sheets['s']['B1']).toEqual({ v: 7 })
+  })
+
+  it('should resolve shared strings', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>'
+        }
+      ],
+      sharedStrings: ['hello', 'world']
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: 'hello' })
+    expect(wb.Sheets['s']['B1']).toEqual({ v: 'world' })
+  })
+
+  it('should read inline strings', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1" t="inlineStr"><is><t>foo</t></is></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: 'foo' })
+  })
+
+  it('should concatenate rich-text runs within a shared string', () => {
+    // sharedStrings can contain <si><r><t>part</t></r><r><t>part</t></r></si>
+    // when the string has mixed formatting. We should concatenate the runs.
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1" t="s"><v>0</v></c></row>'
+        }
+      ],
+      // We can't express rich-text runs through the buildXlsx convenience, so
+      // construct the sharedStrings part as a raw override.
+      sharedStringsXml: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
+<si><r><t>foo</t></r><r><t> </t></r><r><t>bar</t></r></si>
+</sst>`
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: 'foo bar' })
+  })
+
+  it('should skip error cells', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1" t="e"><f>+#REF!</f><v>#REF!</v></c><c r="B1"><v>5</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toBeUndefined()
+    expect(wb.Sheets['s']['B1']).toEqual({ v: 5 })
+  })
+
+  it('should read boolean cells', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1" t="b"><v>1</v></c><c r="B1" t="b"><v>0</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: true })
+    expect(wb.Sheets['s']['B1']).toEqual({ v: false })
+  })
+
+  it('should tolerate a missing sharedStrings.xml', () => {
+    const file = buildXlsx({
+      sheets: [{ name: 's', sheetData: '<row r="1"><c r="A1"><v>5</v></c></row>' }]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['A1']).toEqual({ v: 5 })
+  })
+
+  it('should not let self-closing empty cells shift subsequent cells', () => {
+    // Regression for a bug found in the prototype: a greedy regex matched
+    // across <c r="I4" s="1"/><c r="J4" s="1"/><c r="BC4"><v>1840</v></c>
+    // and recorded BC4's value at I4.
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="4"><c r="I4" s="1"/><c r="J4" s="1"/><c r="K4" s="1"/><c r="BC4"><v>1840</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['BC4']).toEqual({ v: 1840 })
+    expect(wb.Sheets['s']['I4']).toBeUndefined()
+    expect(wb.Sheets['s']['J4']).toBeUndefined()
+    expect(wb.Sheets['s']['K4']).toBeUndefined()
+  })
+
+  it('should return undefined for an unknown sheet', () => {
+    const file = buildXlsx({
+      sheets: [{ name: 's', sheetData: '' }]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['not-a-sheet']).toBeUndefined()
+  })
+
+  it('should expose !ref reflecting the sheet bounds', () => {
+    const file = buildXlsx({
+      sheets: [
+        {
+          name: 's',
+          sheetData: '<row r="1"><c r="A1"><v>1</v></c></row><row r="5"><c r="C5"><v>2</v></c></row>'
+        }
+      ]
+    })
+    const wb = readXlsx(file)
+    expect(wb.Sheets['s']['!ref']).toBe('A1:C5')
+  })
+
+  it('should cache repeated reads of the same file path', () => {
+    const file = buildXlsx({
+      sheets: [{ name: 's', sheetData: '<row r="1"><c r="A1"><v>1</v></c></row>' }]
+    })
+    const wb1 = readXlsx(file)
+    const wb2 = readXlsx(file)
+    // Same instance — workbook-level cache mirrors the previous SheetJS path.
+    expect(wb1).toBe(wb2)
   })
 })

--- a/packages/compile/src/generate/direct-data-helpers.js
+++ b/packages/compile/src/generate/direct-data-helpers.js
@@ -1,8 +1,7 @@
 import path from 'node:path'
 
-import XLSX from 'xlsx'
-
 import { cdbl, readCsv, readXlsx } from '../_shared/helpers.js'
+import { encodeCell } from '../_shared/xlsx.js'
 
 /**
  * Return a `getCellValue` function that reads the CSV or XLS[X] content.
@@ -47,7 +46,7 @@ function handleExcelWorkbook(fileOrTag, workbook, tab, dataKind, dataSource) {
     let sheet = workbook.Sheets[tab]
     if (sheet) {
       return (c, r) => {
-        let cell = sheet[XLSX.utils.encode_cell({ c, r })]
+        let cell = sheet[encodeCell({ c, r })]
         if (cell == null || cell.v === '') {
           return null
         }

--- a/packages/compile/src/generate/gen-direct-const.js
+++ b/packages/compile/src/generate/gen-direct-const.js
@@ -1,7 +1,6 @@
-import XLSX from 'xlsx'
-
 import { cartesianProductOf } from '../_shared/helpers.js'
 import { indexInSepDim, isDimension, sub } from '../_shared/subscript.js'
+import { decodeCell } from '../_shared/xlsx.js'
 
 import { handleExcelOrCsvFile } from './direct-data-helpers.js'
 
@@ -73,7 +72,7 @@ export function generateDirectConstInit(variable, directData, modelDir) {
   // Read tabular data into an indexed variable for each cell.
   let numericSubscripts = lhsIndexSubscripts.map(idx => idx.map(s => sub(s).value))
   let lhsSubscripts = numericSubscripts.map(s => s.reduce((a, v) => a.concat(`[${v}]`), ''))
-  let dataAddress = XLSX.utils.decode_cell(startCell.toUpperCase())
+  let dataAddress = decodeCell(startCell.toUpperCase())
   let startCol = dataAddress.c
   let startRow = dataAddress.r
   if (startCol < 0 || startRow < 0) {

--- a/packages/compile/src/generate/gen-lookup-from-direct.js
+++ b/packages/compile/src/generate/gen-lookup-from-direct.js
@@ -1,8 +1,8 @@
 import * as R from 'ramda'
-import XLSX from 'xlsx'
 
 import { listConcat } from '../_shared/helpers.js'
 import { sub } from '../_shared/subscript.js'
+import { decodeCell, decodeCol, decodeRow } from '../_shared/xlsx.js'
 
 import { handleExcelOrCsvFile } from './direct-data-helpers.js'
 
@@ -61,7 +61,7 @@ function generateDirectDataLookup(varLhs, getCellValue, timeRowOrCol, startCell,
   // The cell(c,r) function wraps data access by column and row.
   let lookupData = ''
   let lookupSize = 0
-  let dataAddress = XLSX.utils.decode_cell(startCell.toUpperCase())
+  let dataAddress = decodeCell(startCell.toUpperCase())
   let dataCol = dataAddress.c
   let dataRow = dataAddress.r
   if (dataCol < 0 || dataRow < 0) {
@@ -71,7 +71,7 @@ function generateDirectDataLookup(varLhs, getCellValue, timeRowOrCol, startCell,
   let timeCol, timeRow, nextCell
   if (isNaN(parseInt(timeRowOrCol))) {
     // Time values are in a column.
-    timeCol = XLSX.utils.decode_col(timeRowOrCol.toUpperCase())
+    timeCol = decodeCol(timeRowOrCol.toUpperCase())
     timeRow = dataRow
     dataCol += indexNum
     nextCell = () => {
@@ -81,7 +81,7 @@ function generateDirectDataLookup(varLhs, getCellValue, timeRowOrCol, startCell,
   } else {
     // Time values are in a row.
     timeCol = dataCol
-    timeRow = XLSX.utils.decode_row(timeRowOrCol)
+    timeRow = decodeRow(timeRowOrCol)
     dataRow += indexNum
     nextCell = () => {
       dataCol++

--- a/packages/compile/src/model/read-subscripts.js
+++ b/packages/compile/src/model/read-subscripts.js
@@ -1,7 +1,6 @@
-import XLSX from 'xlsx'
-
 import { readCsv } from '../_shared/helpers.js'
 import { Subscript } from '../_shared/subscript.js'
+import { decodeCell } from '../_shared/xlsx.js'
 
 /**
  * Read the dimension definitions from the given model.
@@ -46,7 +45,7 @@ export function readDimensionDefs(parsedModel) {
  */
 export function getDirectSubscripts(fileName, tabOrDelimiter, firstCell, lastCell) {
   // If lastCell is a column letter, scan the column, else scan the row
-  const dataAddress = XLSX.utils.decode_cell(firstCell.toUpperCase())
+  const dataAddress = decodeCell(firstCell.toUpperCase())
   let col = dataAddress.c
   let row = dataAddress.r
   if (col < 0 || row < 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,9 @@ importers:
       csv-parse:
         specifier: ^5.3.3
         version: 5.3.3
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       ramda:
         specifier: ^0.27.0
         version: 0.27.2
@@ -1464,36 +1467,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1590,56 +1599,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -2467,6 +2487,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -5006,6 +5029,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,9 +648,6 @@ importers:
       strip-bom:
         specifier: ^5.0.0
         version: 5.0.0
-      xlsx:
-        specifier: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
-        version: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
 
   packages/create:
     dependencies:
@@ -3690,12 +3687,6 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz:
-    resolution: {integrity: sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz}
-    version: 0.20.2
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6105,8 +6096,6 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
-
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Fixes #832 

@ToddFincannonEI: See issue for details.  As noted, this was largely implemented by Claude but I reviewed the code and tests and it all seems pretty straightforward.  Normally I would avoid going with a custom solution but in this case it seemed warranted and the performance wins are a nice bonus.

I tested this branch with the model referenced in the issue and it produces identical values as the previous SheetJS-based reader (the generated C/JS code is identical), and our existing XLSX tests pass as well, so I feel like it should be good enough for SDE's purposes.

**AI disclosure:** I guided Claude Code (Opus 4.7) to plan and implement the changes, and then I reviewed and refined the changes.
