### PR TITLE
deps: require Node.js v22 as minimum supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For more details on all of these packages, refer to the ["Packages"](#packages) 
 
 The SDEverywhere libraries and tools can be used on any computer running macOS, Windows, or Linux.
 
-SDEverywhere requires [Node.js](https://nodejs.org) version 20 or later (the current LTS version 22 is recommended).
+SDEverywhere requires [Node.js](https://nodejs.org) version 22 or later (the current LTS version 24 is recommended).
 Node.js is a cross-platform runtime environment that allows for running JavaScript-based tools (like SDEverywhere) on macOS, Windows, and Linux computers.
 
 Note: It is not necessary to have extensive knowledge of Node.js and JavaScript in order to use SDEverywhere, but a one-time download of Node.js is necessary to get started.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "yargs": "^17.5.1"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "author": "Climate Interactive",
   "license": "MIT",

--- a/packages/create/bin/create-sde.js
+++ b/packages/create/bin/create-sde.js
@@ -3,7 +3,7 @@
 
 const currentVersion = process.versions.node
 const requiredMajorVersion = parseInt(currentVersion.split('.')[0], 10)
-const minimumMajorVersion = 20
+const minimumMajorVersion = 22
 
 if (requiredMajorVersion < minimumMajorVersion) {
   console.error(`Node.js v${currentVersion} is not supported by SDEverywhere.`)


### PR DESCRIPTION
Fixes #869 

See issue for details.  We have already been building on v22 for a while in our GitHub Actions workflows; this just formalizes things in the cli package and docs.
