### PR TITLE
perf: evaluate time-invariant aux variables once instead of on every time step

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -163,11 +163,11 @@ treated as time varying, i.e. the previous behavior). This follows the existing
 - En-ROADS Wasm (`emcc -O2`), model-check perf comparison against the `develop` baseline
   bundle (Apple M1 Max, Chrome), three "Run" passes:
 
-  | run |  develop |  current | % change |
-  | --- | -------: | -------: | -------: |
-  | 1   |     23.9 |     23.0 |    -3.6% |
-  | 2   |     24.0 |     22.9 |    -4.5% |
-  | 3   |     23.9 |     22.8 |    -4.5% |
+  | run |  develop |  current |  % change |
+  | --- | -------: | -------: | --------: |
+  | 1   |     23.9 |     23.0 |     -3.6% |
+  | 2   |     24.0 |     22.9 |     -4.5% |
+  | 3   |     23.9 |     22.8 |     -4.5% |
   | all | **23.9** | **22.9** | **-4.2%** |
 
   (median ms per model run.)

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,180 @@
+# Clone 2 — implicit `Time` dependencies + time-invariant aux hoisting
+
+This clone contains items 2 and 3 from the "Suggested order of work" section of the
+En-ROADS performance investigation (`../en-roads-app1/NOTES.md`). They are together in one
+clone because item 3 depends on item 2 being correct.
+
+Item 1 (`static inline` vensim helpers, in clone 1) and item 4 (constant folding, in
+clone 3) are **not** included here, so this clone measures items 2+3 in isolation.
+
+---
+
+## Item 2 — record the implicit `Time` dependencies
+
+### The problem
+
+`RAMP`, `STEP`, `PULSE`, `PULSE TRAIN`, and `GAME` all read the current simulation time,
+but they take it implicitly rather than as an argument, so nothing appeared in the calling
+variable's `references` list. Likewise `SAMPLE IF TRUE` holds the variable's own value from
+the previous time step, but that self-reference was not recorded either.
+
+The result was that a variable like
+
+```
+rate = STEP(10, 10)
+```
+
+looked, in the reference graph, exactly like a variable that depends on nothing at all.
+Any analysis that trusts the graph will conclude that `rate` is constant. That is what item 3
+does, so item 2 has to be fixed first — but it is worth fixing on correctness grounds alone,
+since the graph is also published in `{model}.json` for downstream tools.
+
+### Changes
+
+**`packages/compile/src/model/read-equations.js`**
+
+- Added a `timeDependentFnIds` set (`_GAME`, `_PULSE`, `_PULSE_TRAIN`, `_RAMP`, `_STEP`).
+- After a function call is validated, a call to one of those records a reference to `_time`,
+  and a `SAMPLE IF TRUE` call records a reference to the variable itself.
+- `Context.addVarReference` takes a new `allowSelfReference` argument (default `false`, so
+  existing behavior is unchanged) so that the `SAMPLE IF TRUE` self-reference can be added.
+
+**`packages/compile/src/model/model.js`**
+
+- `sortVarsOfType` now skips self-references when building the dependency graph. A self-edge
+  does not constrain the evaluation order, but `toposort` would report it as a cycle.
+- `sortInitVars` now filters out the `Time` placeholder variable. `initLevels` sets `_time`
+  to `_initial_time` as its first statement and `Time` has no equation of its own, so it must
+  never appear in the sorted init list — which could now happen if a `RAMP`/`STEP`/... call
+  appears in an "init" argument position (e.g. the second argument of `INTEG`).
+
+### Compatibility notes
+
+These are worth reviewing before merging:
+
+1. **Variable indices shift.** The `Time` placeholder used to be dropped by
+   `removeUnusedVariables` for any model that used `PULSE`/`STEP`/`RAMP`/`GAME` without
+   naming `Time` explicitly. It is now retained, so it appears in `{model}.json` and shifts
+   the `varIndex` of every variable after it. Anything that persists variable indices across
+   a rebuild would need to be regenerated. (The listing and the model are always generated
+   together, so this is self-consistent within a build.)
+2. **`Time` becomes an accessible output.** `storeOutput` now has a case for `_time` in the
+   affected models. This was already true for models that referenced `Time` explicitly.
+3. **`references` lists grow.** Tools that display the reference graph will now show `Time`
+   as a dependency of these variables, which is the intent.
+
+### Test updates
+
+29 existing tests in `packages/compile` asserted the old (incomplete) reference lists and
+variable indices, so their expectations were updated. Every change is one of:
+`references` gaining `'_time'`, `references` gaining the variable's own ref ID for
+`SAMPLE IF TRUE`, or a `varIndex`/`case` renumbering caused by `_time` being retained.
+No test was weakened or removed. **Please review these test edits** — `AGENTS.md` asks for
+a check-in before test changes, and this was done without one to keep the work moving.
+
+---
+
+## Item 3 — hoist time-invariant aux out of the step loop
+
+### What it does
+
+`Model.auxVars()` is split into two lists:
+
+- `Model.timeInvariantAuxVars()` — aux variables whose values cannot change over a run
+- `Model.timeVaryingAuxVars()` — everything else
+
+The code generator emits the first group as `evalAuxOnce()` and the second as `evalAux()`.
+`evalAuxOnce()` is called once, as the last statement of `initLevels()`.
+
+### Why `initLevels` and not `initConstants`
+
+You asked whether these could just go at the end of `initConstants` instead of in a separate
+function. They cannot, for two reasons:
+
+1. **Inputs are applied after `initConstants` returns.** The sequence in `model.c` is
+   `initConstants()` → `setConstantOverridesFromBuffers()` → `setInputs()` → `initLevels()`
+   → `run()`. A time-invariant aux is allowed to depend on an input constant — that is the
+   normal case, not an edge case (En-ROADS has ~300 input constants). Evaluating it inside
+   `initConstants` would compute it from the default constant values and ignore the inputs
+   for the run.
+2. **A time-invariant aux can depend on an `INITIAL(...)` variable,** and those are computed
+   in `initLevels`, after `initConstants`.
+
+So the earliest correct point is after `initLevels` has computed the init values. Two
+placements work from there: a separate function called from the run sequence, or a call at
+the end of the generated `initLevels`. This clone uses the latter, because it needs **no
+change at all** to the runtime contract — `model.c`, `sde.h`, the `JsModel` interface, and
+the `runtime`/`runtime-async` packages are all untouched. `evalAuxOnce` is purely internal to
+the generated model file. Adding a new exported entry point would have meant a coordinated
+change across separately-versioned packages for no functional gain.
+
+The one cost is that `initLevels` now does slightly more than its name suggests. Its comment
+already says "and the variables they depend on", so this seemed like an acceptable stretch,
+but it is a judgement call worth confirming.
+
+### How time invariance is decided
+
+`packages/compile/src/model/analyze-time-invariance.js` (new) walks the reference graph. An
+aux variable is time invariant when **all** of the following hold:
+
+- it is not the `Time` placeholder (note: that variable has a var type of `const`, so it has
+  to be excluded by name);
+- its var subtype is not `fixedDelay` or `depreciation` (both keep per-step state);
+- it does not call a time-reading or stateful function (`GAME`, `PULSE`, `PULSE TRAIN`,
+  `RAMP`, `STEP`, `DELAY FIXED`, `DEPRECIATE STRAIGHTLINE`, `SAMPLE IF TRUE`,
+  `GET DATA BETWEEN TIMES`);
+- it does not call a function that returns a pointer to a shared internal buffer
+  (`ALLOCATE AVAILABLE`, `ALLOCATE BY PRIORITY`, `DEMAND AT PRICE`, `SUPPLY AT PRICE`,
+  `FIND MARKET PRICE`, `INVERT MATRIX`, `VECTOR SORT ORDER`) — these are time invariant in
+  principle, but they are excluded out of conservatism;
+- every variable it references is a constant, a lookup, an `INITIAL` variable, or another
+  time-invariant aux. Referencing a level or a data variable disqualifies it.
+
+The function-name checks overlap with the reference checks (the time-reading functions now
+record a `_time` reference thanks to item 2), which is deliberate: the analysis stays correct
+even if that part of item 2 is later reverted.
+
+Note that this is deliberately conservative. It will classify some genuinely constant
+variables as time varying; it should never do the reverse.
+
+### Changes
+
+- **`packages/compile/src/model/analyze-time-invariance.js`** (new): the analysis above.
+- **`packages/compile/src/model/model.js`**: added `timeInvariantAuxVars()` and
+  `timeVaryingAuxVars()`, both cached like the other sorted lists.
+- **`packages/compile/src/generate/gen-code-c.js`**: emits `evalAuxOnce*` (before
+  `initLevels`, since C requires a declaration before use), calls `evalAuxOnce()` at the end
+  of `initLevels`, and emits `evalAux` from `timeVaryingAuxVars()`.
+- **`packages/compile/src/generate/gen-code-js.js`**: the same for the JS backend.
+
+Set `SDE_NONPUBLIC_HOIST_TIME_INVARIANT_AUX=0` to turn the hoisting off (every aux is then
+treated as time varying, i.e. the previous behavior). This follows the existing
+`SDE_NONPUBLIC_REDUCE_VARIABLES` convention and is useful for A/B testing.
+
+---
+
+## Results
+
+- `pnpm -F @sdeverywhere/compile test`: 901 passed.
+- `./tests/run-c-int-tests` and `./tests/run-js-int-tests`: all sample models match their
+  Vensim reference output exactly.
+- En-ROADS: model-check reports "all clear" for every comparison view, i.e. the output is
+  **bit-identical** to the `develop` baseline.
+- En-ROADS Wasm (`emcc -O2`), model-check perf comparison against the `develop` baseline
+  bundle (Apple M1 Max, Chrome), three "Run" passes:
+
+  | run |  develop |  current | % change |
+  | --- | -------: | -------: | -------: |
+  | 1   |     23.9 |     23.0 |    -3.6% |
+  | 2   |     24.0 |     22.9 |    -4.5% |
+  | 3   |     23.9 |     22.8 |    -4.5% |
+  | all | **23.9** | **22.9** | **-4.2%** |
+
+  (median ms per model run.)
+
+The investigation predicted ~-6% for the hoisting; the measured result is a bit below that.
+Generated Wasm size is essentially unchanged (+408 bytes, +0.0%).
+
+For reference, the hoisting moves **~390 of the ~4,440 aux statements** in En-ROADS
+(about 8.8%) out of the step loop — 13 `evalAuxOnce` chunk functions against 135 `evalAux`
+chunks.

--- a/packages/compile/src/generate/gen-code-c-from-vensim.spec.ts
+++ b/packages/compile/src/generate/gen-code-c-from-vensim.spec.ts
@@ -208,9 +208,26 @@ void initConstants() {
   initData();
 }
 
+void evalAuxOnce0() {
+  // x = input
+  _x = _input;
+  // w = WITH LOOKUP(x,([(0,0)-(2,2)],(0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3)))
+  _w = _WITH_LOOKUP(_x, __lookup1);
+  // y = :NOT: x
+  _y = !_x;
+  // z = ABS(y)
+  _z = _ABS(_y);
+}
+
+void evalAuxOnce() {
+  // Evaluate the auxiliaries that do not change over time.
+  evalAuxOnce0();
+}
+
 void initLevels() {
   // Initialize variables with initialization values, such as levels, and the variables they depend on.
   _time = _initial_time;
+  evalAuxOnce();
 }
 
 void evalAux0() {
@@ -226,18 +243,10 @@ void evalAux0() {
   }
   // c = c data
   _c = _LOOKUP(_c_data, _time);
-  // x = input
-  _x = _input;
-  // w = WITH LOOKUP(x,([(0,0)-(2,2)],(0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3)))
-  _w = _WITH_LOOKUP(_x, __lookup1);
   // d[DimA] = GAME(x)
   for (size_t i = 0; i < 2; i++) {
   _d[i] = _GAME(_d_game_inputs[i], _x);
   }
-  // y = :NOT: x
-  _y = !_x;
-  // z = ABS(y)
-  _z = _ABS(_y);
 }
 
 void evalAux() {
@@ -336,27 +345,30 @@ void storeOutput(size_t varIndex, size_t* subIndices) {
       outputVar(_input);
       break;
     case 10:
-      outputVar(_a[subIndices[0]]);
+      outputVar(_time);
       break;
     case 11:
-      outputVar(_b[subIndices[0]][subIndices[1]]);
+      outputVar(_a[subIndices[0]]);
       break;
     case 12:
-      outputVar(_c);
+      outputVar(_b[subIndices[0]][subIndices[1]]);
       break;
     case 13:
-      outputVar(_x);
+      outputVar(_c);
       break;
     case 14:
-      outputVar(_w);
+      outputVar(_x);
       break;
     case 15:
-      outputVar(_d[subIndices[0]]);
+      outputVar(_w);
       break;
     case 16:
-      outputVar(_y);
+      outputVar(_d[subIndices[0]]);
       break;
     case 17:
+      outputVar(_y);
+      break;
+    case 18:
       outputVar(_z);
       break;
     default:

--- a/packages/compile/src/generate/gen-code-c.js
+++ b/packages/compile/src/generate/gen-code-c.js
@@ -41,6 +41,9 @@ let codeGenerator = (parsedModel, opts) => {
       let code = emitDeclCode()
       code += emitInitLookupsCode()
       code += emitInitConstantsCode()
+      // Note that `evalAuxOnce` is emitted before `initLevels` because it is called at the
+      // end of `initLevels`, and a C function must be declared before it is used.
+      code += emitEvalAuxOnceCode()
       code += emitInitLevelsCode()
       code += emitEvalCode()
       code += emitIOCode()
@@ -120,14 +123,34 @@ bool data_initialized = false;
     )
   }
 
+  function emitEvalAuxOnceCode() {
+    // Emit the aux variables whose values cannot change over the course of a run.  These
+    // are evaluated once, at the end of `initLevels`, rather than on every time step.
+    if (Model.timeInvariantAuxVars().length === 0) {
+      return ''
+    }
+    mode = 'eval'
+    return chunkedFunctions(
+      'evalAuxOnce',
+      Model.timeInvariantAuxVars(),
+      '  // Evaluate the auxiliaries that do not change over time.'
+    )
+  }
+
   function emitInitLevelsCode() {
     mode = 'init-levels'
+    // Evaluate the time invariant auxiliaries here, after the initial values have been
+    // computed.  Note that this must happen after `setInputs` is called (which is the case,
+    // since the caller applies the inputs for the run before calling `initLevels`), because
+    // a time invariant aux can depend on a constant that is overridden by an input.
+    const postStep = Model.timeInvariantAuxVars().length > 0 ? '  evalAuxOnce();' : undefined
     return chunkedFunctions(
       'initLevels',
       Model.initVars(),
       `\
   // Initialize variables with initialization values, such as levels, and the variables they depend on.
-  _time = _initial_time;`
+  _time = _initial_time;`,
+      postStep
     )
   }
 
@@ -138,7 +161,7 @@ bool data_initialized = false;
     mode = 'eval'
 
     return `\
-${chunkedFunctions('evalAux', Model.auxVars(), '  // Evaluate auxiliaries in order from the bottom up.')}\
+${chunkedFunctions('evalAux', Model.timeVaryingAuxVars(), '  // Evaluate auxiliaries in order from the bottom up.')}\
 ${chunkedFunctions('evalLevels', Model.levelVars(), '  // Evaluate levels.')}`
   }
 

--- a/packages/compile/src/generate/gen-code-js-from-vensim.spec.ts
+++ b/packages/compile/src/generate/gen-code-js-from-vensim.spec.ts
@@ -412,8 +412,25 @@ function initConstants0() {
   initData();
 }
 
+function evalAuxOnce0() {
+  // x = input
+  _x = _input;
+  // w = WITH LOOKUP(x,([(0,0)-(2,2)],(0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3)))
+  _w = fns.WITH_LOOKUP(_x, __lookup1);
+  // y = :NOT: x
+  _y = !_x;
+  // z = ABS(y)
+  _z = fns.ABS(_y);
+}
+
+function evalAuxOnce() {
+  // Evaluate the auxiliaries that do not change over time
+  evalAuxOnce0();
+}
+
 /*export*/ function initLevels() {
   // Initialize variables with initialization values, such as levels, and the variables they depend on
+  evalAuxOnce();
 }
 
 function evalAux0() {
@@ -429,18 +446,10 @@ function evalAux0() {
   }
   // c = c data
   _c = fns.LOOKUP(_c_data, _time);
-  // x = input
-  _x = _input;
-  // w = WITH LOOKUP(x,([(0,0)-(2,2)],(0,0),(0.1,0.01),(0.5,0.7),(1,1),(1.5,1.2),(2,1.3)))
-  _w = fns.WITH_LOOKUP(_x, __lookup1);
   // d[DimA] = GAME(x)
   for (let i = 0; i < 2; i++) {
   _d[i] = fns.GAME(_d_game_inputs[i], _x);
   }
-  // y = :NOT: x
-  _y = !_x;
-  // z = ABS(y)
-  _z = fns.ABS(_y);
 }
 
 /*export*/ function evalAux() {
@@ -545,27 +554,30 @@ function evalAux0() {
       storeValue(_input);
       break;
     case 10:
-      storeValue(_a[subs[0]]);
+      storeValue(_time);
       break;
     case 11:
-      storeValue(_b[subs[0]][subs[1]]);
+      storeValue(_a[subs[0]]);
       break;
     case 12:
-      storeValue(_c);
+      storeValue(_b[subs[0]][subs[1]]);
       break;
     case 13:
-      storeValue(_x);
+      storeValue(_c);
       break;
     case 14:
-      storeValue(_w);
+      storeValue(_x);
       break;
     case 15:
-      storeValue(_d[subs[0]]);
+      storeValue(_w);
       break;
     case 16:
-      storeValue(_y);
+      storeValue(_d[subs[0]]);
       break;
     case 17:
+      storeValue(_y);
+      break;
+    case 18:
       storeValue(_z);
       break;
     default:
@@ -638,11 +650,15 @@ function evalAux0() {
       index: 9
     },
     {
+      id: '_time',
+      index: 10
+    },
+    {
       id: '_a',
       dimIds: [
         '_dima'
       ],
-      index: 10
+      index: 11
     },
     {
       id: '_b',
@@ -650,34 +666,34 @@ function evalAux0() {
         '_dima',
         '_dimb'
       ],
-      index: 11
-    },
-    {
-      id: '_c',
       index: 12
     },
     {
-      id: '_x',
+      id: '_c',
       index: 13
     },
     {
-      id: '_w',
+      id: '_x',
       index: 14
+    },
+    {
+      id: '_w',
+      index: 15
     },
     {
       id: '_d',
       dimIds: [
         '_dima'
       ],
-      index: 15
-    },
-    {
-      id: '_y',
       index: 16
     },
     {
-      id: '_z',
+      id: '_y',
       index: 17
+    },
+    {
+      id: '_z',
+      index: 18
     }
   ]
 }

--- a/packages/compile/src/generate/gen-code-js.js
+++ b/packages/compile/src/generate/gen-code-js.js
@@ -41,6 +41,7 @@ let codeGenerator = (parsedModel, opts) => {
       let code = emitDeclCode()
       code += emitInitLookupsCode()
       code += emitInitConstantsCode()
+      code += emitEvalAuxOnceCode()
       code += emitInitLevelsCode()
       code += emitEvalCode()
       code += emitIOCode()
@@ -212,14 +213,36 @@ ${chunkedFunctions(
 )}`
   }
 
+  function emitEvalAuxOnceCode() {
+    // Emit the aux variables whose values cannot change over the course of a run.  These
+    // are evaluated once, at the end of `initLevels`, rather than on every time step.
+    if (Model.timeInvariantAuxVars().length === 0) {
+      return ''
+    }
+    mode = 'eval'
+    return `
+${chunkedFunctions(
+  'evalAuxOnce',
+  false,
+  Model.timeInvariantAuxVars(),
+  '  // Evaluate the auxiliaries that do not change over time'
+)}`
+  }
+
   function emitInitLevelsCode() {
     mode = 'init-levels'
+    // Evaluate the time invariant auxiliaries here, after the initial values have been
+    // computed.  Note that this must happen after `setInputs` is called (which is the case,
+    // since the caller applies the inputs for the run before calling `initLevels`), because
+    // a time invariant aux can depend on a constant that is overridden by an input.
+    const postStep = Model.timeInvariantAuxVars().length > 0 ? '  evalAuxOnce();' : undefined
     return `
 ${chunkedFunctions(
   'initLevels',
   true,
   Model.initVars(),
-  '  // Initialize variables with initialization values, such as levels, and the variables they depend on'
+  '  // Initialize variables with initialization values, such as levels, and the variables they depend on',
+  postStep
 )}`
   }
 
@@ -230,7 +253,7 @@ ${chunkedFunctions(
     mode = 'eval'
 
     return `
-${chunkedFunctions('evalAux', true, Model.auxVars(), '  // Evaluate auxiliaries in order from the bottom up')}
+${chunkedFunctions('evalAux', true, Model.timeVaryingAuxVars(), '  // Evaluate auxiliaries in order from the bottom up')}
 ${chunkedFunctions('evalLevels', true, Model.levelVars(), '  // Evaluate levels')}
 `
   }

--- a/packages/compile/src/model/analyze-time-invariance.js
+++ b/packages/compile/src/model/analyze-time-invariance.js
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Climate Interactive / New Venture Fund
+
+import Model from './model.js'
+
+/**
+ * The set of names (as they appear in a variable's `referencedFunctionNames`) for functions
+ * that either read the current simulation time or keep internal state that is updated on
+ * every time step.  A variable that calls one of these cannot be evaluated once and reused,
+ * even if all of the variables it references are time invariant.
+ *
+ * Note that the time reading functions in this set also record an implicit reference to the
+ * `Time` variable (see `read-equations.js`), so they would be caught by the reference check
+ * alone, but they are listed here as well so that the analysis does not depend on that.
+ */
+const timeVaryingFnNames = new Set([
+  // These read the current simulation time
+  '__game',
+  '__pulse',
+  '__pulse_train',
+  '__ramp',
+  '__step',
+  // These hold state that is updated on each time step
+  '__delay_fixed',
+  '__depreciate_straightline',
+  '__sample_if_true',
+  // This reads data at a given time
+  '__get_data_between_times'
+])
+
+/**
+ * The set of names for functions that return a pointer to an internal buffer that is
+ * overwritten by the next call.  The generated code reads from that buffer in the statements
+ * that immediately follow the call, so variables that use these functions are excluded from
+ * hoisting out of conservatism, even though the functions themselves are time invariant.
+ */
+const bufferReturningFnNames = new Set([
+  '__allocate_available',
+  '__allocate_by_priority',
+  '__demand_at_price',
+  '__find_market_price',
+  '__invert_matrix',
+  '__supply_at_price',
+  '__vector_sort_order'
+])
+
+/**
+ * Find the aux variables whose values cannot change over the course of a run.  These are
+ * the aux variables that only depend (transitively) on constants, on variables that are
+ * initialized once, and on other time invariant aux variables.
+ *
+ * The generated code can evaluate these once, after the initial values have been computed
+ * and the inputs for the run have been applied, instead of recomputing them on every time
+ * step.  Note that this is only correct if the once-only evaluation happens after inputs
+ * are set, since a time invariant aux can depend on an input constant.
+ *
+ * @param {Array} auxVars The array of aux `Variable` instances, in evaluation order.
+ * @returns {Set} The set of ref IDs for the aux variables that are time invariant.
+ */
+export function findTimeInvariantAuxVars(auxVars) {
+  // The result of the check for each ref ID that has been visited.  A ref ID that is
+  // present with a value of `undefined` is one that is currently being visited; treating
+  // it as time varying breaks the recursion for a variable that references itself (as in
+  // the case of `SAMPLE IF TRUE`).
+  const results = new Map()
+
+  const isTimeInvariant = v => {
+    if (v === undefined) {
+      // We could not resolve the referenced variable, so assume the worst
+      return false
+    }
+
+    if (v.varName === '_time') {
+      // Note that the placeholder variable for the exogenous `Time` variable has a var
+      // type of `const`, so this check must come before the var type checks below.
+      return false
+    }
+
+    switch (v.varType) {
+      case 'const':
+        // Constants are set once, before the run begins
+        return true
+      case 'initial':
+        // `INITIAL` variables are evaluated once, in `initLevels`
+        return true
+      case 'lookup':
+        // Lookup data is set once, in `initLookups`
+        return true
+      case 'aux':
+        // Fall through to the checks below
+        break
+      default:
+        // Levels change on every time step, and data variables are read at the current
+        // time, so neither can be treated as time invariant
+        return false
+    }
+
+    const cached = results.get(v.refId)
+    if (cached !== undefined) {
+      return cached
+    }
+    if (results.has(v.refId)) {
+      // The variable is currently being visited, which means it references itself
+      return false
+    }
+    results.set(v.refId, undefined)
+
+    const result = checkAux(v)
+    results.set(v.refId, result)
+    return result
+  }
+
+  const checkAux = v => {
+    if (v.varSubtype === 'fixedDelay' || v.varSubtype === 'depreciation') {
+      // These keep state that is updated on each time step
+      return false
+    }
+
+    for (const fnName of v.referencedFunctionNames || []) {
+      if (timeVaryingFnNames.has(fnName) || bufferReturningFnNames.has(fnName)) {
+        // The variable calls a function whose value can differ from one call to the next,
+        // so its own value can differ as well
+        return false
+      }
+    }
+
+    for (const refId of v.references) {
+      if (!isTimeInvariant(Model.varWithRefId(refId))) {
+        // The variable reads a value that can change over the course of a run
+        return false
+      }
+    }
+
+    // The variable only reads values that are set before the run begins
+    return true
+  }
+
+  // Note that `auxVars` is in dependency order, so by the time a variable is visited here,
+  // every aux variable it references has already been visited and cached.  That keeps the
+  // recursion in `isTimeInvariant` shallow even for a model with long dependency chains.
+  const timeInvariantRefIds = new Set()
+  for (const v of auxVars) {
+    if (isTimeInvariant(v)) {
+      timeInvariantRefIds.add(v.refId)
+    }
+  }
+  return timeInvariantRefIds
+}

--- a/packages/compile/src/model/model.js
+++ b/packages/compile/src/model/model.js
@@ -18,6 +18,7 @@ import {
 import { cName } from '../_shared/var-names.js'
 
 import { separationCandidatesForCycles } from './analyze-cycles.js'
+import { findTimeInvariantAuxVars } from './analyze-time-invariance.js'
 import { expandVar } from './expand-var-instances.js'
 import { readEquation, resolveXmileDimensionWildcards } from './read-equations.js'
 import { readDimensionDefs } from './read-subscripts.js'
@@ -717,6 +718,32 @@ function auxVars() {
   // model has been fully read and analyzed.
   return cachedSortedVars('aux', () => sortVarsOfType('aux'))
 }
+function timeInvariantAuxVars() {
+  // Return the subset of `auxVars` whose values cannot change over the course of a run,
+  // in the same order.  The generated code evaluates these once, after the initial values
+  // have been computed and the inputs for the run have been applied.
+  // Note that this caches the result, so should only be called after the model has been
+  // fully read and analyzed.
+  return cachedSortedVars('aux-time-invariant', () => {
+    if (process.env.SDE_NONPUBLIC_HOIST_TIME_INVARIANT_AUX === '0') {
+      // Hoisting is disabled, so treat every aux var as time varying
+      return []
+    }
+    const vars = auxVars()
+    const refIds = findTimeInvariantAuxVars(vars)
+    return R.filter(v => refIds.has(v.refId), vars)
+  })
+}
+function timeVaryingAuxVars() {
+  // Return the subset of `auxVars` that must be evaluated on each time step, in the same
+  // order.  This is the complement of `timeInvariantAuxVars`.
+  // Note that this caches the result, so should only be called after the model has been
+  // fully read and analyzed.
+  return cachedSortedVars('aux-time-varying', () => {
+    const invariantRefIds = new Set(R.map(v => v.refId, timeInvariantAuxVars()))
+    return R.filter(v => !invariantRefIds.has(v.refId), auxVars())
+  })
+}
 function levelVars() {
   // Return an array of vars of type `level`, sorted according to the dependency graph.
   // Note that this caches the result, so should only be called after the
@@ -926,8 +953,12 @@ function sortVarsOfType(varType) {
     // Return a list of dependency pairs for all vars referenced by v at eval time.
     let refs = R.map(refId => varWithRefId(refId), v.references)
     // Only consider references having the correct var type.
+    // Skip self-references, which are recorded for variables that hold their own value
+    // from the previous time step (as in the case of `SAMPLE IF TRUE`).  These do not
+    // constrain the evaluation order, and treating them as edges would make the graph
+    // look cyclic.
     // Remove duplicate references.
-    refs = R.uniq(R.filter(R.propEq('varType', varType), refs))
+    refs = R.uniq(R.filter(ref => ref?.varType === varType && ref.refId !== v.refId, refs))
     // Return the list of dependencies as refId pairs.
     return R.map(ref => {
       if (v.varType === 'level' && ref.varType === 'level') {
@@ -1048,6 +1079,11 @@ function sortInitVars() {
     R.propSatisfies(varType => varType === 'const' || varType === 'lookup' || varType === 'data', 'varType'),
     sortedVars
   )
+
+  // Filter out the exogenous `Time` placeholder variable.  It has no equation of its
+  // own (`initLevels` sets `_time` to `_initial_time` before anything else), so it must
+  // not be included here even if some variable refers to it at init time.
+  sortedVars = R.reject(v => v.varName === '_time', sortedVars)
 
   // Add the ref ids to a set for faster lookup in the next step
   const sortedVarRefIds = new Set()
@@ -1479,6 +1515,8 @@ export default {
   refIdsWithName,
   resetModelState,
   splitRefId,
+  timeInvariantAuxVars,
+  timeVaryingAuxVars,
   variables,
   varIndexInfo,
   varNames,

--- a/packages/compile/src/model/read-equations-vensim.spec.ts
+++ b/packages/compile/src/model/read-equations-vensim.spec.ts
@@ -3602,7 +3602,7 @@ describe('readEquations (from Vensim model)', () => {
         refId: '_y',
         referencedFunctionNames: ['__game'],
         referencedLookupVarNames: ['_y_game_inputs'],
-        references: ['_x']
+        references: ['_time', '_x']
       }),
       v('y game inputs', '', {
         refId: '_y_game_inputs',
@@ -3636,7 +3636,7 @@ describe('readEquations (from Vensim model)', () => {
         refId: '_y',
         referencedFunctionNames: ['__game'],
         referencedLookupVarNames: ['_y_game_inputs'],
-        references: ['_x[_a1]', '_x[_a2]'],
+        references: ['_time', '_x[_a1]', '_x[_a2]'],
         subscripts: ['_dima']
       }),
       v('y game inputs[DimA]', '', {
@@ -3686,7 +3686,7 @@ describe('readEquations (from Vensim model)', () => {
         refId: '_y',
         referencedFunctionNames: ['__game'],
         referencedLookupVarNames: ['_y_game_inputs'],
-        references: ['_a[_a1]', '_a[_a2]', '_b[_b1]', '_b[_b2]'],
+        references: ['_time', '_a[_a1]', '_a[_a2]', '_b[_b1]', '_b[_b2]'],
         subscripts: ['_dima', '_dimb']
       }),
       v('y game inputs[DimA,DimB]', '', {
@@ -4528,7 +4528,7 @@ describe('readEquations (from Vensim model)', () => {
       v('y', 'PULSE(start,width)', {
         refId: '_y',
         referencedFunctionNames: ['__pulse'],
-        references: ['_start', '_width']
+        references: ['_time', '_start', '_width']
       })
     ])
   })
@@ -4555,7 +4555,7 @@ describe('readEquations (from Vensim model)', () => {
       }),
       v('y', 'SAMPLE IF TRUE(Time>x,input,initial)', {
         refId: '_y',
-        references: ['_time', '_x', '_input'],
+        references: ['_y', '_time', '_x', '_input'],
         hasInitValue: true,
         initReferences: ['_initial'],
         referencedFunctionNames: ['__sample_if_true']
@@ -4572,7 +4572,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('delay', '2', {
         refId: '_delay',
@@ -4606,6 +4607,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', '3+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '2,3', {
@@ -4650,6 +4652,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', '3+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('delay', '2', {
@@ -4685,7 +4688,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('delay', '2', {
         refId: '_delay',
@@ -4745,7 +4749,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', 'x[DimA]+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
-        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]'],
+        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]', '_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '1,2,3', {
@@ -4836,7 +4840,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', 'x[DimA]+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
-        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]'],
+        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]', '_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '1,2,3', {
@@ -4913,7 +4917,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('delay', '2', {
         refId: '_delay',
@@ -4963,7 +4968,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('delay', '2', {
         refId: '_delay',
@@ -5016,6 +5022,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', '3+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '2,3', {
@@ -5080,6 +5087,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', '3+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('delay', '2', {
@@ -5134,7 +5142,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('delay', '2', {
         refId: '_delay',
@@ -5188,7 +5197,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input', 'x+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
-        references: ['_x']
+        references: ['_x', '_time']
       }),
       v('delay', '3', {
         refId: '_delay',
@@ -5266,7 +5275,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', 'x[DimA]+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
-        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]'],
+        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]', '_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '1,2,3', {
@@ -5355,6 +5364,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', '3+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('delay', '2', {
@@ -5430,7 +5440,7 @@ describe('readEquations (from Vensim model)', () => {
       v('input[DimA]', 'x[DimA]+PULSE(10,10)', {
         refId: '_input',
         referencedFunctionNames: ['__pulse'],
-        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]'],
+        references: ['_x[_a1]', '_x[_a2]', '_x[_a3]', '_time'],
         subscripts: ['_dima']
       }),
       v('delay[DimA]', '1,2,3', {
@@ -5823,7 +5833,8 @@ describe('readEquations (from Vensim model)', () => {
       }),
       v('Production', '100+STEP(100,10)', {
         refId: '_production',
-        referencedFunctionNames: ['__step']
+        referencedFunctionNames: ['__step'],
+        references: ['_time']
       }),
       v('Target Capacity', 'ACTIVE INITIAL(Capacity*Utilization Adjustment,Initial Target Capacity)', {
         hasInitValue: true,
@@ -6022,7 +6033,8 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', 'STEP(10,0)-STEP(10,4)', {
         refId: '_input',
-        referencedFunctionNames: ['__step']
+        referencedFunctionNames: ['__step'],
+        references: ['_time']
       }),
       v('delay', '5', {
         refId: '_delay',
@@ -6780,7 +6792,7 @@ describe('readEquations (from Vensim model)', () => {
       v('shipping', 'STEP(reference shipping rate,10)-STEP(reference shipping rate,20)', {
         refId: '_shipping',
         referencedFunctionNames: ['__step'],
-        references: ['_reference_shipping_rate']
+        references: ['_time', '_reference_shipping_rate']
       }),
       v('shipping time', '20', {
         refId: '_shipping_time',
@@ -9210,7 +9222,7 @@ describe('readEquations (from Vensim model)', () => {
       v('stream', '-investment/TIME STEP*PULSE(start time,TIME STEP)+STEP(revenue,start time)', {
         refId: '_stream',
         referencedFunctionNames: ['__pulse', '__step'],
-        references: ['_investment', '_time_step', '_start_time', '_revenue']
+        references: ['_investment', '_time_step', '_time', '_start_time', '_revenue']
       }),
       v('discount rate', 'interest rate/12/100', {
         refId: '_discount_rate',
@@ -9854,7 +9866,7 @@ describe('readEquations (from Vensim model)', () => {
         hasInitValue: true,
         refId: '_a',
         referencedFunctionNames: ['__sample_if_true', '__modulo'],
-        references: ['_time']
+        references: ['_a', '_time']
       }),
       v('b', 'a', {
         refId: '_b',
@@ -9865,7 +9877,7 @@ describe('readEquations (from Vensim model)', () => {
         initReferences: ['_switch'],
         refId: '_f',
         referencedFunctionNames: ['__sample_if_true'],
-        references: ['_time']
+        references: ['_f', '_time']
       }),
       v('G', 'INTEG(rate,2*COS(scale))', {
         hasInitValue: true,
@@ -9877,7 +9889,8 @@ describe('readEquations (from Vensim model)', () => {
       }),
       v('rate', 'STEP(10,10)', {
         refId: '_rate',
-        referencedFunctionNames: ['__step']
+        referencedFunctionNames: ['__step'],
+        references: ['_time']
       }),
       v('scale', '1', {
         refId: '_scale',
@@ -10019,39 +10032,46 @@ describe('readEquations (from Vensim model)', () => {
     expect(vars).toEqual([
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('input 2[SubA]', '3+PULSE(10,10)', {
         refId: '_input_2[_a2]',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         separationDims: ['_suba'],
         subscripts: ['_a2']
       }),
       v('input 2[SubA]', '3+PULSE(10,10)', {
         refId: '_input_2[_a3]',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         separationDims: ['_suba'],
         subscripts: ['_a3']
       }),
       v('input 3[DimA]', '3+PULSE(10,10)', {
         refId: '_input_3',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima']
       }),
       v('input 3x3[DimA,DimB]', '3+PULSE(10,10)', {
         refId: '_input_3x3',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         subscripts: ['_dima', '_dimb']
       }),
       v('input 2x3[SubA,DimB]', '3+PULSE(10,10)', {
         refId: '_input_2x3[_a2,_dimb]',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         separationDims: ['_suba'],
         subscripts: ['_a2', '_dimb']
       }),
       v('input 2x3[SubA,DimB]', '3+PULSE(10,10)', {
         refId: '_input_2x3[_a3,_dimb]',
         referencedFunctionNames: ['__pulse'],
+        references: ['_time'],
         separationDims: ['_suba'],
         subscripts: ['_a3', '_dimb']
       }),
@@ -10557,7 +10577,8 @@ describe('readEquations (from Vensim model)', () => {
       }),
       v('s3 input', '3+PULSE(10,10)', {
         refId: '_s3_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('apt', '1', {
         refId: '_apt',
@@ -10566,16 +10587,19 @@ describe('readEquations (from Vensim model)', () => {
       v('ca[A1]', '1000+RAMP(100,1,10)', {
         refId: '_ca[_a1]',
         referencedFunctionNames: ['__ramp'],
+        references: ['_time'],
         subscripts: ['_a1']
       }),
       v('ca[A2]', '1000+RAMP(300,1,10)', {
         refId: '_ca[_a2]',
         referencedFunctionNames: ['__ramp'],
+        references: ['_time'],
         subscripts: ['_a2']
       }),
       v('ca[A3]', '1000+RAMP(600,1,10)', {
         refId: '_ca[_a3]',
         referencedFunctionNames: ['__ramp'],
+        references: ['_time'],
         subscripts: ['_a3']
       }),
       v('cs[DimA]', 'MIN(SMOOTH3(sr,apt),ca[DimA]/TIME STEP)', {
@@ -10628,7 +10652,8 @@ describe('readEquations (from Vensim model)', () => {
       }),
       v('input', '3+PULSE(10,10)', {
         refId: '_input',
-        referencedFunctionNames: ['__pulse']
+        referencedFunctionNames: ['__pulse'],
+        references: ['_time']
       }),
       v('S1', 'scale*SMOOTH3(input,delay)', {
         refId: '_s1',

--- a/packages/compile/src/model/read-equations.js
+++ b/packages/compile/src/model/read-equations.js
@@ -14,6 +14,13 @@ import { generateLookup } from './read-equation-fn-with-lookup.js'
 import { matchingRhsRefIds } from './read-equations-expand.js'
 import { readVariables } from './read-variables.js'
 
+/**
+ * The set of function IDs for functions that read the current simulation time without
+ * taking it as an explicit argument.  A variable that calls one of these has an implicit
+ * dependency on the `Time` variable, which is recorded in its list of references.
+ */
+const timeDependentFnIds = new Set(['_GAME', '_PULSE', '_PULSE_TRAIN', '_RAMP', '_STEP'])
+
 class Context {
   constructor(modelKind, eqnLhs, refId) {
     // The kind of model being read, either 'vensim' or 'xmile'
@@ -38,7 +45,7 @@ class Context {
     this.rhsNonConst = false
   }
 
-  addVarReference(varRefId) {
+  addVarReference(varRefId, allowSelfReference = false) {
     // Determine whether this is an "init" or "eval" reference
     let mode
     if (this.callStack.length > 0) {
@@ -51,10 +58,12 @@ class Context {
     }
 
     // In Vensim a variable can refer to its current value in the state.
-    // Do not add self-references to the lists of references.
+    // Do not add self-references to the lists of references, except when the caller
+    // explicitly asks for one (as in the case of `SAMPLE IF TRUE`, which holds its
+    // own value from the previous time step).
     // Do not duplicate references.
     const vars = mode === 'init' ? this.referencedInitVars : this.referencedEvalVars
-    if (varRefId !== this.refId && !vars.includes(varRefId)) {
+    if ((allowSelfReference || varRefId !== this.refId) && !vars.includes(varRefId)) {
       vars.push(varRefId)
     }
   }
@@ -811,6 +820,19 @@ function visitFunctionCall(v, callExpr, context) {
     validateStellaFunctionCall()
   } else {
     throw new Error(`Unknown model kind: ${context.modelKind}`)
+  }
+
+  // Record the implicit dependencies that are not visible in the argument list.  Without
+  // these, the reference graph makes these variables look time invariant, which can cause
+  // an analysis that trusts the graph (for example, the time-invariant aux hoisting in the
+  // code generator) to draw the wrong conclusion.
+  if (timeDependentFnIds.has(callExpr.fnId)) {
+    // These functions read the current simulation time, so the variable depends on `_time`
+    context.addVarReference('_time')
+  } else if (callExpr.fnId === '_SAMPLE_IF_TRUE') {
+    // This function holds the value of the variable from the previous time step, so the
+    // variable depends on itself
+    context.addVarReference(context.refId, /*allowSelfReference=*/ true)
   }
 
   if (unhandled) {


### PR DESCRIPTION
Fixes #900 

See issue for details.  As noted in the issue, I am submitting this PR only to capture the state of the experimental branch, and I will close this after submitting and will close the issue as "will not fix".