### PR TITLE
fix: handle cycles when reducing variables

### DIFF
--- a/packages/compile/src/model/reduce-variables.js
+++ b/packages/compile/src/model/reduce-variables.js
@@ -49,14 +49,22 @@ export function reduceVariables(variables, inputVarIds, mode) {
       return
     }
 
-    // Add this variable to the set of active ones
-    // TODO: Allow cycle if the current LHS is referenced on the RHS
-    // const baseVarId = v.parsedEqn.lhs.varId
-    // if (baseVarId !== currentLhsBaseVarId) {
+    // Stop if this variable is already being reduced further up the call stack, which means
+    // it takes part in a dependency cycle.  This is normal and expected: every stock and flow
+    // feedback loop is a cycle (a level's rate refers to a variable that reads the level), and
+    // a variable that holds its own value from the previous time step (`SAMPLE IF TRUE`)
+    // refers to itself.  Leaving the variable unreduced here is safe.  The caller
+    // (`resolveVarRef`) only substitutes a referenced variable when its reduced RHS is a
+    // single number, and a variable that takes part in a cycle refers to at least one other
+    // variable, so its RHS can never be a single number.  The cycle simply stops the reduction
+    // from propagating any further along that path.  Note that a cycle that is a genuine error
+    // in the model (a simultaneous equation between two aux variables, say) is still reported:
+    // `sortVarsOfType` detects it during the dependency sort and reports the whole chain.
     if (activelyReducingRefIds.has(v.refId)) {
-      throw new Error(`Cycle detected when reducing variables: ${v.refId}`)
+      return
     }
-    // }
+
+    // Add this variable to the set of active ones
     activelyReducingRefIds.add(v.refId)
 
     // We currently have two options for reducing variables.  The less aggressive

--- a/packages/compile/src/model/reduce-variables.spec.ts
+++ b/packages/compile/src/model/reduce-variables.spec.ts
@@ -67,6 +67,39 @@ function readInlineModel(reduceVariables: 'default' | 'aggressive', modelText: s
   return vars.filter(v => v.varName !== '_time')
 }
 
+/**
+ * Return the reduced formula for each variable in the model, in the order that the variables
+ * are defined.  This is a lighter-weight alternative to comparing whole `Variable` instances,
+ * for tests that only care about how far the reduction got.
+ */
+function readInlineModelFormulas(reduceVariables: 'default' | 'aggressive', modelText: string): string[][] {
+  return readInlineModel(reduceVariables, modelText).map(v => [v.varName, v.modelFormula])
+}
+
+/**
+ * Read the given model and run the full analysis (including the dependency sort) rather than
+ * stopping after the reduction step.  This is used to verify that a genuine dependency cycle
+ * is still reported by the sort.
+ */
+function readInlineModelWithFullAnalysis(reduceVariables: 'default' | 'aggressive', modelText: string): void {
+  // XXX: These steps are needed due to subs/dims and variables being in module-level storage
+  resetHelperState()
+  resetSubscriptsAndDimensions()
+  Model.resetModelState()
+
+  const parsedModel = parseInlineVensimModel(modelText)
+  Model.read(
+    parsedModel,
+    /*spec=*/ {},
+    /*extData=*/ undefined,
+    /*directData=*/ undefined,
+    /*modelDirname=*/ undefined,
+    {
+      reduceVariables
+    }
+  )
+}
+
 // function readSubscriptsAndEquations(modelName: string): Variable[] {
 //   return readSubscriptsAndEquationsFromSource({ modelName })
 // }
@@ -190,5 +223,55 @@ describe('reduceVariables (aggressive mode: reduce everything)', () => {
         refId: '_z'
       })
     ])
+  })
+
+  it('should stop at a feedback loop between a level and an aux variable', () => {
+    // This is the classic shape of a stock-and-flow feedback loop, and is the reason
+    // aggressive reduction previously failed on any real model: reducing `gas uptake`
+    // requires visiting `gas in atm`, whose rate refers back to `gas uptake`.
+    const formulas = readInlineModelFormulas(
+      'aggressive',
+      `
+        gas emissions = 300 ~~|
+        time constant = 8 ~~|
+        gas in atm = INTEG(gas emissions - gas uptake, 4900) ~~|
+        gas uptake = gas in atm / time constant ~~|
+      `
+    )
+    expect(formulas).toEqual([
+      ['_gas_emissions', '300'],
+      ['_time_constant', '8'],
+      // The constant is substituted, but the variable in the loop is left alone
+      ['_gas_in_atm', 'INTEG(300-gas uptake,4900)'],
+      ['_gas_uptake', 'gas in atm/8']
+    ])
+  })
+
+  it('should stop at a variable that refers to itself', () => {
+    const formulas = readInlineModelFormulas(
+      'aggressive',
+      `
+        x = 1 ~~|
+        y = SAMPLE IF TRUE(Time > x, y + 1, 0) ~~|
+      `
+    )
+    expect(formulas).toEqual([
+      ['_x', '1'],
+      ['_y', 'SAMPLE IF TRUE(Time>1,y+1,0)']
+    ])
+  })
+
+  it('should leave a genuine dependency cycle to be reported by the dependency sort', () => {
+    // A cycle between two aux variables is a real error in the model, but it is the
+    // dependency sort that should report it (with the full chain), not the reduction step
+    expect(() =>
+      readInlineModelWithFullAnalysis(
+        'aggressive',
+        `
+          X = Y ~~|
+          Y = X + 1 ~~|
+        `
+      )
+    ).toThrow('Found cyclic dependency during toposort:\n_y →\n_x →\n_y')
   })
 })


### PR DESCRIPTION
Fixes #897 

See issue for details.  The fix is simple; just return early instead of throwing, which skips any optimization.  This case was only likely to come up in practice when using the non-public / opt-in "aggressive" mode, so it should have no impact on existing models with default compilation.

**AI disclosure:** I guided Claude Code (Opus 5) to plan and implement the changes, and then I reviewed and refined the changes.
