### PR TITLE
test: flesh out tests for model-check annotations

### DIFF
--- a/packages/check-ui-shell/src/components/compare/_shared/annotations.spec.ts
+++ b/packages/check-ui-shell/src/components/compare/_shared/annotations.spec.ts
@@ -6,7 +6,10 @@ import type {
   ComparisonDataset,
   ComparisonResolverError,
   ComparisonScenario,
+  ComparisonScenarioInput,
+  ComparisonScenarioInputState,
   DatasetKey,
+  InputVar,
   OutputVar
 } from '@sdeverywhere/check-core'
 
@@ -14,6 +17,7 @@ import { varIdForName } from '../../../_mocks/mock-vars'
 
 import { getAnnotationsForDataset, getAnnotationsForScenario } from './annotations'
 import {
+  allAtPos,
   inputAtPositionSpec,
   inputSettingsSpec,
   inputVar,
@@ -50,10 +54,58 @@ function dataset(key: DatasetKey, outputVarL?: OutputVar, outputVarR?: OutputVar
   }
 }
 
+/** Return an input state for an input that resolved without errors or warnings. */
+function okState(v: InputVar): ComparisonScenarioInputState {
+  return { inputVar: v, value: 50 }
+}
+
+/** Return an input state for an input that could not be resolved. */
+function errState(error: ComparisonResolverError): ComparisonScenarioInputState {
+  return { error }
+}
+
+/** Return an input state for an input that resolved to a value outside of the valid range. */
+function oorState(v: InputVar): ComparisonScenarioInputState {
+  return { inputVar: v, value: 500, warning: { kind: 'value-out-of-range' } }
+}
+
+/** Return a scenario input with the given left and right resolution states. */
+function input(
+  requestedName: string,
+  stateL: ComparisonScenarioInputState,
+  stateR: ComparisonScenarioInputState
+): ComparisonScenarioInput {
+  return { requestedName, stateL, stateR }
+}
+
+/** Return an "input settings" scenario containing the given resolved inputs. */
+function scenario(inputs: ComparisonScenarioInput[], settingsDiffer?: boolean): ComparisonScenario {
+  return {
+    kind: 'scenario',
+    key: 's1',
+    id: 'sg1',
+    title: 'sg1',
+    settings: {
+      kind: 'input-settings',
+      inputs,
+      settingsDiffer
+    },
+    specL: undefined,
+    specR: undefined
+  }
+}
+
 describe('getAnnotationsForDataset', () => {
   it('should return no annotations for valid dataset', () => {
     const v = outputVar('A')
     const d = dataset(v.datasetKey, v, v)
+    const annotations = getAnnotationsForDataset(d, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([])
+  })
+
+  it('should return no annotations when variable is not defined on either side', () => {
+    const v = outputVar('A')
+    const d = dataset(v.datasetKey, undefined, undefined)
     const annotations = getAnnotationsForDataset(d, bundleNameL, bundleNameR)
     expect(annotations).toEqual([])
   })
@@ -96,11 +148,28 @@ describe('getAnnotationsForScenario', () => {
     expect(annotations).toEqual([])
   })
 
+  it('should return no annotations for an "all inputs" scenario', () => {
+    const s = allAtPos('s1', 'at-default')
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([])
+  })
+
   it('should return correct annotation when scenario is invalid on both sides', () => {
     const s = scenarioWithInput('s1', 'i1', 'at-maximum', errUnknownInput, errUnknownInput, undefined, undefined)
     const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
     expect(annotations).toEqual([
       `<span class="annotation"><span class="status-color-failed">✗</span>&ensp;invalid scenario: unknown input 'i1'</span>`
+    ])
+  })
+
+  it('should return correct annotation when multiple inputs are unknown on both sides', () => {
+    const s = scenario([
+      input('i1', errState(errUnknownInput), errState(errUnknownInput)),
+      input('i2', errState(errUnknownInput), errState(errUnknownInput))
+    ])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation"><span class="status-color-failed">✗</span>&ensp;invalid scenario: unknown inputs 'i1', 'i2'</span>`
     ])
   })
 
@@ -213,6 +282,31 @@ describe('getAnnotationsForScenario', () => {
     ])
   })
 
+  it('should give precedence to setting group errors when an input is also unknown on both sides', () => {
+    const s = scenario([
+      input('i1', errState(errUnknownInput), errState(errUnknownInput)),
+      input('sg1', errState(errUnknownSettingGroup), errState(errUnknownSettingGroup))
+    ])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation"><span class="status-color-failed">✗</span>&ensp;invalid scenario: unknown input setting group 'sg1'; unknown input 'i1'</span>`
+    ])
+  })
+
+  it('should return separate annotations when there are errors in both and on each side', () => {
+    const s = scenario([
+      input('i1', errState(errUnknownInput), errState(errUnknownInput)),
+      input('i2', errState(errUnknownInput), {}),
+      input('i3', {}, errState(errUnknownInput))
+    ])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation"><span class="status-color-failed">✗</span>&ensp;invalid scenario: unknown input 'i1'</span>`,
+      `<span class="annotation"><span class="status-color-warning">‼</span>&ensp;scenario not valid in <span class="dataset-color-0">baseline</span>: unknown input 'i2'</span>`,
+      `<span class="annotation"><span class="status-color-warning">‼</span>&ensp;scenario not valid in <span class="dataset-color-1">current</span>: unknown input 'i3'</span>`
+    ])
+  })
+
   it('should return correct annotation when value is out of range on both sides', () => {
     const i1 = inputVar('1', 'Input1')[1]
     const spec = inputAtPositionSpec('uid1', '_input1', 'at-maximum')
@@ -310,6 +404,53 @@ describe('getAnnotationsForScenario', () => {
     ])
   })
 
+  it('should return correct annotation when value is out of range on left side only', () => {
+    const i1 = inputVar('1', 'Input1')[1]
+    const s = scenario([input('i1', oorState(i1), okState(i1))])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation" title="warning for baseline: value out of range for 'i1'"><span class="status-color-warning">‼</span>&ensp;warning for <span class="dataset-color-0">baseline</span>: value out of range for 1 input</span>`
+    ])
+  })
+
+  it('should return separate annotations when there are warnings in both and on each side', () => {
+    const i1 = inputVar('1', 'Input1')[1]
+    const i2 = inputVar('2', 'Input2')[1]
+    const i3 = inputVar('3', 'Input3')[1]
+    const i4 = inputVar('4', 'Input4')[1]
+    const s = scenario([
+      input('i1', oorState(i1), oorState(i1)),
+      input('i2', oorState(i2), oorState(i2)),
+      input('i3', oorState(i3), okState(i3)),
+      input('i4', okState(i4), oorState(i4))
+    ])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation" title="warning: value out of range for 'i1', 'i2'"><span class="status-color-warning">‼</span>&ensp;warning: value out of range for 2 inputs</span>`,
+      `<span class="annotation" title="warning for baseline: value out of range for 'i3'"><span class="status-color-warning">‼</span>&ensp;warning for <span class="dataset-color-0">baseline</span>: value out of range for 1 input</span>`,
+      `<span class="annotation" title="warning for current: value out of range for 'i4'"><span class="status-color-warning">‼</span>&ensp;warning for <span class="dataset-color-1">current</span>: value out of range for 1 input</span>`
+    ])
+  })
+
+  it('should escape special characters in the warning tooltip', () => {
+    const i1 = inputVar('1', 'Input1')[1]
+    const s = scenario([input(`a "b" & <c>`, oorState(i1), oorState(i1))])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation" title="warning: value out of range for 'a &quot;b&quot; &amp; &lt;c&gt;'"><span class="status-color-warning">‼</span>&ensp;warning: value out of range for 1 input</span>`
+    ])
+  })
+
+  it('should return correct annotations when an input is unknown on one side and out of range on the other', () => {
+    const i1 = inputVar('1', 'Input1')[1]
+    const s = scenario([input('i1', errState(errUnknownInput), oorState(i1))])
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation"><span class="status-color-warning">‼</span>&ensp;scenario not valid in <span class="dataset-color-0">baseline</span>: unknown input 'i1'</span>`,
+      `<span class="annotation" title="warning for current: value out of range for 'i1'"><span class="status-color-warning">‼</span>&ensp;warning for <span class="dataset-color-1">current</span>: value out of range for 1 input</span>`
+    ])
+  })
+
   it('should return correct annotation when settings differ between the two models', () => {
     const s: ComparisonScenario = {
       kind: 'scenario',
@@ -327,6 +468,27 @@ describe('getAnnotationsForScenario', () => {
 
     const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
     expect(annotations).toEqual([
+      '<span class="annotation"><span class="status-color-warning">‼</span>&ensp;input settings differ between the two models</span>'
+    ])
+  })
+
+  it('should return no annotations when settings do not differ between the two models', () => {
+    const i1 = inputVar('1', 'Input1')[1]
+    const s = scenario([input('i1', okState(i1), okState(i1))], false)
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([])
+  })
+
+  it('should return annotations in a consistent order when a scenario has errors, warnings, and differing settings', () => {
+    const i2 = inputVar('2', 'Input2')[1]
+    const s = scenario(
+      [input('i1', errState(errUnknownInput), errState(errUnknownInput)), input('i2', oorState(i2), oorState(i2))],
+      true
+    )
+    const annotations = getAnnotationsForScenario(s, bundleNameL, bundleNameR)
+    expect(annotations).toEqual([
+      `<span class="annotation"><span class="status-color-failed">✗</span>&ensp;invalid scenario: unknown input 'i1'</span>`,
+      `<span class="annotation" title="warning: value out of range for 'i2'"><span class="status-color-warning">‼</span>&ensp;warning: value out of range for 1 input</span>`,
       '<span class="annotation"><span class="status-color-warning">‼</span>&ensp;input settings differ between the two models</span>'
     ])
   })

--- a/packages/check-ui-shell/src/components/compare/_shared/annotations.spec.ts
+++ b/packages/check-ui-shell/src/components/compare/_shared/annotations.spec.ts
@@ -510,19 +510,7 @@ describe('getAnnotationsForScenario', () => {
     // - ! {min/max} value changed for input {var} ({left val} | {right val})
   })
 
-  // it('should return correct annotation when max value has changed for an input', () => {})
-
   // it('should return correct annotation when an input has been renamed', () => {
   //   // - ! input variable renamed: {left var} -> {right var}
-  // })
-
-  // it('should return correct annotation when a value is out of range on left side', () => {
-  //   // - x value out of range for input {var} in {bundle}
-  // })
-
-  // it('should return correct annotation when a value is out of range on right side', () => {})
-
-  // it('should return correct annotation when a value is out of range on both sides', () => {
-  //   // - x value out of range for input {var}
   // })
 })


### PR DESCRIPTION
Fixes #336 

See issue for details.  This only adds tests; no changes to the implementation.

**AI disclosure:** I guided Claude Code (Opus 5) to implement the changes, and then I reviewed and refined the changes.
