### PR TITLE
fix: upgrade antlr4-vensim to correct `^` operator precedence

### DIFF
--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@rgrove/parse-xml": "^4.1.0",
     "antlr4": "4.12.0",
-    "antlr4-vensim": "0.6.3",
+    "antlr4-vensim": "0.6.4",
     "assert-never": "^1.2.1",
     "split-string": "^6.1.0"
   },

--- a/packages/parse/src/vensim/parse-vensim-expr.spec.ts
+++ b/packages/parse/src/vensim/parse-vensim-expr.spec.ts
@@ -80,6 +80,60 @@ describe('parseVensimExpr', () => {
     expect(parseVensimExpr('(1 + 2) * 3')).toEqual(binaryOp(parens(binaryOp(one, '+', two)), '*', three))
   })
 
+  // The following tests exercise operator grouping.  Precedence in the Vensim grammar comes
+  // from the order of the alternatives in the (left-recursive) `expr` rule, so a change to
+  // that order silently changes how an expression evaluates without causing a parse error.
+  // For more details, see: https://github.com/climateinteractive/antlr4-vensim/issues/16
+
+  it('should parse an expr with ^ op binding tighter than a leading unary - op', () => {
+    expect(parseVensimExpr('-x^2')).toEqual(unaryOp('-', binaryOp(x, '^', two)))
+  })
+
+  it('should parse an expr with ^ op binding tighter than a leading unary + op', () => {
+    expect(parseVensimExpr('+x^2')).toEqual(unaryOp('+', binaryOp(x, '^', two)))
+  })
+
+  it('should parse an expr with ^ op binding tighter than a leading unary - op (with constant base)', () => {
+    expect(parseVensimExpr('-2^3')).toEqual(unaryOp('-', binaryOp(two, '^', three)))
+  })
+
+  it('should parse an expr with a negated exponent', () => {
+    expect(parseVensimExpr('x^-2')).toEqual(binaryOp(x, '^', unaryOp('-', two)))
+  })
+
+  it('should parse an expr with a negated base (with explicit parentheses)', () => {
+    expect(parseVensimExpr('(-x)^2')).toEqual(binaryOp(parens(unaryOp('-', x)), '^', two))
+  })
+
+  it('should parse a Gaussian kernel expr with the sign applied to the power', () => {
+    // This is the case that motivated the grammar fix; grouping this as `EXP(((-x)^2)/2)`
+    // drops the sign of the exponent, turning a decaying curve into a growing one
+    expect(parseVensimExpr('EXP(-x^2/2)')).toEqual(call('EXP', binaryOp(unaryOp('-', binaryOp(x, '^', two)), '/', two)))
+  })
+
+  it('should parse an expr with ^ op binding tighter than * op', () => {
+    expect(parseVensimExpr('x^2 * y')).toEqual(binaryOp(binaryOp(x, '^', two), '*', y))
+  })
+
+  it('should parse an expr with ^ op binding tighter than - op (used as subtraction)', () => {
+    expect(parseVensimExpr('x - y^2')).toEqual(binaryOp(x, '-', binaryOp(y, '^', two)))
+  })
+
+  it('should parse an expr with a negated power followed by a * op', () => {
+    expect(parseVensimExpr('-x^2 * y')).toEqual(binaryOp(unaryOp('-', binaryOp(x, '^', two)), '*', y))
+  })
+
+  it('should parse an expr with unary - op binding tighter than * op', () => {
+    // Unary sign still outranks `*` and `/`, so this grouping is unaffected by the
+    // precedence of the `^` op
+    expect(parseVensimExpr('-x * y')).toEqual(binaryOp(unaryOp('-', x), '*', y))
+  })
+
+  it('should parse an expr with left-associative ^ ops', () => {
+    // Left associative, so `2^3^2` is `(2^3)^2` (64), not `2^(3^2)` (512)
+    expect(parseVensimExpr('2^3^2')).toEqual(binaryOp(binaryOp(two, '^', three), '^', two))
+  })
+
   it('should parse an expr with binary = op', () => {
     expect(parseVensimExpr('x = y')).toEqual(binaryOp(x, '=', y))
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,8 +707,8 @@ importers:
         specifier: 4.12.0
         version: 4.12.0
       antlr4-vensim:
-        specifier: 0.6.3
-        version: 0.6.3
+        specifier: 0.6.4
+        version: 0.6.4
       assert-never:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2051,8 +2051,8 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  antlr4-vensim@0.6.3:
-    resolution: {integrity: sha512-xDjUXNjeDEj2ahCFIIxOIlA6Jf/YtBMngugH1AyvVeg4qKttTFmof13j7lXvE24hHcW9sa0ACs6JmgR+/x8c+A==}
+  antlr4-vensim@0.6.4:
+    resolution: {integrity: sha512-vj2odeD2345dlEYWmlUIvQoWSJEdAEpRG/WN1cCDWSHwjZT5OPbuc6nYZx8aGOAf6BfTLknhZLpKUqKxk3J5UQ==}
 
   antlr4@4.12.0:
     resolution: {integrity: sha512-23iB5IzXJZRZeK9TigzUyrNc9pSmNqAerJRBcNq1ETrmttMWRgaYZzC561IgEO3ygKsDJTYDTozABXa4b/fTQQ==}
@@ -4579,7 +4579,7 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  antlr4-vensim@0.6.3:
+  antlr4-vensim@0.6.4:
     dependencies:
       antlr4: 4.12.0
 


### PR DESCRIPTION
Fixes #850

See issue for details.  This upgrades the package to the latest with the fix contributed by @ToddFincannonEI.  I also added more tests in the `parse` package to cover these cases.