### PR TITLE
build: update peer dependency config in plugin packages

### DIFF
--- a/packages/plugin-check/package.json
+++ b/packages/plugin-check/package.json
@@ -62,7 +62,6 @@
     "@sdeverywhere/build": "^0.3.10"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "@types/node": "^20.14.8"
   },
   "author": "Climate Interactive",

--- a/packages/plugin-config/package.json
+++ b/packages/plugin-config/package.json
@@ -41,7 +41,6 @@
     "@sdeverywhere/build": "^0.3.10"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "@types/byline": "^4.2.33",
     "@types/dedent": "^0.7.0",
     "@types/marked": "^4.0.1",

--- a/packages/plugin-deploy/package.json
+++ b/packages/plugin-deploy/package.json
@@ -37,7 +37,6 @@
     "@sdeverywhere/build": "^0.3.10"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "@types/node": "^20.14.8"
   },
   "author": "Climate Interactive",

--- a/packages/plugin-vite/package.json
+++ b/packages/plugin-vite/package.json
@@ -34,7 +34,6 @@
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "vite": "^7.3.6"
   },
   "author": "Climate Interactive",

--- a/packages/plugin-wasm/package.json
+++ b/packages/plugin-wasm/package.json
@@ -36,7 +36,6 @@
     "@sdeverywhere/build": "^0.3.10"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "@types/node": "^20.14.8"
   },
   "author": "Climate Interactive",

--- a/packages/plugin-worker/package.json
+++ b/packages/plugin-worker/package.json
@@ -39,7 +39,6 @@
     "@sdeverywhere/build": "^0.3.10"
   },
   "devDependencies": {
-    "@sdeverywhere/build": "*",
     "@types/node": "^20.14.8"
   },
   "author": "Climate Interactive",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,6 +728,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.62.4)
+      '@sdeverywhere/build':
+        specifier: ^0.3.10
+        version: link:../build
       '@sdeverywhere/check-core':
         specifier: ^0.1.12
         version: link:../check-core
@@ -756,15 +759,15 @@ importers:
         specifier: ^7.1.12
         version: 7.3.6(@types/node@20.19.19)(sass@1.102.0)(yaml@2.9.0)
     devDependencies:
-      '@sdeverywhere/build':
-        specifier: '*'
-        version: link:../build
       '@types/node':
         specifier: ^20.14.8
         version: 20.19.19
 
   packages/plugin-config:
     dependencies:
+      '@sdeverywhere/build':
+        specifier: ^0.3.10
+        version: link:../build
       byline:
         specifier: ^5.0.0
         version: 5.0.0
@@ -775,9 +778,6 @@ importers:
         specifier: ^2.17.6
         version: 2.17.6
     devDependencies:
-      '@sdeverywhere/build':
-        specifier: '*'
-        version: link:../build
       '@types/byline':
         specifier: ^4.2.33
         version: 4.2.33
@@ -798,38 +798,43 @@ importers:
         version: 0.7.0
 
   packages/plugin-deploy:
-    devDependencies:
+    dependencies:
       '@sdeverywhere/build':
-        specifier: '*'
+        specifier: ^0.3.10
         version: link:../build
+    devDependencies:
       '@types/node':
         specifier: ^20.14.8
         version: 20.19.19
 
   packages/plugin-vite:
-    devDependencies:
+    dependencies:
       '@sdeverywhere/build':
-        specifier: '*'
+        specifier: ^0.3.10
         version: link:../build
+    devDependencies:
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@20.19.19)(sass@1.102.0)(yaml@2.9.0)
 
   packages/plugin-wasm:
     dependencies:
+      '@sdeverywhere/build':
+        specifier: ^0.3.10
+        version: link:../build
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
     devDependencies:
-      '@sdeverywhere/build':
-        specifier: '*'
-        version: link:../build
       '@types/node':
         specifier: ^20.14.8
         version: 20.19.19
 
   packages/plugin-worker:
     dependencies:
+      '@sdeverywhere/build':
+        specifier: ^0.3.10
+        version: link:../build
       '@sdeverywhere/runtime':
         specifier: ^0.2.9
         version: link:../runtime
@@ -840,9 +845,6 @@ importers:
         specifier: ^7.1.12
         version: 7.3.6(@types/node@20.19.19)(sass@1.102.0)(yaml@2.9.0)
     devDependencies:
-      '@sdeverywhere/build':
-        specifier: '*'
-        version: link:../build
       '@types/node':
         specifier: ^20.14.8
         version: 20.19.19

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,17 @@ packages:
 # because those don't always play well with release-please, so instead we
 # use normal semver ranges (e.g., "^1.2.3") and let pnpm handle resolution.
 linkWorkspacePackages: true
+
+# Automatically install peer dependencies:
+#   https://pnpm.io/settings#autoinstallpeers
+# This is the default in pnpm >= 8, but we set it explicitly because the
+# plugin packages rely on it: they declare `@sdeverywhere/build` only as a
+# peer dependency (not as a dev dependency), and this setting is what makes
+# pnpm resolve that peer to the local `packages/build` workspace package.
+# Keeping it out of `devDependencies` is deliberate: release-please's
+# `node-workspace` plugin builds its dependency graph from `dependencies`,
+# `devDependencies`, and `optionalDependencies` only, so a peer-only
+# reference means the plugin packages aren't force-bumped (and their
+# `@sdeverywhere/build` range isn't rewritten) every time `build` is
+# released.
+autoInstallPeers: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,12 @@
     "packages/plugin-deploy": {},
     "packages/create": {}
   },
-  "plugins": ["node-workspace"],
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "updatePeerDependencies": false
+    }
+  ],
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "pull-request-title-pattern": "chore: release${component} ${version}",


### PR DESCRIPTION
Fixes #871 

See issue for details.  This has no impact on the behavior of the packages, but removes an annoyance when releasing them.