### PR TITLE
perf: mark some C functions as `static inline` to improve performance

### DIFF
--- a/packages/cli/src/c/allocation.c
+++ b/packages/cli/src/c/allocation.c
@@ -24,7 +24,7 @@
 // #define PRINT_ALLOCATIONS_DEBUG_INFO
 
 // Return true if the value is near zero up to the epsilon tolerance.
-static inline bool __isZero(double value) { return fabs(value) < _epsilon; }
+static inline bool __isZero(double value) { return fabs(value) < SDE_EPSILON; }
 // Compute the absolute difference when x or y is near zero, otherwise compute
 // the relative difference, with y considered as the baseline.
 static inline double __difference(double x, double y) {
@@ -37,7 +37,7 @@ static inline double __difference(double x, double y) {
   return diff;
 }
 // Return true if the values are equal up to the tolerance.
-static inline bool __isEqual(double x, double y) { return __difference(x, y) < _epsilon; }
+static inline bool __isEqual(double x, double y) { return __difference(x, y) < SDE_EPSILON; }
 // Clamp x to the interval [0,1].
 static inline double __clamp01(double x) {
   if (x < 0.0) return 0.0;
@@ -440,7 +440,7 @@ double* _ALLOCATE_BY_PRIORITY(
 
   // Validate request values (must be non-negative)
   for (size_t i = 0; i < num_requesters; i++) {
-    if (request_quantities[i] < -_epsilon) {
+    if (request_quantities[i] < -SDE_EPSILON) {
       fprintf(stderr,
           "_ALLOCATE_BY_PRIORITY encountered negative request value at index %zu: %f\n",
           i, request_quantities[i]);
@@ -449,7 +449,7 @@ double* _ALLOCATE_BY_PRIORITY(
   }
 
   // Validate width (must not be negative)
-  if (width < -_epsilon) {
+  if (width < -SDE_EPSILON) {
     fprintf(stderr,
         "_ALLOCATE_BY_PRIORITY encountered invalid width value: %f\n"
         "Width must not be negative.\n",
@@ -458,7 +458,7 @@ double* _ALLOCATE_BY_PRIORITY(
   }
 
   // Validate supply (must not be negative)
-  if (supply < -_epsilon) {
+  if (supply < -SDE_EPSILON) {
     fprintf(stderr,
         "_ALLOCATE_BY_PRIORITY encountered invalid supply value: %f\n"
         "Supply must not be negative.\n",
@@ -472,7 +472,7 @@ double* _ALLOCATE_BY_PRIORITY(
   }
 
   // If supply = 0, all targets get allocated 0
-  if(fabs(supply) < _epsilon) {
+  if(fabs(supply) < SDE_EPSILON) {
     return allocations;
   }
 
@@ -539,7 +539,7 @@ double* _ALLOCATE_BY_PRIORITY(
   size_t c_i = 0;
 
   // Continue allocating until supply is exhausted
-  while (supply > _epsilon) {
+  while (supply > SDE_EPSILON) {
     // Check if there are any active targets left
     bool any_active = false;
     for (size_t i = 0; i < m; i++) {

--- a/packages/cli/src/c/sde.h
+++ b/packages/cli/src/c/sde.h
@@ -25,8 +25,6 @@ extern "C" {
 #include "vensim.h"
 #include "macros.h"
 
-EXTERN double _epsilon;
-
 // Enable this to add print statements in initLevels and evalAux for debugging.
 // #define PRDBG
 #ifdef PRDBG

--- a/packages/cli/src/c/vensim.c
+++ b/packages/cli/src/c/vensim.c
@@ -1,19 +1,16 @@
 #include "sde.h"
 
-double _epsilon = 1e-6;
+//
+// Note: This file only contains implementations of complex functions.  Simple
+// (inline-friendly) functions are defined as `static inline` functions in `vensim.h`
+// so that they can be inlined at each call site (for improved performance).
+//
 
 //
 // Vensim functions
 // See the Vensim Reference Manual for descriptions of the functions.
 // http://www.vensim.com/documentation/index.html?22300.htm
 //
-double _PULSE(double start, double width) {
-  double time_plus = _time + _time_step / 2.0;
-  if (width == 0.0) {
-    width = _time_step;
-  }
-  return (time_plus > start && time_plus < start + width) ? 1.0 : 0.0;
-}
 double _PULSE_TRAIN(double start, double width, double interval, double end) {
   double n = floor((end - start) / interval);
   for (double k = 0; k <= n; k++) {
@@ -22,29 +19,6 @@ double _PULSE_TRAIN(double start, double width, double interval, double end) {
     }
   }
   return 0.0;
-}
-double _RAMP(double slope, double start_time, double end_time) {
-  // Return 0 until the start time is exceeded.
-  // Interpolate from start time to end time.
-  // Hold at the end time value.
-  // Allow start time > end time.
-  if (_time > start_time) {
-    if (_time < end_time || start_time > end_time) {
-      return slope * (_time - start_time);
-    } else {
-      return slope * (end_time - start_time);
-    }
-  } else {
-    return 0.0;
-  }
-}
-double _XIDZ(double a, double b, double x) { return fabs(b) < _epsilon ? x : a / b; }
-double _ZIDZ(double a, double b) {
-  if (fabs(b) < _epsilon) {
-    return 0.0;
-  } else {
-    return a / b;
-  }
 }
 
 //

--- a/packages/cli/src/c/vensim.h
+++ b/packages/cli/src/c/vensim.h
@@ -10,6 +10,14 @@ extern "C" {
 #define _NA_ (-DBL_MAX)
 #define bool_cond(cond) ((double)(cond) != 0.0)
 
+// The tolerance used by the functions that guard against division by zero.
+#define SDE_EPSILON 1e-6
+
+// Note: The `_time` and `_time_step` variables are declared in `sde.h`, but `sde.h` includes
+// this header, so we declare them here for use by the inline functions below.
+extern double _time;
+extern double _time_step;
+
 //
 // Vensim functions
 // See the Vensim Reference Manual for descriptions of the functions.
@@ -44,13 +52,49 @@ double* _DEMAND_AT_PRICE(double* demand_quantities, double* demand_profiles, dou
 double _FIND_MARKET_PRICE(double* demand_quantities, double* demand_profiles, double* supply_quantities,
     double* supply_profiles, size_t num_demanders, size_t num_suppliers);
 double* _INVERT_MATRIX(double* matrix, size_t n);
-double _PULSE(double start, double width);
 double _PULSE_TRAIN(double start, double width, double interval, double end);
-double _RAMP(double slope, double start_time, double end_time);
 double* _SUPPLY_AT_PRICE(double* supply_quantities, double* supply_profiles, double price, size_t num_suppliers);
 double* _VECTOR_SORT_ORDER(double* vector, size_t size, double direction);
-double _XIDZ(double a, double b, double x);
-double _ZIDZ(double a, double b);
+
+//
+// Note: The following functions are defined here as `static inline` (rather than as
+// out-of-line functions in `vensim.c`) because they are called very frequently (millions of
+// times per run for a large model).  Defining them in the header allows the compiler to
+// inline them at each call site, which avoids the call overhead and allows repeated
+// identical calls to be replaced with a single one.
+//
+
+static inline double _PULSE(double start, double width) {
+  double time_plus = _time + _time_step / 2.0;
+  if (width == 0.0) {
+    width = _time_step;
+  }
+  return (time_plus > start && time_plus < start + width) ? 1.0 : 0.0;
+}
+
+static inline double _RAMP(double slope, double start_time, double end_time) {
+  // Return 0 until the start time is exceeded.
+  // Interpolate from start time to end time.
+  // Hold at the end time value.
+  // Allow start time > end time.
+  if (_time > start_time) {
+    if (_time < end_time || start_time > end_time) {
+      return slope * (_time - start_time);
+    } else {
+      return slope * (end_time - start_time);
+    }
+  } else {
+    return 0.0;
+  }
+}
+
+static inline double _XIDZ(double a, double b, double x) {
+  return fabs(b) < SDE_EPSILON ? x : a / b;
+}
+
+static inline double _ZIDZ(double a, double b) {
+  return fabs(b) < SDE_EPSILON ? 0.0 : a / b;
+}
 
 //
 // Lookups


### PR DESCRIPTION
Fixes #893 

See issue for details.  This helps improve performance of large models like En-ROADS and has no impact on outputs of generated models.

**AI disclosure:** I guided Claude Code (Opus 5) to plan and implement the changes, and then I reviewed and refined the changes.
