### PR TITLE
fix: remove folder-hash dependency and use node:crypto instead

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -33,14 +33,12 @@
     "@sdeverywhere/parse": "^0.1.5",
     "chokidar": "^5.0.0",
     "cross-spawn": "^7.0.6",
-    "folder-hash": "^4.0.2",
     "neverthrow": "^4.3.1",
     "picocolors": "^1.0.0",
     "tinyglobby": "^0.2.15"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
-    "@types/folder-hash": "^4.0.1",
     "@types/node": "^20.14.8"
   },
   "author": "Climate Interactive",

--- a/packages/build/src/build/impl/hash-files.spec.ts
+++ b/packages/build/src/build/impl/hash-files.spec.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+import { mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ResolvedConfig } from '../../_shared/resolved-config'
+
+import { computeInputFilesHash } from './hash-files'
+
+describe('computeInputFilesHash', () => {
+  let tempDir: string
+
+  function writeTestFile(path: string, content: string) {
+    mkdirSync(join(tempDir, dirname(path)), { recursive: true })
+    writeFileSync(join(tempDir, path), content)
+  }
+
+  function config(modelFiles: string[], modelInputPaths: string[] = []): ResolvedConfig {
+    return {
+      rootDir: tempDir,
+      prepDir: tempDir,
+      modelFiles: modelFiles.map(f => join(tempDir, f)),
+      modelInputPaths
+    } as ResolvedConfig
+  }
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `hash-files-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tempDir, { recursive: true })
+    // The `spec.json` file is always included in the hash, so write one for every test
+    writeTestFile('spec.json', '{"inputVarNames":["a"],"outputVarNames":["b"]}')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('should compute a stable hash for a known set of input files', async () => {
+    // Note: This test pins the exact hash values so that any change to the hashing
+    // scheme is caught.  The hash is the concatenation of one base64-encoded SHA-1
+    // digest per input file, where each digest covers the file's base name followed
+    // by its contents.
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+
+    const hash = await computeInputFilesHash(config(['model.mdl']))
+
+    expect(hash).toBe('LLyGa2yqCtnE1nG3cjVGCUUJoQo=foSrukKqBbYbYMm1iFTsn5XVsKA=')
+  })
+
+  it('should produce the same hash when called repeatedly with unchanged files', async () => {
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+
+    const hash1 = await computeInputFilesHash(config(['model.mdl']))
+    const hash2 = await computeInputFilesHash(config(['model.mdl']))
+
+    expect(hash1).toBe(hash2)
+  })
+
+  it('should produce a different hash when the contents of an input file change', async () => {
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+    const before = await computeInputFilesHash(config(['model.mdl']))
+
+    writeTestFile('model.mdl', 'x = 2 ~~|')
+    const after = await computeInputFilesHash(config(['model.mdl']))
+
+    expect(after).not.toBe(before)
+  })
+
+  it('should produce a different hash when an input file is renamed', async () => {
+    // Note that the base name of each file contributes to the hash, so renaming a
+    // file changes the hash even if the contents are unchanged
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+    const before = await computeInputFilesHash(config(['model.mdl']))
+
+    renameSync(join(tempDir, 'model.mdl'), join(tempDir, 'renamed.mdl'))
+    const after = await computeInputFilesHash(config(['renamed.mdl']))
+
+    expect(after).not.toBe(before)
+  })
+
+  it('should include the spec file in the hash', async () => {
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+    const before = await computeInputFilesHash(config(['model.mdl']))
+
+    writeTestFile('spec.json', '{"inputVarNames":["c"],"outputVarNames":["d"]}')
+    const after = await computeInputFilesHash(config(['model.mdl']))
+
+    expect(after).not.toBe(before)
+  })
+
+  it('should hash the files matched by `modelInputPaths` when it is defined', async () => {
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+    writeTestFile('data/a.csv', 'a,1')
+    writeTestFile('data/b.csv', 'b,2')
+
+    const before = await computeInputFilesHash(config(['model.mdl'], ['data/**/*.csv']))
+
+    // Changing a file matched by the glob should change the hash
+    writeTestFile('data/a.csv', 'a,99')
+    const after = await computeInputFilesHash(config(['model.mdl'], ['data/**/*.csv']))
+
+    expect(after).not.toBe(before)
+  })
+
+  it('should ignore the model files when `modelInputPaths` is defined', async () => {
+    writeTestFile('model.mdl', 'x = 1 ~~|')
+    writeTestFile('data/a.csv', 'a,1')
+
+    const before = await computeInputFilesHash(config(['model.mdl'], ['data/**/*.csv']))
+
+    // The mdl file is not included when `modelInputPaths` is defined, so changing
+    // it should not affect the hash
+    writeTestFile('model.mdl', 'x = 2 ~~|')
+    const after = await computeInputFilesHash(config(['model.mdl'], ['data/**/*.csv']))
+
+    expect(after).toBe(before)
+  })
+
+  it('should handle an empty input file', async () => {
+    writeTestFile('empty.mdl', '')
+
+    const hash = await computeInputFilesHash(config(['empty.mdl']))
+
+    expect(hash.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/build/src/build/impl/hash-files.ts
+++ b/packages/build/src/build/impl/hash-files.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2022 Climate Interactive / New Venture Fund
 
-import { join as joinPath } from 'path'
-import { hashElement } from 'folder-hash'
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { basename, join as joinPath } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+
 import { glob } from 'tinyglobby'
 
 import type { ResolvedConfig } from '../../_shared/resolved-config'
@@ -19,11 +22,7 @@ export async function computeInputFilesHash(config: ResolvedConfig): Promise<str
   inputFiles.push(specFile)
 
   if (config.modelInputPaths && config.modelInputPaths.length > 0) {
-    // Include the files that match the glob patterns in the config file.
-    // Note that the folder-hash package supports glob patterns, but its
-    // configuration is complicated, so it is easier if we resolve the
-    // glob patterns here and pass each individual file to the
-    // `hashElement` function.
+    // Include the files that match the glob patterns in the config file
     for (const globPath of config.modelInputPaths) {
       const paths = await glob(globPath, {
         cwd: config.rootDir,
@@ -40,9 +39,23 @@ export async function computeInputFilesHash(config: ResolvedConfig): Promise<str
   // Compute the hash of each input file and concatenate into a single string
   let hash = ''
   for (const inputFile of inputFiles) {
-    const result = await hashElement(inputFile)
-    hash += result.hash
+    hash += await hashFile(inputFile)
   }
 
   return hash
+}
+
+/**
+ * Asynchronously compute the hash of a single file.  The returned hash covers the
+ * base name of the file followed by its contents, so that renaming a file changes
+ * the hash even if its contents are unchanged.
+ *
+ * @param file The absolute path of the file to hash.
+ * @returns The base64-encoded SHA-1 digest for the file.
+ */
+async function hashFile(file: string): Promise<string> {
+  const hash = createHash('sha1')
+  hash.update(basename(file))
+  await pipeline(createReadStream(file), hash)
+  return hash.digest('base64')
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,9 +484,6 @@ importers:
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
-      folder-hash:
-        specifier: ^4.0.2
-        version: 4.0.2
       neverthrow:
         specifier: ^4.3.1
         version: 4.3.1
@@ -500,9 +497,6 @@ importers:
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2
-      '@types/folder-hash':
-        specifier: ^4.0.1
-        version: 4.0.1
       '@types/node':
         specifier: ^20.14.8
         version: 20.19.19
@@ -2171,9 +2165,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/folder-hash@4.0.1':
-    resolution: {integrity: sha512-HrIikWNP/7ubX+XB1awPxA+zTI8T3NXgb4g3BQnT4iAWbeZThsaAm+sg+xqO+eK6kPlpOLS6o29FaaWqb2THbA==}
-
   '@types/fontfaceobserver@2.1.3':
     resolution: {integrity: sha512-AewfFg9iUfoUZ4EfKxhBaEuzY2TUS+Hm0vXWMPcJRY7C4wC9XtW20lPVYHTcWVZYq1uthCEa5APl7RAX7jr2Xg==}
 
@@ -2420,9 +2411,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2435,9 +2423,6 @@ packages:
 
   bootstrap-slider@10.6.2:
     resolution: {integrity: sha512-8JTPZB9QVOdrGzYF3YgC3YW6ssfPeBvBwZnXffiZ7YH/zz1D0EKlZvmQsm/w3N0XjVNYQEoQ0ax+jHrErV4K1Q==}
-
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2873,11 +2858,6 @@ packages:
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
-  folder-hash@4.0.2:
-    resolution: {integrity: sha512-Iw9GCqdA+zHfDVvk90TSAV66jq0IwiZaPvPgUiW+DHRwnaPOeZomzlgutx9QclinsQGz/XcVIGlDEJbFhCV5wA==}
-    engines: {node: '>=10.10.0'}
-    hasBin: true
-
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
@@ -3207,10 +3187,6 @@ packages:
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@5.0.1:
-    resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
-    engines: {node: '>=10'}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -4833,8 +4809,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/folder-hash@4.0.1': {}
-
   '@types/fontfaceobserver@2.1.3': {}
 
   '@types/fs-extra@9.0.13':
@@ -5145,8 +5119,6 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -5158,10 +5130,6 @@ snapshots:
       readable-stream: 3.6.0
 
   bootstrap-slider@10.6.2: {}
-
-  brace-expansion@2.1.4:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -5610,14 +5578,6 @@ snapshots:
 
   flatted@3.4.4: {}
 
-  folder-hash@4.0.2:
-    dependencies:
-      debug: 4.4.3
-      graceful-fs: 4.2.10
-      minimatch: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   fontfaceobserver@2.3.0: {}
 
   fs-extra@10.1.0:
@@ -5876,10 +5836,6 @@ snapshots:
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
-
-  minimatch@5.0.1:
-    dependencies:
-      brace-expansion: 2.1.4
 
   mlly@1.8.0:
     dependencies:


### PR DESCRIPTION
Fixes #873 

See issue for details.  The new function has the same behavior as the old, and there are tests added to verify.

**AI disclosure:** I guided Claude Code (Opus 5) to plan and implement the changes, and then I reviewed and refined the changes.
