### PR TITLE
docs: replace "Example" section in API index page with a sentence that links to README

### DIFF
--- a/packages/plugin-check/docs/index.md
+++ b/packages/plugin-check/docs/index.md
@@ -6,7 +6,6 @@ Example `sde.config.js` file:
 
 ```js
 import { checkPlugin } from '@sdeverywhere/plugin-check'
-import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
 import { workerPlugin } from '@sdeverywhere/plugin-worker'
 
 export async function config() {
@@ -22,13 +21,10 @@ export async function config() {
     },
 
     plugins: [
-      // Generate a `generated-model.js` file containing the Wasm model
-      wasmPlugin(),
-
-      // Generate a `worker.js` file that runs the Wasm model in a worker
+      // Generate a `worker.js` file that runs the generated model in a worker
       workerPlugin(),
 
-      // Run checks and comparison tests against the generated Wasm model
+      // Run checks and comparison tests against the generated model
       checkPlugin({
         // There are no required properties; see `CheckPluginOptions` below
         // for optional configuration

--- a/packages/plugin-check/docs/index.md
+++ b/packages/plugin-check/docs/index.md
@@ -1,38 +1,7 @@
 # @sdeverywhere/plugin-check
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { checkPlugin } from '@sdeverywhere/plugin-check'
-import { workerPlugin } from '@sdeverywhere/plugin-worker'
-
-export async function config() {
-  return {
-    modelFiles: ['example.mdl'],
-
-    modelSpec: async () => {
-      return {
-        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
-        outputs: [{ varName: 'Z' }],
-        datFiles: []
-      }
-    },
-
-    plugins: [
-      // Generate a `worker.js` file that runs the generated model in a worker
-      workerPlugin(),
-
-      // Run checks and comparison tests against the generated model
-      checkPlugin({
-        // There are no required properties; see `CheckPluginOptions` below
-        // for optional configuration
-      })
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 

--- a/packages/plugin-config/docs/index.md
+++ b/packages/plugin-config/docs/index.md
@@ -1,36 +1,7 @@
 # @sdeverywhere/plugin-config
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { dirname, join as joinPath } from 'path'
-import { fileURLToPath } from 'url'
-
-import { configProcessor } from '@sdeverywhere/plugin-config'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-export async function config() {
-  return {
-    // Specify the Vensim model to read
-    modelFiles: ['example.mdl'],
-
-    // Read csv files from the `config` directory and write to the recommended output
-    // directory structure under the `core` package.  Note that the `config` and `out`
-    // paths must be absolute.  See `ConfigProcessorOptions` for more details.
-    modelSpec: configProcessor({
-      config: joinPath(__dirname, 'config'),
-      out: joinPath(__dirname, 'packages', 'core')
-    }),
-
-    plugins: [
-      // ...
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 

--- a/packages/plugin-config/docs/index.md
+++ b/packages/plugin-config/docs/index.md
@@ -5,17 +5,24 @@
 Example `sde.config.js` file:
 
 ```js
+import { dirname, join as joinPath } from 'path'
+import { fileURLToPath } from 'url'
+
 import { configProcessor } from '@sdeverywhere/plugin-config'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export async function config() {
   return {
     // Specify the Vensim model to read
     modelFiles: ['example.mdl'],
 
-    // Read csv files from `config` directory and write to the recommended output
-    // directory structure.  See `ConfigProcessorOptions` for more details.
+    // Read csv files from the `config` directory and write to the recommended output
+    // directory structure under the `core` package.  Note that the `config` and `out`
+    // paths must be absolute.  See `ConfigProcessorOptions` for more details.
     modelSpec: configProcessor({
-      config: 'config'
+      config: joinPath(__dirname, 'config'),
+      out: joinPath(__dirname, 'packages', 'core')
     }),
 
     plugins: [

--- a/packages/plugin-deploy/docs/index.md
+++ b/packages/plugin-deploy/docs/index.md
@@ -1,52 +1,7 @@
 # @sdeverywhere/plugin-deploy
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { checkPlugin } from '@sdeverywhere/plugin-check'
-import { deployPlugin } from '@sdeverywhere/plugin-deploy'
-import { vitePlugin } from '@sdeverywhere/plugin-vite'
-import { workerPlugin } from '@sdeverywhere/plugin-worker'
-
-export async function config() {
-  return {
-    modelFiles: ['example.mdl'],
-
-    modelSpec: async () => {
-      return {
-        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
-        outputs: [{ varName: 'Z' }],
-        datFiles: []
-      }
-    },
-
-    plugins: [
-      // Generate a `worker.js` file that runs the model in a worker
-      workerPlugin(),
-
-      // Build or serve a web application using a provided Vite config file
-      vitePlugin({
-        // ...
-      }),
-
-      // Run checks and comparison tests against the generated model
-      checkPlugin({
-        // ...
-      }),
-
-      // Deploy the app and model-check report to GitHub Pages.  Make sure that
-      // `deployPlugin` is the last step, since it depends on the output of the
-      // earlier plugins.
-      deployPlugin({
-        // There are no required properties; see `DeployPluginOptions` below
-        // for optional configuration
-      })
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 

--- a/packages/plugin-deploy/docs/index.md
+++ b/packages/plugin-deploy/docs/index.md
@@ -29,14 +29,16 @@ export async function config() {
       // Build or serve a web application using a provided Vite config file
       vitePlugin({
         // ...
-      })
+      }),
 
       // Run checks and comparison tests against the generated model
       checkPlugin({
         // ...
-      })
+      }),
 
-      // Deploy the app and model-check report to GitHub Pages
+      // Deploy the app and model-check report to GitHub Pages.  Make sure that
+      // `deployPlugin` is the last step, since it depends on the output of the
+      // earlier plugins.
       deployPlugin({
         // There are no required properties; see `DeployPluginOptions` below
         // for optional configuration

--- a/packages/plugin-vite/docs/index.md
+++ b/packages/plugin-vite/docs/index.md
@@ -1,44 +1,7 @@
 # @sdeverywhere/plugin-vite
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { vitePlugin } from '@sdeverywhere/plugin-vite'
-import { workerPlugin } from '@sdeverywhere/plugin-worker'
-
-export async function config() {
-  return {
-    modelFiles: ['example.mdl'],
-
-    modelSpec: async () => {
-      return {
-        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
-        outputs: [{ varName: 'Z' }],
-        datFiles: []
-      }
-    },
-
-    plugins: [
-      // Generate a `worker.js` file that runs the generated model in a worker
-      workerPlugin(),
-
-      // Build or serve a web application using a provided Vite config file.
-      // See `VitePluginOptions` for the full set of configuration options.
-      vitePlugin({
-        name: 'app',
-        apply: {
-          development: 'serve'
-        },
-        config: {
-          configFile: 'app/vite.config.js'
-        }
-      })
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 

--- a/packages/plugin-vite/docs/index.md
+++ b/packages/plugin-vite/docs/index.md
@@ -6,7 +6,6 @@ Example `sde.config.js` file:
 
 ```js
 import { vitePlugin } from '@sdeverywhere/plugin-vite'
-import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
 import { workerPlugin } from '@sdeverywhere/plugin-worker'
 
 export async function config() {
@@ -22,10 +21,7 @@ export async function config() {
     },
 
     plugins: [
-      // Generate a `generated-model.js` file containing the Wasm model
-      wasmPlugin(),
-
-      // Generate a `worker.js` file that runs the Wasm model in a worker
+      // Generate a `worker.js` file that runs the generated model in a worker
       workerPlugin(),
 
       // Build or serve a web application using a provided Vite config file.

--- a/packages/plugin-wasm/docs/index.md
+++ b/packages/plugin-wasm/docs/index.md
@@ -9,6 +9,9 @@ import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
 
 export async function config() {
   return {
+    // Note that `plugin-wasm` requires the sde compiler to generate C code
+    genFormat: 'c',
+
     modelFiles: ['example.mdl'],
 
     modelSpec: async () => {
@@ -20,7 +23,7 @@ export async function config() {
     },
 
     plugins: [
-      // Generate a `wasm-model.js` file containing the Wasm model
+      // Generate a `generated-model.js` file containing the Wasm model
       wasmPlugin({
         // There are no required properties; see `WasmPluginOptions` below
         // for optional configuration

--- a/packages/plugin-wasm/docs/index.md
+++ b/packages/plugin-wasm/docs/index.md
@@ -1,37 +1,7 @@
 # @sdeverywhere/plugin-wasm
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
-
-export async function config() {
-  return {
-    // Note that `plugin-wasm` requires the sde compiler to generate C code
-    genFormat: 'c',
-
-    modelFiles: ['example.mdl'],
-
-    modelSpec: async () => {
-      return {
-        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
-        outputs: [{ varName: 'Z' }],
-        datFiles: []
-      }
-    },
-
-    plugins: [
-      // Generate a `generated-model.js` file containing the Wasm model
-      wasmPlugin({
-        // There are no required properties; see `WasmPluginOptions` below
-        // for optional configuration
-      })
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 

--- a/packages/plugin-worker/docs/index.md
+++ b/packages/plugin-worker/docs/index.md
@@ -5,7 +5,6 @@
 Example `sde.config.js` file:
 
 ```js
-import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
 import { workerPlugin } from '@sdeverywhere/plugin-worker'
 
 export async function config() {
@@ -21,14 +20,35 @@ export async function config() {
     },
 
     plugins: [
-      // Generate a `generated-model.js` file containing the Wasm model
-      wasmPlugin(),
-
-      // Generate a `worker.js` file that runs the Wasm model in a worker
+      // Generate a `worker.js` file that runs the generated model in a worker
       workerPlugin({
         // There are no required properties; see `WorkerPluginOptions` below
         // for optional configuration
       })
+    ]
+  }
+}
+```
+
+If you set `genFormat` to `'c'`, add `wasmPlugin()` before `workerPlugin()` so that the
+generated C code is compiled to a WebAssembly module first:
+
+```js
+import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
+import { workerPlugin } from '@sdeverywhere/plugin-worker'
+
+export async function config() {
+  return {
+    genFormat: 'c',
+
+    // ...
+
+    plugins: [
+      // Generate a `generated-model.js` file containing the Wasm model
+      wasmPlugin(),
+
+      // Generate a `worker.js` file that runs the Wasm model in a worker
+      workerPlugin()
     ]
   }
 }

--- a/packages/plugin-worker/docs/index.md
+++ b/packages/plugin-worker/docs/index.md
@@ -1,58 +1,7 @@
 # @sdeverywhere/plugin-worker
 
-## Example
-
-Example `sde.config.js` file:
-
-```js
-import { workerPlugin } from '@sdeverywhere/plugin-worker'
-
-export async function config() {
-  return {
-    modelFiles: ['example.mdl'],
-
-    modelSpec: async () => {
-      return {
-        inputs: [{ varName: 'Y', defaultValue: 0, minValue: -10, maxValue: 10 }],
-        outputs: [{ varName: 'Z' }],
-        datFiles: []
-      }
-    },
-
-    plugins: [
-      // Generate a `worker.js` file that runs the generated model in a worker
-      workerPlugin({
-        // There are no required properties; see `WorkerPluginOptions` below
-        // for optional configuration
-      })
-    ]
-  }
-}
-```
-
-If you set `genFormat` to `'c'`, add `wasmPlugin()` before `workerPlugin()` so that the
-generated C code is compiled to a WebAssembly module first:
-
-```js
-import { wasmPlugin } from '@sdeverywhere/plugin-wasm'
-import { workerPlugin } from '@sdeverywhere/plugin-worker'
-
-export async function config() {
-  return {
-    genFormat: 'c',
-
-    // ...
-
-    plugins: [
-      // Generate a `generated-model.js` file containing the Wasm model
-      wasmPlugin(),
-
-      // Generate a `worker.js` file that runs the Wasm model in a worker
-      workerPlugin()
-    ]
-  }
-}
-```
+For examples of how to configure this plugin in an `sde.config.js` file, refer to the
+["Usage"](../README.md#usage) section of the README.
 
 ## Initialization
 


### PR DESCRIPTION
Fixes #883 

See issue for details.  This will reduce redundancy and will make it so that we can focus documentation efforts on one place.
