### PR TITLE
docs: flesh out Usage sections in plugin package README files

### DIFF
--- a/packages/plugin-check/README.md
+++ b/packages/plugin-check/README.md
@@ -25,7 +25,7 @@ yarn add -D @sdeverywhere/plugin-check
 _Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-check`.
 Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-check` can be integrated into your project.
 
-### What this plugin does
+### Why use this plugin?
 
 Each time your model is built, this plugin:
 

--- a/packages/plugin-check/README.md
+++ b/packages/plugin-check/README.md
@@ -22,7 +22,172 @@ yarn add -D @sdeverywhere/plugin-check
 
 ## Usage
 
-_TODO: This section needs to be fleshed out. In the meantime, you can refer to the API documentation below for the options used to configure this plugin._
+_Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-check`.
+Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-check` can be integrated into your project.
+
+### What this plugin does
+
+Each time your model is built, this plugin:
+
+1. Generates a _bundle_ (`check-bundle.js`), which packages up your generated model together with metadata about its inputs, outputs, and graphs.
+2. Runs **check tests**, which assert that a single version of your model behaves as expected (for example, that a stock never goes negative).
+3. Runs **comparison tests**, which run two different versions ("bundles") of your model side by side and flag any differences. This step is skipped if no `baseline` bundle is configured.
+4. Builds an interactive **model-check report** that summarizes the results.
+
+In development mode (`sde dev`), the report is served from a local dev server and re-runs automatically as you edit your model and tests.
+In production mode (`sde bundle`), the report is written to disk, and the build fails if any check test fails.
+
+### Steps
+
+1. Add `@sdeverywhere/plugin-check` as a project "dev" dependency:
+
+```sh
+cd your-model-project
+npm install --save-dev @sdeverywhere/plugin-check
+```
+
+2. Update your `sde.config.js` file to use `checkPlugin`. This plugin runs as a `postBuild` step, so it should generally appear near the end of the `plugins` array (but before `deployPlugin`, if you use it):
+
+```js
+import { checkPlugin } from '@sdeverywhere/plugin-check'
+
+export async function config() {
+  return {
+    modelFiles: ['model/example.mdl'],
+
+    // Re-run checks when the model or the test definitions change
+    watchPaths: ['model/**'],
+
+    // ...
+
+    plugins: [
+      // ...
+
+      // Build or serve the model-check report
+      checkPlugin({
+        // There are no required options; see below for optional configuration
+      })
+    ]
+  }
+}
+```
+
+3. Write check tests in one or more YAML files (see "Defining tests" below).
+
+4. Run `sde dev` to work on your model with the report open in a browser, or `sde bundle` to build the report as part of a production build.
+
+### Defining tests
+
+By default, the plugin discovers test definitions by scanning your project directory for YAML files:
+
+- Check tests: files matching `**/checks/*.yaml`.
+- Comparison tests: files matching `**/comparisons/*.yaml`.
+
+A common layout is to keep them next to the model:
+
+```
+  model/
+  ├── example.mdl
+  ├── checks/
+  |   └── checks.yaml
+  └── comparisons/
+      └── comparisons.yaml
+```
+
+A simple `checks.yaml` file looks like this:
+
+```yaml
+# yaml-language-server: $schema=../../node_modules/@sdeverywhere/plugin-check/node_modules/@sdeverywhere/check-core/schema/check.schema.json
+
+- describe: Total inventory
+  tests:
+    - it: should be in the range [1000,1300] for all input scenarios
+      scenarios:
+        - preset: matrix
+      datasets:
+        - name: Total inventory
+      predicates:
+        - gte: 1000
+          lte: 1300
+```
+
+The `yaml-language-server` comment at the top is optional but recommended; it enables autocompletion and validation of the test definitions in editors that support the YAML language server.
+
+For the full set of scenarios, datasets, and predicates, refer to [Testing and Comparing Your Model](https://github.com/climateinteractive/SDEverywhere/wiki/Testing-and-Comparing-Your-Model) in the [SDEverywhere wiki](https://github.com/climateinteractive/SDEverywhere/wiki).
+
+If you prefer to define tests programmatically instead of in YAML, use the `testConfigPath` option to point at a JS file that exports a `getConfigOptions` function; when that option is set, the YAML files are not scanned.
+
+### Working locally with `sde dev`
+
+When you run `sde dev`, the plugin starts a local dev server (at `http://localhost:8081` by default) that serves the model-check report.
+As you edit your model or your test YAML files, the tests are re-run in the browser and the report refreshes automatically.
+
+Each time the model is rebuilt in development mode, the previous bundle is copied to `bundles/previous.js` in your project directory, so you can immediately compare your latest changes against the version you had a moment ago.
+Any other bundle you place in the `bundles` directory is also available for selection in the report, which makes it easy to compare against a known-good version of your model.
+
+Use the `serverPort` option to use a custom port:
+
+```js
+checkPlugin({
+  serverPort: 8082
+})
+```
+
+### Comparing against a baseline in production builds
+
+For production builds, use the `baseline` and `current` options to tell the plugin which two bundles to compare.
+The `baseline` bundle is usually the bundle that was produced by the last build of your main branch, and can be loaded from a local path or from a URL:
+
+```js
+const deployBaseUrl = 'https://your-username.github.io/your-repo'
+
+let baselineBundle
+let currentBundle
+if (process.env.NODE_ENV !== 'development') {
+  baselineBundle = {
+    name: 'main',
+    url: `${deployBaseUrl}/branch/main/extras/check-bundle.js`
+  }
+  currentBundle = {
+    name: process.env.GITHUB_REF_NAME || 'current'
+  }
+}
+
+// ...
+
+checkPlugin({
+  // The "left" bundle in comparisons; if undefined, comparison tests are skipped
+  baseline: baselineBundle,
+
+  // The "right" bundle in comparisons; if undefined, the bundle generated by this
+  // build is used
+  current: currentBundle,
+
+  // The list of bundles that can be selected in the report when running locally
+  remoteBundlesUrl: `${deployBaseUrl}/metadata/bundles.json`
+})
+```
+
+Notes on this configuration:
+
+- If the `baseline` bundle cannot be loaded (for example, the first time you build, before any bundle has been published), the build logs a warning, runs the check tests, and skips the comparisons.
+- If the `baseline` bundle was produced by a different version of SDEverywhere than the `current` bundle, comparisons are skipped as well.
+- Use `fetchRemoteBundle` if loading the baseline bundle requires custom logic, such as an authorization header.
+
+The [`@sdeverywhere/plugin-deploy`](https://github.com/climateinteractive/SDEverywhere/tree/main/packages/plugin-deploy) package publishes both `check-bundle.js` and `metadata/bundles.json` in the layout assumed above, so the two plugins are designed to be used together.
+
+### Build products
+
+In a production build (`sde bundle`), the plugin writes the following to the `sde-prep` directory:
+
+```
+  sde-prep/
+  ├── check-bundle.js    # The bundle for the current version of the model
+  └── check-report/      # The generated model-check report (a static web app)
+```
+
+Use the `reportPath` option to write the report somewhere else.
+If any check test fails, `sde bundle` exits with a non-zero status, which causes the build to fail in CI.
 
 ## Documentation
 

--- a/packages/plugin-config/README.md
+++ b/packages/plugin-config/README.md
@@ -25,7 +25,16 @@ yarn add -D @sdeverywhere/plugin-config
 _Note:_ If you followed the "Quick Start" instructions above, the `create` script will have already performed the following steps for you.
 Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-config` can be integrated into your project.
 
-To get started:
+### Why use this plugin?
+
+Every SDEverywhere project needs a `modelSpec` that declares which model variables are exposed as inputs and outputs.
+For a small model, it is fine to write that specification by hand in `sde.config.js`.
+
+For a larger model, and especially for one that drives a full application with sliders, graphs, and translated labels, keeping all of that in a JavaScript file becomes unwieldy.
+This plugin lets you describe those things in a set of CSV files instead, which can be edited in a spreadsheet program by people who don't work in the code.
+It reads those CSV files and produces both the `modelSpec` needed by the build process and a set of generated source files that your application can use directly.
+
+### Steps
 
 1. Copy the included template config files to your local project:
 
@@ -35,22 +44,34 @@ npm install --save-dev @sdeverywhere/plugin-config
 cp -rf "./node_modules/@sdeverywhere/plugin-config/template-config" ./config
 ```
 
-2. Replace the placeholder values in the CSV files with values that are suitable for your model.
+2. Replace the placeholder values in the CSV files with values that are suitable for your model (see "The config files" below).
 
-3. Add a line to your `sde.config.js` file that uses the `configProcessor` function supplied by this package:
+3. Add a line to your `sde.config.js` file that uses the `configProcessor` function supplied by this package. Note that `configProcessor` is used as the value of the `modelSpec` property; it is not added to the `plugins` array:
 
 ```js
+import { dirname, join as joinPath } from 'path'
+import { fileURLToPath } from 'url'
+
 import { configProcessor } from '@sdeverywhere/plugin-config'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const configDir = joinPath(__dirname, 'config')
+const corePath = (...parts) => joinPath(__dirname, 'packages', 'core', ...parts)
 
 export async function config() {
   return {
     // Specify the Vensim model to read
-    modelFiles: ['example.mdl'],
+    modelFiles: ['model/example.mdl'],
 
-    // Read csv files from `config` directory and write to the recommended output
-    // directory structure.  See `ConfigProcessorOptions` for more details.
+    // Rebuild when the config files are changed
+    watchPaths: ['config/**', 'model/example.mdl'],
+
+    // Read csv files from the `config` directory and write generated files to the
+    // recommended output directory structure under the `core` package.  See
+    // `ConfigProcessorOptions` for more details.
     modelSpec: configProcessor({
-      config: 'config'
+      config: configDir,
+      out: corePath()
     }),
 
     plugins: [
@@ -61,6 +82,63 @@ export async function config() {
 ```
 
 4. Run `sde bundle` or `sde dev`; your config files will be used to drive the build process.
+
+### The config files
+
+The `config` directory contains the following CSV files:
+
+| File          | Purpose                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `model.csv`   | Basic model settings: default graph time range, `.dat` files, and flags such as `bundle listing`.          |
+| `inputs.csv`  | One row per input (slider or switch), including the model variable name, range, default value, and labels. |
+| `outputs.csv` | One row per model variable that should be included in the model outputs.                                   |
+| `graphs.csv`  | One row per graph, including the title, axis settings, and up to 15 plotted variables with their styles.   |
+| `colors.csv`  | Named colors that can be referenced by ID from `graphs.csv`.                                               |
+| `strings.csv` | User-visible strings that are gathered from the other config files, for use in translation.                |
+
+Because the files are plain CSV, they can be edited in a spreadsheet program (or in a shared spreadsheet that is exported to CSV), which makes it practical for modelers and designers to adjust the app configuration without touching any code.
+
+### Generated files
+
+If `out` is set to a single directory, the plugin writes the following files:
+
+```
+  <out-dir>/
+  ├── src/
+  |   ├── config/
+  |   |   └── generated/
+  |   |       ├── config-specs.ts    # Input, graph, and color specs derived from the config files
+  |   |       └── spec-types.ts      # Types (e.g., `InputId`, `OutputVarId`) for the above
+  |   └── model/
+  |       └── generated/
+  |           └── model-spec.ts      # Input/output variable IDs for the generated model
+  └── strings/
+      └── en.js                      # The base (English) strings gathered from the config files
+```
+
+These files are intended to be imported by the application or library that wraps your model, for example:
+
+```ts
+import { graphSpecs, inputSpecs } from '../config/generated/config-specs'
+import type { InputId, OutputVarId } from '../config/generated/spec-types'
+```
+
+If you need finer control over where each group of files is written, pass a `ConfigProcessorOutputPaths` object instead of a single path:
+
+```js
+modelSpec: configProcessor({
+  config: configDir,
+  out: {
+    modelSpecsDir: corePath('src', 'model', 'generated'),
+    configSpecsDir: corePath('src', 'config', 'generated'),
+    stringsDir: corePath('strings')
+  }
+})
+```
+
+Omitting one of these paths causes that group of files to be skipped; omitting `out` entirely causes no files to be written, in which case the plugin only supplies the `modelSpec` used by the build process.
+
+For more guidance on building an application around these generated files, refer to [Creating a Web Application](https://github.com/climateinteractive/SDEverywhere/wiki/Creating-a-Web-Application) in the [SDEverywhere wiki](https://github.com/climateinteractive/SDEverywhere/wiki).
 
 ## Documentation
 

--- a/packages/plugin-vite/README.md
+++ b/packages/plugin-vite/README.md
@@ -22,7 +22,152 @@ yarn add -D @sdeverywhere/plugin-vite
 
 ## Usage
 
-_TODO: This section needs to be fleshed out. In the meantime, you can refer to the API documentation below for the options used to configure this plugin._
+_Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-vite`.
+Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-vite` can be integrated into your project.
+
+### Why use this plugin?
+
+Most SDEverywhere projects include an application (or a library) that is built around the generated model.
+Rather than running `sde bundle` and `vite build` as two separate steps, this plugin folds the Vite build into the `sde` build process, which means:
+
+- your app is rebuilt automatically whenever the model is regenerated; and
+- in development mode (`sde dev`), a single command starts a Vite dev server that reloads the app when either the model or your app sources change.
+
+The plugin does not replace your Vite configuration; it simply runs Vite using the config you provide.
+
+### Steps
+
+1. Add `@sdeverywhere/plugin-vite` as a project "dev" dependency:
+
+```sh
+cd your-model-project
+npm install --save-dev @sdeverywhere/plugin-vite
+```
+
+2. Update your `sde.config.js` file to use `vitePlugin`. Both the `name` (used in log messages) and `config` (the Vite config) options are required:
+
+```js
+import { dirname, join as joinPath } from 'path'
+import { fileURLToPath } from 'url'
+
+import { vitePlugin } from '@sdeverywhere/plugin-vite'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const appPath = (...parts) => joinPath(__dirname, 'packages', 'app', ...parts)
+
+export async function config() {
+  return {
+    modelFiles: ['model/example.mdl'],
+
+    // ...
+
+    plugins: [
+      // ...
+
+      // Build or serve the model explorer app
+      vitePlugin({
+        name: 'app',
+        apply: {
+          // Run the Vite dev server when `sde dev` is used
+          development: 'serve'
+        },
+        config: {
+          configFile: appPath('vite.config.js')
+        }
+      })
+    ]
+  }
+}
+```
+
+3. Run `sde bundle` to build your app, or `sde dev` to serve it locally with live reload.
+
+### Choosing the `apply` behavior
+
+The `apply` option controls when (and how) Vite runs for each `sde` build mode.
+Both `apply.development` and `apply.production` default to `'post-build'`.
+
+For a **web application** that you want to view while you work on the model, use `'serve'` in development mode.
+Vite starts a dev server and refreshes the browser when changes are detected:
+
+```js
+vitePlugin({
+  name: 'app',
+  apply: {
+    development: 'serve'
+  },
+  config: {
+    configFile: appPath('vite.config.js')
+  }
+})
+```
+
+For a **library** that other packages depend on (for example, a `core` package that wraps the generated model), use `'watch'` in development mode so that Vite rebuilds the library whenever its sources change:
+
+```js
+vitePlugin({
+  name: 'core',
+  apply: {
+    development: 'watch'
+  },
+  config: {
+    configFile: corePath('vite.config.js')
+  }
+})
+```
+
+The full set of values is:
+
+| Value             | Development | Production | Behavior                                                 |
+| ----------------- | :---------: | :--------: | -------------------------------------------------------- |
+| `'skip'`          |      ✓      |     ✓      | Don't run the plugin.                                    |
+| `'post-generate'` |      ✓      |     ✓      | Run `vite build` in the `postGenerate` phase.            |
+| `'post-build'`    |      ✓      |     ✓      | Run `vite build` in the `postBuild` phase (the default). |
+| `'watch'`         |      ✓      |            | Run `vite build` in watch mode; useful for libraries.    |
+| `'serve'`         |      ✓      |            | Run the Vite dev server; useful for applications.        |
+
+Use `'post-generate'` when a later plugin needs the output of this Vite build; use `'post-build'` (the default) otherwise.
+
+### Using more than one instance
+
+A project can include as many `vitePlugin` instances as it needs; give each one a distinct `name` so that log messages are easy to follow.
+Because plugins run in order, list a library before the app that depends on it:
+
+```js
+plugins: [
+  // Build the `core` library that wraps the generated model
+  vitePlugin({
+    name: 'core',
+    apply: { development: 'watch' },
+    config: { configFile: corePath('vite.config.js') }
+  }),
+
+  // Build or serve the app that depends on the `core` library
+  vitePlugin({
+    name: 'app',
+    apply: { development: 'serve' },
+    config: { configFile: appPath('vite.config.js') }
+  })
+]
+```
+
+### Providing the Vite config inline
+
+The `config` option is a Vite [`InlineConfig`](https://vite.dev/config/), so you can define the configuration directly in `sde.config.js` instead of pointing at a separate config file:
+
+```js
+vitePlugin({
+  name: 'app',
+  config: {
+    configFile: false,
+    root: appPath(),
+    build: {
+      outDir: appPath('dist'),
+      emptyOutDir: true
+    }
+  }
+})
+```
 
 ## Documentation
 

--- a/packages/plugin-wasm/README.md
+++ b/packages/plugin-wasm/README.md
@@ -22,7 +22,117 @@ yarn add -D @sdeverywhere/plugin-wasm
 
 ## Usage
 
-_TODO: This section needs to be fleshed out. In the meantime, you can refer to the API documentation below for the options used to configure this plugin._
+_Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-wasm`.
+Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-wasm` can be integrated into your project.
+
+### Do you need this plugin?
+
+SDEverywhere can generate your model as either JavaScript or C code, which is controlled by the `genFormat` property in your `sde.config.js` file:
+
+- If `genFormat` is `'js'` (the default), the generated model is plain JavaScript that runs in a browser or in Node.js with no additional build steps. In this case, you do _not_ need `plugin-wasm`.
+- If `genFormat` is `'c'`, the generated C code must be compiled to a WebAssembly module before it can be used in a browser or in Node.js. This is the job of `plugin-wasm`.
+
+A WebAssembly model typically runs faster than the pure JavaScript version, but requires the [Emscripten SDK](https://emscripten.org) to be installed.
+Regardless of which format you choose, the same runtime APIs (e.g., `ModelRunner`) can be used to run the generated model, so it is easy to switch between the two.
+
+### Prerequisites
+
+This plugin runs the Emscripten compiler (`emcc`), so the Emscripten SDK must be installed on your machine (and on your CI machine, if you build there).
+The `@sdeverywhere/create` package can install the SDK for you; see the "Quick Start" instructions above.
+
+By default, the plugin walks up the directory structure from your project to find the nearest `emsdk` directory.
+If your SDK lives somewhere else, use the `emsdkDir` option (see "Configuring the Emscripten SDK location" below).
+
+### Steps
+
+1. Add `@sdeverywhere/plugin-wasm` as a project "dev" dependency:
+
+```sh
+cd your-model-project
+npm install --save-dev @sdeverywhere/plugin-wasm
+```
+
+2. Update your `sde.config.js` file to set `genFormat` to `'c'` and to use `wasmPlugin`. Make sure that `wasmPlugin` appears before any plugin that consumes the generated model (for example, `plugin-worker`):
+
+```js
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+export async function config() {
+  return {
+    // `plugin-wasm` requires the sde compiler to generate C code
+    genFormat: 'c',
+
+    modelFiles: ['model/example.mdl'],
+
+    // ...
+
+    plugins: [
+      // Generate a `generated-model.js` file containing the Wasm model
+      wasmPlugin({
+        // Include options here if needed
+      }),
+
+      // Other plugins that use the generated model must run after `wasmPlugin`
+      workerPlugin()
+    ]
+  }
+}
+```
+
+3. Run `sde bundle` (or `sde dev`). The plugin compiles the generated C code and writes a `generated-model.js` file to the `sde-prep` directory.
+
+### The generated model file
+
+The plugin writes a single `generated-model.js` file that contains the compiled Wasm module inlined as base64 data (the default `emcc` arguments include `-sSINGLE_FILE=1`), so there is no separate `.wasm` file to load or deploy.
+
+The default module exports a function that loads the model, so it can be used directly with the `@sdeverywhere/runtime` APIs:
+
+```js
+import loadGeneratedModel from './sde-prep/generated-model.js'
+
+const generatedModel = await loadGeneratedModel()
+```
+
+More commonly, you will let `plugin-worker` wrap this file in a `worker.js` file that runs the model on a separate thread; see the [`@sdeverywhere/plugin-worker`](https://github.com/climateinteractive/SDEverywhere/tree/main/packages/plugin-worker) package for details.
+
+Use the `outputJsPath` option if you want the file written somewhere other than the `sde-prep` directory:
+
+```js
+wasmPlugin({
+  outputJsPath: joinPath(__dirname, 'packages', 'core', 'src', 'model', 'generated', 'generated-model.js')
+})
+```
+
+### Configuring the Emscripten SDK location
+
+If the plugin cannot find your `emsdk` directory automatically, set `emsdkDir` to an absolute path (or to a function that returns one, which is useful if the location is only known at build time):
+
+```js
+wasmPlugin({
+  emsdkDir: process.env.EMSDK || '/opt/emsdk'
+})
+```
+
+### Customizing the `emcc` arguments
+
+The plugin passes a default set of arguments to `emcc` that is known to work with the SDEverywhere runtime; see [`defaultEmccArgs`](./docs/functions/defaultEmccArgs.md) for the full list.
+
+Each element of the `emccArgs` array is passed to `emcc` as a separate command line argument (they are not processed by a shell), so a `-s` option must be written without a space between the flag and the option name, for example `-sASSERTIONS=1`.
+
+If you only need to add to the defaults, spread `defaultEmccArgs()` instead of repeating the full set:
+
+```js
+import { defaultEmccArgs, wasmPlugin } from '@sdeverywhere/plugin-wasm'
+
+// ...
+
+wasmPlugin({
+  emccArgs: [...defaultEmccArgs(), '-sASSERTIONS=1']
+})
+```
+
+_Note:_ If you replace the defaults entirely, be sure to keep the `-sEXPORTED_FUNCTIONS` and `-sEXPORTED_RUNTIME_METHODS` arguments, since the SDEverywhere runtime depends on those exports.
 
 ## Documentation
 

--- a/packages/plugin-wasm/README.md
+++ b/packages/plugin-wasm/README.md
@@ -25,7 +25,7 @@ yarn add -D @sdeverywhere/plugin-wasm
 _Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-wasm`.
 Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-wasm` can be integrated into your project.
 
-### Do you need this plugin?
+### Why use this plugin?
 
 SDEverywhere can generate your model as either JavaScript or C code, which is controlled by the `genFormat` property in your `sde.config.js` file:
 

--- a/packages/plugin-worker/README.md
+++ b/packages/plugin-worker/README.md
@@ -22,7 +22,96 @@ yarn add -D @sdeverywhere/plugin-worker
 
 ## Usage
 
-_TODO: This section needs to be fleshed out. In the meantime, you can refer to the API documentation below for the options used to configure this plugin._
+_Note:_ If you followed the "Quick Start" instructions above and/or are using one of the standard project templates provided by SDEverywhere, the `sde.config.js` file should already be set up to use `plugin-worker`.
+Reading these instructions can still be helpful if you are setting up a project manually or want to understand how `plugin-worker` can be integrated into your project.
+
+### Why use this plugin?
+
+Running an SDEverywhere-generated model can take long enough to make an application feel unresponsive if the model runs on the main (UI) thread.
+This plugin bundles your generated model together with the `@sdeverywhere/runtime-async` glue code into a single, self-contained `worker.js` file.
+When your application spawns that worker, model runs happen on a separate thread, which keeps sliders and other controls responsive.
+
+The generated worker works in both web browser and Node.js environments without any changes on your part: it uses a Web Worker in a browser, and a worker thread in Node.js.
+
+### Steps
+
+1. Add `@sdeverywhere/plugin-worker` as a project "dev" dependency:
+
+```sh
+cd your-model-project
+npm install --save-dev @sdeverywhere/plugin-worker
+```
+
+2. Update your `sde.config.js` file to use `workerPlugin`. Make sure that `workerPlugin` runs after any plugin that produces the generated model (for example, `plugin-wasm`):
+
+```js
+import { dirname, join as joinPath } from 'path'
+import { fileURLToPath } from 'url'
+
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const corePath = (...parts) => joinPath(__dirname, 'packages', 'core', ...parts)
+
+export async function config() {
+  return {
+    modelFiles: ['model/example.mdl'],
+
+    // ...
+
+    plugins: [
+      // Generate a `worker.js` file that runs the model asynchronously on a
+      // worker thread for improved responsiveness
+      workerPlugin({
+        // If `outputPaths` is undefined, `worker.js` is written to the `sde-prep`
+        // directory.  More commonly, you will write it into your app or library
+        // source tree so that it can be imported directly.
+        outputPaths: [corePath('src', 'model', 'generated', 'worker.js')]
+      })
+    ]
+  }
+}
+```
+
+3. Run `sde bundle` (or `sde dev`); the plugin writes a `worker.js` file to each configured output path.
+
+_Note:_ If you set `genFormat` to `'c'` in your `sde.config.js` file, add `wasmPlugin()` before `workerPlugin()` so that the C code is compiled to a WebAssembly module first.
+If `genFormat` is `'js'` (the default), `workerPlugin` can pick up the generated JavaScript model directly and no additional plugin is needed.
+
+### Using the generated worker
+
+The generated `worker.js` is a self-contained bundle, so the recommended approach is to import its source and pass it to `spawnAsyncModelRunner` from `@sdeverywhere/runtime-async`.
+This avoids having to serve or resolve a separate worker file at runtime.
+In a Vite-based project, you can use the `?raw` suffix to import the file as a string:
+
+```js
+import { spawnAsyncModelRunner } from '@sdeverywhere/runtime-async'
+
+import workerJs from './generated/worker.js?raw'
+
+export async function createModelRunner() {
+  return spawnAsyncModelRunner({ source: workerJs })
+}
+```
+
+Alternatively, if you serve `worker.js` as a static asset, you can spawn it by path instead:
+
+```js
+const runner = await spawnAsyncModelRunner({ path: './worker.js' })
+```
+
+The resulting `ModelRunner` can be used directly, or can be passed to a higher-level scheduler such as `ModelScheduler`.
+See the [`@sdeverywhere/runtime`](https://github.com/climateinteractive/SDEverywhere/tree/main/packages/runtime) and [`@sdeverywhere/runtime-async`](https://github.com/climateinteractive/SDEverywhere/tree/main/packages/runtime-async) packages for more details.
+
+### Writing to multiple locations
+
+The `outputPaths` option accepts more than one path, which is useful if the same worker is needed by more than one package in a monorepo:
+
+```js
+workerPlugin({
+  outputPaths: [corePath('src', 'model', 'generated', 'worker.js'), appPath('src', 'model', 'generated', 'worker.js')]
+})
+```
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #337 

See issue for details.  This is one of the last things that I wanted to address before we reach the "1.0" milestone for all packages.

I have carefully read through the Claude-generated docs and made a number of edits so that it better matches my style.  Overall I think the quality of the docs is good and they match the style used in earlier documentation that I've written in this repo.  I think these Usage sections are more verbose than what I would have written myself but that's probably a good thing, since the devil is in the details for a lot of these, and the detailed docs will be helpful to humans and tools.

**AI disclosure:** I guided Claude Code (Opus 5) to draft the Usage section text (it used existing text from plugin-deploy and other places and matched that style), and then I reviewed and refined the text to better match my normal writing style.
