### PR TITLE
docs: clarify format of Emscripten `-s` parameters

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -152,9 +152,9 @@ The `emcc` command line options should be similar to the following:
 $ emcc \
 build/<mymodel>.c build/macros.c build/model.c build/vensim.c build/allocation.c \
 -Ibuild -o ./output/<mymodel>.js -Wall -Os \
--s STRICT=1 -s MALLOC=emmalloc -s FILESYSTEM=0 -s MODULARIZE=1 \
--s EXPORTED_FUNCTIONS="['_malloc','_free','_getInitialTime','_getFinalTime','_getSaveper','_setLookup','_runModelWithBuffers']" \
--s EXPORTED_RUNTIME_METHODS="['cwrap']"
+-sSTRICT=1 -sMALLOC=emmalloc -sFILESYSTEM=0 -sMODULARIZE=1 \
+-sEXPORTED_FUNCTIONS="['_malloc','_free','_getInitialTime','_getFinalTime','_getSaveper','_setLookup','_runModelWithBuffers']" \
+-sEXPORTED_RUNTIME_METHODS="['cwrap']"
 ```
 
 Note that the generated module must export the following functions at minimum:


### PR DESCRIPTION
Fixes #878 

See issue for details.
