### PR TITLE
feat: add support for check tests that verify that one dataset is equal/etc to the sum of other datasets

### DIFF
--- a/packages/check-core/schema/check.schema.json
+++ b/packages/check-core/schema/check.schema.json
@@ -532,6 +532,16 @@
       "type": "number"
     },
     "predicate_ref_data": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/predicate_ref_data_single_dataset"
+        },
+        {
+          "$ref": "#/$defs/predicate_ref_data_multiple_datasets"
+        }
+      ]
+    },
+    "predicate_ref_data_single_dataset": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -544,6 +554,45 @@
       },
       "required": [
         "dataset"
+      ]
+    },
+    "predicate_ref_data_multiple_datasets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "op": {
+          "$ref": "#/$defs/predicate_ref_data_datasets_op"
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate_ref_data_datasets_item"
+          },
+          "minItems": 1
+        },
+        "scenario": {
+          "$ref": "#/$defs/predicate_ref_data_scenario"
+        }
+      },
+      "required": [
+        "op",
+        "datasets"
+      ]
+    },
+    "predicate_ref_data_datasets_op": {
+      "type": "string",
+      "enum": [
+        "sum"
+      ]
+    },
+    "predicate_ref_data_datasets_item": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/dataset_name"
+        }
       ]
     },
     "predicate_ref_data_dataset": {

--- a/packages/check-core/src/check/_mocks/mock-check-report.ts
+++ b/packages/check-core/src/check/_mocks/mock-check-report.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
-import { dataRef } from '../check-data-ref'
+import { dataRef, sumDataRef } from '../check-data-ref'
 import type { CheckDataset } from '../check-dataset'
 import type { CheckResult } from '../check-func'
 import type { CheckKey } from '../check-planner'
@@ -31,6 +31,13 @@ export function opDataRef(dataset: CheckDataset, scenario?: CheckScenario): Chec
   return {
     kind: 'data',
     dataRef: dataRef(dataset, scenario)
+  }
+}
+
+export function opSumDataRef(datasets: CheckDataset[], scenario?: CheckScenario): CheckPredicateOpDataRef {
+  return {
+    kind: 'data',
+    dataRef: sumDataRef(datasets, scenario)
   }
 }
 

--- a/packages/check-core/src/check/check-data-ref.ts
+++ b/packages/check-core/src/check/check-data-ref.ts
@@ -10,10 +10,15 @@ import type { CheckScenario } from './check-scenario'
 export type CheckDataRefKey = string
 
 /**
- * The scenario and dataset referenced by a particular predicate (for cases
- * where the check is against another dataset rather than a constant value).
+ * The operation used to combine multiple referenced datasets into a single dataset.
  */
-export interface CheckDataRef {
+export type CheckDataRefOp = 'sum'
+
+/**
+ * A single dataset (along with the scenario used to produce it) that is referenced
+ * by a predicate.  Each of these corresponds to one data fetch.
+ */
+export interface CheckRefDataset {
   /** The key for the reference; can be undefined if inputs or datasets failed to match. */
   key?: CheckDataRefKey
   /** The scenario used to generate the referenced dataset. */
@@ -23,22 +28,66 @@ export interface CheckDataRef {
 }
 
 /**
- * Return a new `CheckDataRef` that includes the given dataset and scenario.
+ * The dataset(s) referenced by a particular predicate op (for cases where the check
+ * is against other datasets rather than a constant value).  When more than one dataset
+ * is referenced, the `op` determines how they are combined into a single dataset.
+ */
+export interface CheckDataRef {
+  /** The operation used to combine the referenced datasets; undefined if there is a single dataset. */
+  op?: CheckDataRefOp
+  /** The referenced datasets. */
+  refs: CheckRefDataset[]
+}
+
+/**
+ * Return a new `CheckRefDataset` that includes the given dataset and scenario.
  *
  * @param dataset The referenced dataset.
  * @param scenario The referenced scenario; if undefined, the "all inputs at default"
  * scenario will be used.
  */
-export function dataRef(dataset: CheckDataset, scenario?: CheckScenario): CheckDataRef {
+export function refDataset(dataset: CheckDataset, scenario?: CheckScenario): CheckRefDataset {
   if (!scenario) {
     scenario = {
       spec: allInputsAtPositionSpec('at-default'),
       inputDescs: []
     }
   }
+  let key: CheckDataRefKey
+  if (scenario.spec && dataset.datasetKey) {
+    key = `${scenario.spec.uid}::${dataset.datasetKey}`
+  }
   return {
-    key: `${scenario.spec.uid}::${dataset.datasetKey}`,
+    key,
     dataset,
     scenario
+  }
+}
+
+/**
+ * Return a new `CheckDataRef` that refers to the single given dataset and scenario.
+ *
+ * @param dataset The referenced dataset.
+ * @param scenario The referenced scenario; if undefined, the "all inputs at default"
+ * scenario will be used.
+ */
+export function dataRef(dataset: CheckDataset, scenario?: CheckScenario): CheckDataRef {
+  return {
+    refs: [refDataset(dataset, scenario)]
+  }
+}
+
+/**
+ * Return a new `CheckDataRef` that refers to the sum of the given datasets (all
+ * evaluated in the same scenario).
+ *
+ * @param datasets The referenced datasets.
+ * @param scenario The referenced scenario; if undefined, the "all inputs at default"
+ * scenario will be used.
+ */
+export function sumDataRef(datasets: CheckDataset[], scenario?: CheckScenario): CheckDataRef {
+  return {
+    op: 'sum',
+    refs: datasets.map(dataset => refDataset(dataset, scenario))
   }
 }

--- a/packages/check-core/src/check/check-parser.spec.ts
+++ b/packages/check-core/src/check/check-parser.spec.ts
@@ -79,6 +79,20 @@ const pred1WithInherit = ([op, time]: [string, string]) => {
   return p
 }
 
+const pred1WithSumRef = ([op, time]: [string, string]) => {
+  const whitespace = '        '
+  let p = `${whitespace}- ${op}:`
+  p += `\n${whitespace}    op: sum`
+  p += `\n${whitespace}    datasets:`
+  p += `\n${whitespace}      - Other 1`
+  p += `\n${whitespace}      - Other 2`
+  p += `\n${whitespace}    scenario: inherit`
+  if (time) {
+    p += `\n${time}`
+  }
+  return p
+}
+
 const pred2 = ([op1, op2, time]: [string, string, string]) => {
   const whitespace = '        '
   let p = `${whitespace}- ${op1}: 0`
@@ -361,6 +375,128 @@ ${predicates}
 `
     const result = parseTestYaml([yaml])
     expect(result.isOk()).toBe(true)
+  })
+
+  it('should accept test with multiple predicates that reference the sum of other datasets', () => {
+    const ops = ['gt', 'gte', 'lt', 'lte', 'eq', 'approx']
+    const combos = cartesianProductOf([ops, times])
+    const predicates = combos.map(pred1WithSumRef).join('\n')
+
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+${predicates}
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('should accept test with predicate that references the sum of datasets in expanded form', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - approx:
+            op: sum
+            datasets:
+              - name: Output Y
+              - name: Output Z
+                source: Reference
+          tolerance: 0.1
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('should reject test with predicate that includes both dataset and datasets', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - eq:
+            dataset: inherit
+            op: sum
+            datasets:
+              - Output Y
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(false)
+  })
+
+  it('should reject test with predicate that includes datasets without an op', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - eq:
+            datasets:
+              - Output Y
+              - Output Z
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(false)
+  })
+
+  it('should reject test with predicate that includes an op without datasets', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - eq:
+            op: sum
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(false)
+  })
+
+  it('should reject test with predicate that includes an unknown op', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - eq:
+            op: product_of
+            datasets:
+              - Output Y
+              - Output Z
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(false)
+  })
+
+  it('should reject test with predicate that includes an empty datasets array', () => {
+    const yaml = `
+- describe: Group1
+  tests:
+    - it: should do something
+      datasets:
+        - name: Output X
+      predicates:
+        - eq:
+            op: sum
+            datasets: []
+`
+    const result = parseTestYaml([yaml])
+    expect(result.isOk()).toBe(false)
   })
 
   it('should accept test with range predicates', () => {

--- a/packages/check-core/src/check/check-planner.spec.ts
+++ b/packages/check-core/src/check/check-planner.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import type { Dataset } from '../_shared/types'
 import type { ModelSpec } from '../bundle/bundle-types'
 import type { CheckDataRef } from './check-data-ref'
-import { dataRef } from './check-data-ref'
+import { dataRef, sumDataRef } from './check-data-ref'
 import { parseTestYaml } from './check-parser'
 import type { CheckPlanPredicate } from './check-planner'
 import { CheckPlanner } from './check-planner'
@@ -194,6 +194,58 @@ describe('CheckPlanner', () => {
     expect(ref2).toEqual({
       key: 'inputs__i1_at_75::ModelImpl_v3',
       dataset: dataset('ModelImpl', 'V3'),
+      scenario: inputAtValue(i1, 75)
+    })
+  })
+
+  it('should build a plan that includes a data ref for each dataset referenced by a `sum` predicate', () => {
+    const yamlString = `
+- describe: group1
+  tests:
+    - it: test1
+      scenarios:
+        - with: I1
+          at: 75
+      datasets:
+        - name: V1
+      predicates:
+        - approx:
+            op: sum
+            datasets:
+              - V3
+              - name: V4[A1]
+            scenario: inherit
+          tolerance: 0.1
+`
+
+    const checkSpecResult = parseTestYaml([yamlString])
+    if (checkSpecResult.isErr()) {
+      throw new Error(`Failed to parse yaml: ${checkSpecResult.error}`)
+    }
+    const checkSpec = checkSpecResult.value
+    const planner = new CheckPlanner(modelSpec)
+    planner.addAllChecks(checkSpec, [])
+    const plan = planner.buildPlan()
+
+    // Verify that the check task references both datasets
+    expect(plan.tasks.size).toBe(1)
+    const task = plan.tasks.get(1)
+    const expectedDataRef = sumDataRef(
+      [dataset('ModelImpl', 'V3'), dataset('ModelImpl', 'V4[A1]')],
+      inputAtValue(i1, 75)
+    )
+    expect(task.dataRefs).toEqual(new Map([['approx', expectedDataRef]]))
+
+    // Verify that each referenced dataset is fetched separately
+    expect(plan.dataRefs.size).toBe(2)
+    expect(plan.dataRefs.get('inputs__i1_at_75::ModelImpl_v3')).toEqual({
+      key: 'inputs__i1_at_75::ModelImpl_v3',
+      dataset: dataset('ModelImpl', 'V3'),
+      scenario: inputAtValue(i1, 75)
+    })
+    expect(plan.dataRefs.get('inputs__i1_at_75::ModelImpl_v4[_a1]')).toEqual({
+      key: 'inputs__i1_at_75::ModelImpl_v4[_a1]',
+      dataset: dataset('ModelImpl', 'V4[A1]'),
       scenario: inputAtValue(i1, 75)
     })
   })

--- a/packages/check-core/src/check/check-planner.ts
+++ b/packages/check-core/src/check/check-planner.ts
@@ -4,7 +4,7 @@ import assertNever from 'assert-never'
 import type { ModelSpec } from '../bundle/bundle-types'
 import type { CheckAction } from './check-action'
 import { actionForPredicate } from './check-action'
-import type { CheckDataRef, CheckDataRefKey } from './check-data-ref'
+import type { CheckDataRef, CheckDataRefKey, CheckRefDataset } from './check-data-ref'
 import type { CheckDataset } from './check-dataset'
 import { expandDatasets } from './check-dataset'
 import type { CheckPredicateOp } from './check-predicate'
@@ -70,7 +70,7 @@ export interface CheckPlan {
    */
   tasks: Map<CheckKey, CheckTask>
   /**
-   * All data references for the checks.  These are kept separate so that the
+   * All referenced datasets for the checks.  These are kept separate so that the
    * reference data can be fetched in advance (and kept in memory) before
    * the actual checks are performed.
    *
@@ -79,13 +79,13 @@ export interface CheckPlan {
    * memory, but for now it's easier to just load all the reference data
    * as a preliminary step.
    */
-  dataRefs: Map<CheckDataRefKey, CheckDataRef>
+  dataRefs: Map<CheckDataRefKey, CheckRefDataset>
 }
 
 export class CheckPlanner {
   private readonly groups: CheckPlanGroup[] = []
   private readonly tasks: Map<CheckKey, CheckTask> = new Map()
-  private readonly dataRefs: Map<CheckDataRefKey, CheckDataRef> = new Map()
+  private readonly dataRefs: Map<CheckDataRefKey, CheckRefDataset> = new Map()
   private checkKey = 1
 
   constructor(private readonly modelSpec: ModelSpec) {}
@@ -232,6 +232,17 @@ export class CheckPlanner {
    * this will add a reference to the scenario/dataset pair so that the data can
    * be fetched in a later stage.
    *
+   * A predicate can also reference multiple datasets that are combined into a
+   * single dataset, for example:
+   * ```
+   *   approx:
+   *     op: sum
+   *     datasets:
+   *       - 'X'
+   *       - 'Y'
+   * ```
+   * in which case one reference is added for each of the datasets.
+   *
    * @param predicateSpec The predicate spec.
    * @param checkScenario The scenario in which the dataset is being checked.
    * @param checkDataset The dataset that is being checked.
@@ -251,36 +262,36 @@ export class CheckPlanner {
         return
       }
 
-      // Resolve the dataset
-      let refDataset: CheckDataset
-      if (typeof predOp.dataset === 'string') {
+      // Resolve the dataset(s)
+      const refDatasets: CheckDataset[] = []
+      if (predOp.datasets !== undefined) {
+        // The predicate references multiple datasets that will be combined using
+        // the given op
+        for (const datasetSpec of predOp.datasets) {
+          // Each item can be either a plain dataset name or an object that includes
+          // the name (and optional source)
+          const refDatasetSpec: CheckDatasetSpec =
+            typeof datasetSpec === 'string'
+              ? { name: datasetSpec }
+              : { name: datasetSpec.name, source: datasetSpec.source }
+          refDatasets.push(this.resolveRefDataset(refDatasetSpec))
+        }
+      } else if (typeof predOp.dataset === 'string') {
         switch (predOp.dataset) {
           case 'inherit':
             // Use the same dataset as the one being checked (this is typically used
             // when checking one dataset in one scenario against the same dataset in
             // a different scenario)
-            refDataset = checkDataset
+            refDatasets.push(checkDataset)
             break
           default:
             assertNever(predOp.dataset)
         }
       } else {
-        // Resolve the dataset for the given name; if it does not expand
-        // to a single valid dataset, treat it as an error case
-        const refDatasetSpec: CheckDatasetSpec = { name: predOp.dataset.name }
-        const matchedRefDatasets = expandDatasets(this.modelSpec, refDatasetSpec)
-        if (matchedRefDatasets.length === 1) {
-          refDataset = matchedRefDatasets[0]
-        } else {
-          // We failed to match a dataset (or the match expanded to multiple datasets);
-          // use an empty CheckDataset so that we can report the error later
-          refDataset = {
-            name: predOp.dataset.name
-          }
-        }
+        refDatasets.push(this.resolveRefDataset({ name: predOp.dataset.name }))
       }
 
-      // Resolve the scenario
+      // Resolve the scenario (this is shared by all referenced datasets)
       let refScenario: CheckScenario
       if (typeof predOp.scenario === 'string') {
         switch (predOp.scenario) {
@@ -311,28 +322,35 @@ export class CheckPlanner {
         }
       }
 
-      // Create the data ref that will be used for this predicate/op
-      let dataRefKey: CheckDataRefKey
-      if (refScenario.spec && refDataset.datasetKey) {
-        dataRefKey = `${refScenario.spec.uid}::${refDataset.datasetKey}`
-      }
-      const dataRef: CheckDataRef = {
-        key: dataRefKey,
-        dataset: refDataset,
-        scenario: refScenario
-      }
+      // Create a reference for each dataset that is used by this predicate/op
+      const refs: CheckRefDataset[] = refDatasets.map(refDataset => {
+        let dataRefKey: CheckDataRefKey
+        if (refScenario.spec && refDataset.datasetKey) {
+          dataRefKey = `${refScenario.spec.uid}::${refDataset.datasetKey}`
+        }
+        const ref: CheckRefDataset = {
+          key: dataRefKey,
+          dataset: refDataset,
+          scenario: refScenario
+        }
 
-      // Add the data ref to the plan only if the key is defined
-      if (dataRefKey) {
-        this.dataRefs.set(dataRefKey, dataRef)
-      }
+        // Add the reference to the plan only if the key is defined
+        if (dataRefKey) {
+          this.dataRefs.set(dataRefKey, ref)
+        }
 
-      // Add an entry to the map so that the op is associated with a particular
-      // reference dataset
+        return ref
+      })
+
+      // Add an entry to the map so that the op is associated with the reference
+      // dataset(s)
       if (dataRefs === undefined) {
         dataRefs = new Map()
       }
-      dataRefs.set(op, dataRef)
+      dataRefs.set(op, {
+        op: predOp.op,
+        refs
+      })
     }
 
     addDataRef('gt')
@@ -343,5 +361,25 @@ export class CheckPlanner {
     addDataRef('approx')
 
     return dataRefs
+  }
+
+  /**
+   * Resolve the dataset that matches the given spec.  If the spec does not expand
+   * to exactly one dataset, this will return a `CheckDataset` with an undefined
+   * `datasetKey` so that the error can be reported later.
+   *
+   * @param refDatasetSpec The spec for the referenced dataset.
+   */
+  private resolveRefDataset(refDatasetSpec: CheckDatasetSpec): CheckDataset {
+    const matchedRefDatasets = expandDatasets(this.modelSpec, refDatasetSpec)
+    if (matchedRefDatasets.length === 1) {
+      return matchedRefDatasets[0]
+    } else {
+      // We failed to match a dataset (or the match expanded to multiple datasets);
+      // use an empty CheckDataset so that we can report the error later
+      return {
+        name: refDatasetSpec.name
+      }
+    }
   }
 }

--- a/packages/check-core/src/check/check-report.spec.ts
+++ b/packages/check-core/src/check/check-report.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { positionSetting, inputSettingsSpec, valueSetting } from '../_shared/scenario-specs'
 import type { CheckDataRef } from './check-data-ref'
-import { dataRef } from './check-data-ref'
+import { dataRef, sumDataRef } from './check-data-ref'
 import type { CheckResult } from './check-func'
 import type { CheckKey, CheckPlan, CheckPlanPredicate } from './check-planner'
 import type { CheckPredicateOp } from './check-predicate'
@@ -28,6 +28,7 @@ import {
   groupReport,
   opConstantRef,
   opDataRef,
+  opSumDataRef,
   predicateReport,
   scenarioReport,
   testReport
@@ -190,6 +191,56 @@ describe('buildCheckReport', () => {
     )
   })
 
+  it('should build a report that describes a predicate that references the sum of multiple datasets', () => {
+    const dataRefs: Map<CheckPredicateOp, CheckDataRef> = new Map([
+      ['approx', sumDataRef([dataset('ModelImpl', 'V3'), dataset('ModelImpl', 'V4[A1]')], inputAtPos(i1, 'at-minimum'))]
+    ])
+    const predPlanWithSumRef: PredPlansFunc = k0 => [
+      predPlan(
+        k0,
+        {
+          approx: {
+            op: 'sum',
+            datasets: ['V3', { name: 'V4[A1]' }],
+            scenario: 'inherit'
+          },
+          tolerance: 0.5
+        },
+        dataRefs
+      )
+    ]
+
+    const checkPlan: CheckPlan = {
+      groups: [
+        groupPlan('group1', [
+          testPlan('test1', [
+            scenarioPlan(inputAtPos(i1, 'at-minimum'), [datasetPlan('Model', 'V1', predPlanWithSumRef(1))])
+          ])
+        ])
+      ],
+      tasks: new Map(),
+      dataRefs: new Map()
+    }
+
+    const passedResult: CheckResult = {
+      status: 'passed'
+    }
+
+    const report = buildCheckReport(checkPlan, new Map([[1, passedResult]]))
+    const predicate = report.groups[0].tests[0].scenarios[0].datasets[0].predicates[0]
+    expect(predicate.result).toEqual(passedResult)
+    expect(predicate.opValues).toEqual([`≈ 'V3' + 'V4[A1]' (w/ same scenario) ±0.5`])
+    expect(predicate.opRefs).toEqual(
+      new Map([
+        [
+          'approx',
+          opSumDataRef([dataset('ModelImpl', 'V3'), dataset('ModelImpl', 'V4[A1]')], inputAtPos(i1, 'at-minimum'))
+        ]
+      ])
+    )
+    expect(predicateMessage(predicate, bold)).toBe(`should be _≈ 'V3' + 'V4[A1]' (w/ same scenario) ±0.5_`)
+  })
+
   it('should build a report that includes the correct statuses for error cases', () => {
     const dataRefs: Map<CheckPredicateOp, CheckDataRef> = new Map()
     const predPlanWithUnknownDataset: PredPlansFunc = k0 => [
@@ -245,7 +296,7 @@ describe('buildCheckReport', () => {
         ])
       ],
       tasks: new Map(),
-      dataRefs
+      dataRefs: new Map()
     }
 
     const result1: CheckResult = {

--- a/packages/check-core/src/check/check-report.ts
+++ b/packages/check-core/src/check/check-report.ts
@@ -193,7 +193,7 @@ function predicateReport(
         opValue = `${sym} ${predOp}`
       } else {
         const dataRef = predicatePlan.dataRefs?.get(op)
-        if (!dataRef) {
+        if (!dataRef || dataRef.refs.length === 0) {
           return
         }
         const opDataRef: CheckPredicateOpDataRef = {
@@ -201,9 +201,15 @@ function predicateReport(
           dataRef
         }
         opRef = opDataRef
-        opValue = `${sym} '${dataRef.dataset.name}'`
 
-        const refScenarioSpec = dataRef.scenario?.spec
+        // When multiple datasets are referenced, show them as a sum (for now
+        // `sum` is the only supported op)
+        const refDatasetNames = dataRef.refs.map(ref => `'${ref.dataset.name}'`)
+        opValue = `${sym} ${refDatasetNames.join(' + ')}`
+
+        // Note that all referenced datasets use the same scenario, so we only
+        // need to consult the first one here
+        const refScenarioSpec = dataRef.refs[0].scenario?.spec
         if (!refScenarioSpec) {
           return
         }

--- a/packages/check-core/src/check/check-runner.spec.ts
+++ b/packages/check-core/src/check/check-runner.spec.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { actionForPredicate } from './check-action'
-import { dataRef } from './check-data-ref'
+import { dataRef, sumDataRef } from './check-data-ref'
 import type { CheckTask } from './check-planner'
 import { runCheck } from './check-runner'
 import { dataset as checkDataset } from './_mocks/mock-check-dataset'
@@ -62,6 +62,138 @@ describe('runCheck', () => {
     })
   })
 
+  it('should return correct result for passed check that references the sum of multiple datasets', () => {
+    const task: CheckTask = {
+      scenario: allAtPos('at-default'),
+      dataset: checkDataset('Model', 'X'),
+      action: actionForPredicate({
+        approx: {
+          op: 'sum',
+          datasets: ['Y', 'Z']
+        },
+        tolerance: 0.01
+      }),
+      dataRefs: new Map([['approx', sumDataRef([checkDataset('Model', 'Y'), checkDataset('Model', 'Z')])]])
+    }
+
+    const dataset = new Map([
+      [2000, 3],
+      [2050, 7],
+      [2100, 11]
+    ])
+
+    const refDatasets = new Map([
+      [
+        'all_inputs_at_default::Model_y',
+        new Map([
+          [2000, 1],
+          [2050, 3],
+          [2100, 5]
+        ])
+      ],
+      [
+        'all_inputs_at_default::Model_z',
+        new Map([
+          [2000, 2],
+          [2050, 4],
+          [2100, 6]
+        ])
+      ]
+    ])
+
+    const result = runCheck(task, dataset, refDatasets)
+    expect(result).toEqual({ status: 'passed' })
+  })
+
+  it('should return correct result for failed check that references the sum of multiple datasets', () => {
+    const task: CheckTask = {
+      scenario: allAtPos('at-default'),
+      dataset: checkDataset('Model', 'X'),
+      action: actionForPredicate({
+        approx: {
+          op: 'sum',
+          datasets: ['Y', 'Z']
+        },
+        tolerance: 0.01
+      }),
+      dataRefs: new Map([['approx', sumDataRef([checkDataset('Model', 'Y'), checkDataset('Model', 'Z')])]])
+    }
+
+    const dataset = new Map([
+      [2000, 3],
+      [2050, 7],
+      [2100, 99]
+    ])
+
+    const refDatasets = new Map([
+      [
+        'all_inputs_at_default::Model_y',
+        new Map([
+          [2000, 1],
+          [2050, 3],
+          [2100, 5]
+        ])
+      ],
+      [
+        'all_inputs_at_default::Model_z',
+        new Map([
+          [2000, 2],
+          [2050, 4],
+          [2100, 6]
+        ])
+      ]
+    ])
+
+    const result = runCheck(task, dataset, refDatasets)
+    expect(result).toEqual({
+      status: 'failed',
+      failValue: 99,
+      failOp: 'approx',
+      failRefValue: 11,
+      failTime: 2100
+    })
+  })
+
+  it('should return correct error result when one of the summed datasets cannot be resolved', () => {
+    const task: CheckTask = {
+      scenario: allAtPos('at-default'),
+      dataset: checkDataset('Model', 'X'),
+      action: actionForPredicate({
+        approx: {
+          op: 'sum',
+          datasets: ['Y', 'Unknown Z']
+        }
+      }),
+      dataRefs: new Map([['approx', sumDataRef([checkDataset('Model', 'Y'), { name: 'Unknown Z' }])]])
+    }
+
+    const dataset = new Map([
+      [2000, 3],
+      [2050, 7],
+      [2100, 11]
+    ])
+
+    const refDatasets = new Map([
+      [
+        'all_inputs_at_default::Model_y',
+        new Map([
+          [2000, 1],
+          [2050, 3],
+          [2100, 5]
+        ])
+      ]
+    ])
+
+    const result = runCheck(task, dataset, refDatasets)
+    expect(result).toEqual({
+      status: 'error',
+      errorInfo: {
+        kind: 'unknown-dataset',
+        name: 'Unknown Z'
+      }
+    })
+  })
+
   it('should return correct error result when referenced dataset cannot be resolved', () => {
     const task: CheckTask = {
       scenario: allAtPos('at-default'),
@@ -107,10 +239,14 @@ describe('runCheck', () => {
         [
           'gte',
           {
-            dataset: checkDataset('Model', 'Y'),
-            scenario: {
-              inputDescs: [{ name: 'Unknown Input' }]
-            }
+            refs: [
+              {
+                dataset: checkDataset('Model', 'Y'),
+                scenario: {
+                  inputDescs: [{ name: 'Unknown Input' }]
+                }
+              }
+            ]
           }
         ]
       ])
@@ -149,14 +285,18 @@ describe('runCheck', () => {
         [
           'gte',
           {
-            dataset: checkDataset('Model', 'Y'),
-            scenario: {
-              inputDescs: [],
-              error: {
-                kind: 'unknown-input-group',
-                name: 'Unknown Input Group'
+            refs: [
+              {
+                dataset: checkDataset('Model', 'Y'),
+                scenario: {
+                  inputDescs: [],
+                  error: {
+                    kind: 'unknown-input-group',
+                    name: 'Unknown Input Group'
+                  }
+                }
               }
-            }
+            ]
           }
         ]
       ])

--- a/packages/check-core/src/check/check-runner.ts
+++ b/packages/check-core/src/check/check-runner.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Climate Interactive / New Venture Fund
 
+import assertNever from 'assert-never'
+
 import type { Dataset } from '../_shared/types'
 import type { DataPlanner } from '../data/data-planner'
 import type { CheckConfig } from './check-config'
@@ -10,7 +12,7 @@ import type { CheckPredicateOp } from './check-predicate'
 import type { CheckReport } from './check-report'
 import { buildCheckReport } from './check-report'
 import type { CheckNameSpec, CheckSpec } from './check-spec'
-import type { CheckDataRefKey } from './check-data-ref'
+import type { CheckDataRef, CheckDataRefKey, CheckRefDataset } from './check-data-ref'
 
 /**
  * Process all checks from the given spec and add them to the given data planner.
@@ -41,12 +43,12 @@ export function runChecks(
   const refDatasets: Map<CheckDataRefKey, Dataset> = new Map()
 
   // Plan the reference data fetches
-  for (const [dataRefKey, dataRef] of checkPlan.dataRefs.entries()) {
+  for (const [dataRefKey, ref] of checkPlan.dataRefs.entries()) {
     // Add a request to the ref data planner for each dataset that is referenced
     // by one or more predicates.  These requests will be processed before all
     // other checks so that the reference data is available in memory when the
     // check action is performed.
-    refDataPlanner.addRequest(undefined, dataRef.scenario.spec, dataRef.dataset.datasetKey, datasets => {
+    refDataPlanner.addRequest(undefined, ref.scenario.spec, ref.dataset.datasetKey, datasets => {
       const dataset = datasets.datasetR
       if (dataset) {
         refDatasets.set(dataRefKey, dataset)
@@ -105,63 +107,130 @@ export function runCheck(
     }
   }
 
-  // Associate each op with a ref dataset (if the op references one)
+  // Associate each op with a ref dataset (if the op references one or more)
   let opRefDatasets: Map<CheckPredicateOp, Dataset>
   if (checkTask.dataRefs) {
     opRefDatasets = new Map()
     for (const [op, dataRef] of checkTask.dataRefs.entries()) {
-      const refDataset = refDatasets?.get(dataRef.key)
-      if (refDataset === undefined) {
-        // Set an error status when the reference data could not be resolved
-        if (dataRef.dataset.datasetKey === undefined) {
-          // The dataset could not be resolved
-          return {
-            status: 'error',
-            errorInfo: {
-              kind: 'unknown-dataset',
-              name: dataRef.dataset.name
-            }
-          }
-        } else if (dataRef.scenario.spec === undefined) {
-          // One or more inputs could not be resolved
-          if (dataRef.scenario.error) {
-            return {
-              status: 'error',
-              errorInfo: {
-                kind: dataRef.scenario.error.kind,
-                name: dataRef.scenario.error.name
-              }
-            }
-          } else {
-            let inputName: string
-            if (dataRef.scenario.inputDescs.length > 0) {
-              // TODO: Include all unresolved input names here
-              inputName = dataRef.scenario.inputDescs[0].name
-            } else {
-              inputName = 'unknown'
-            }
-            return {
-              status: 'error',
-              errorInfo: {
-                kind: 'unknown-input',
-                name: inputName
-              }
-            }
-          }
-        } else {
-          // Something else went wrong; treat this as an internal error
-          return {
-            status: 'error',
-            message: 'unresolved data reference'
-          }
+      // Resolve the data for each referenced dataset
+      const resolvedDatasets: Dataset[] = []
+      for (const ref of dataRef.refs) {
+        const refDataset = refDatasets?.get(ref.key)
+        if (refDataset === undefined) {
+          // Set an error status when the reference data could not be resolved
+          return errorResultForRefDataset(ref)
         }
+        resolvedDatasets.push(refDataset)
       }
 
-      // Associate the dataset with the op
-      opRefDatasets.set(op, refDataset)
+      // Associate the (possibly combined) dataset with the op
+      opRefDatasets.set(op, combineRefDatasets(dataRef, resolvedDatasets))
     }
   }
 
   // All data was resolved; run the check action on the dataset
   return checkTask.action.run(dataset, opRefDatasets)
+}
+
+/**
+ * Return an error result that describes why the given referenced dataset could
+ * not be resolved.
+ *
+ * @param ref The referenced dataset that could not be resolved.
+ */
+function errorResultForRefDataset(ref: CheckRefDataset): CheckResult {
+  if (ref.dataset.datasetKey === undefined) {
+    // The dataset could not be resolved
+    return {
+      status: 'error',
+      errorInfo: {
+        kind: 'unknown-dataset',
+        name: ref.dataset.name
+      }
+    }
+  } else if (ref.scenario.spec === undefined) {
+    // One or more inputs could not be resolved
+    if (ref.scenario.error) {
+      return {
+        status: 'error',
+        errorInfo: {
+          kind: ref.scenario.error.kind,
+          name: ref.scenario.error.name
+        }
+      }
+    } else {
+      let inputName: string
+      if (ref.scenario.inputDescs.length > 0) {
+        // TODO: Include all unresolved input names here
+        inputName = ref.scenario.inputDescs[0].name
+      } else {
+        inputName = 'unknown'
+      }
+      return {
+        status: 'error',
+        errorInfo: {
+          kind: 'unknown-input',
+          name: inputName
+        }
+      }
+    }
+  } else {
+    // Something else went wrong; treat this as an internal error
+    return {
+      status: 'error',
+      message: 'unresolved data reference'
+    }
+  }
+}
+
+/**
+ * Combine the given resolved datasets into the single dataset that will be used
+ * as the reference for a predicate op.
+ *
+ * @param dataRef The data reference that describes how the datasets are combined.
+ * @param datasets The resolved data for each referenced dataset.
+ */
+function combineRefDatasets(dataRef: CheckDataRef, datasets: Dataset[]): Dataset {
+  if (dataRef.op === undefined) {
+    // There is a single referenced dataset, so no combining is needed
+    return datasets[0]
+  }
+
+  switch (dataRef.op) {
+    case 'sum':
+      return sumDatasets(datasets)
+    default:
+      assertNever(dataRef.op)
+  }
+}
+
+/**
+ * Return a dataset containing the sum of the values from the given datasets.  Note
+ * that a time is only included in the resulting dataset if a value is available at
+ * that time in every one of the given datasets.
+ *
+ * @param datasets The datasets to be summed.
+ */
+function sumDatasets(datasets: Dataset[]): Dataset {
+  const firstDataset = datasets[0]
+  const otherDatasets = datasets.slice(1)
+
+  const summed: Dataset = new Map()
+  for (const [time, value] of firstDataset) {
+    let sum = value
+    let complete = true
+    for (const otherDataset of otherDatasets) {
+      const otherValue = otherDataset.get(time)
+      if (otherValue === undefined) {
+        complete = false
+        break
+      }
+      sum += otherValue
+    }
+    if (complete) {
+      summed.set(time, sum)
+    }
+  }
+
+  return summed
 }

--- a/packages/check-core/src/check/check-spec.ts
+++ b/packages/check-core/src/check/check-spec.ts
@@ -40,6 +40,7 @@ export type CheckPredicateRefConstant = number
 export type CheckPredicateRefDataDatasetSpecial = 'inherit'
 export interface CheckPredicateRefDataDatasetSpec {
   name: string
+  source?: string
 }
 export type CheckPredicateRefDataScenarioSpecial = 'inherit'
 export interface CheckPredicateRefDataScenarioSpec {
@@ -47,8 +48,21 @@ export interface CheckPredicateRefDataScenarioSpec {
   input?: string
   at?: CheckScenarioPosition | number
 }
+export type CheckPredicateRefDataDatasetsOp = 'sum'
 export interface CheckPredicateRefData {
-  dataset: CheckPredicateRefDataDatasetSpecial | CheckPredicateRefDataDatasetSpec
+  /**
+   * A single referenced dataset.  Note that exactly one of `dataset` or (`op` and
+   * `datasets`) must be defined; this is enforced by the JSON schema.
+   */
+  dataset?: CheckPredicateRefDataDatasetSpecial | CheckPredicateRefDataDatasetSpec
+  /** The operation used to combine the datasets in `datasets` into a single dataset. */
+  op?: CheckPredicateRefDataDatasetsOp
+  /**
+   * The referenced datasets.  Each item can be either the name of a dataset, or an
+   * object that includes the `name` (and optional `source`) of a dataset.
+   */
+  datasets?: (string | CheckPredicateRefDataDatasetSpec)[]
+  /** The scenario used to produce the referenced dataset(s). */
   scenario?: CheckPredicateRefDataScenarioSpecial | CheckPredicateRefDataScenarioSpec
 }
 

--- a/packages/check-core/src/check/check.schema.js
+++ b/packages/check-core/src/check/check.schema.js
@@ -378,6 +378,13 @@ export default {
     },
 
     predicate_ref_data: {
+      oneOf: [
+        { $ref: '#/$defs/predicate_ref_data_single_dataset' },
+        { $ref: '#/$defs/predicate_ref_data_multiple_datasets' }
+      ]
+    },
+
+    predicate_ref_data_single_dataset: {
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -385,6 +392,29 @@ export default {
         scenario: { $ref: '#/$defs/predicate_ref_data_scenario' }
       },
       required: ['dataset']
+    },
+
+    predicate_ref_data_multiple_datasets: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        op: { $ref: '#/$defs/predicate_ref_data_datasets_op' },
+        datasets: {
+          type: 'array',
+          items: { $ref: '#/$defs/predicate_ref_data_datasets_item' },
+          minItems: 1
+        },
+        scenario: { $ref: '#/$defs/predicate_ref_data_scenario' }
+      },
+      required: ['op', 'datasets']
+    },
+
+    predicate_ref_data_datasets_op: {
+      type: 'string',
+      enum: ['sum']
+    },
+    predicate_ref_data_datasets_item: {
+      oneOf: [{ type: 'string' }, { $ref: '#/$defs/dataset_name' }]
     },
 
     predicate_ref_data_dataset: {

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -65,7 +65,7 @@ export {
   createCheckDataCoordinatorForTests
 } from './check/check-data-coordinator'
 
-export type { CheckDataRef, CheckDataRefKey } from './check/check-data-ref'
+export type { CheckDataRef, CheckDataRefKey, CheckDataRefOp, CheckRefDataset } from './check/check-data-ref'
 
 export type { CheckDataset, CheckDatasetError } from './check/check-dataset'
 

--- a/packages/check-ui-shell/src/_mocks/mock-check-report.ts
+++ b/packages/check-ui-shell/src/_mocks/mock-check-report.ts
@@ -13,6 +13,7 @@ import type {
   CheckPredicateOpRef,
   CheckPredicateReport,
   CheckPredicateTimeSpec,
+  CheckRefDataset,
   CheckResult,
   CheckScenarioReport,
   CheckStatus,
@@ -31,7 +32,7 @@ export function dataset(prefix: string, varName: string): CheckDataset {
   }
 }
 
-function dataRef(dataset: CheckDataset, scenario?: CheckScenario): CheckDataRef {
+function refDataset(dataset: CheckDataset, scenario?: CheckScenario): CheckRefDataset {
   if (!scenario) {
     scenario = {
       spec: allInputsAtPositionSpec('at-default'),
@@ -42,6 +43,19 @@ function dataRef(dataset: CheckDataset, scenario?: CheckScenario): CheckDataRef 
     key: `${scenario.spec.uid}::${dataset.datasetKey}`,
     dataset,
     scenario
+  }
+}
+
+function dataRef(dataset: CheckDataset, scenario?: CheckScenario): CheckDataRef {
+  return {
+    refs: [refDataset(dataset, scenario)]
+  }
+}
+
+function sumDataRef(datasets: CheckDataset[], scenario?: CheckScenario): CheckDataRef {
+  return {
+    op: 'sum',
+    refs: datasets.map(dataset => refDataset(dataset, scenario))
   }
 }
 
@@ -56,6 +70,13 @@ export function opDataRef(dataset: CheckDataset, scenario?: CheckScenario): Chec
   return {
     kind: 'data',
     dataRef: dataRef(dataset, scenario)
+  }
+}
+
+export function opSumDataRef(datasets: CheckDataset[], scenario?: CheckScenario): CheckPredicateOpDataRef {
+  return {
+    kind: 'data',
+    dataRef: sumDataRef(datasets, scenario)
   }
 }
 

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box-vm.ts
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box-vm.ts
@@ -24,6 +24,48 @@ import { pointsFromDataset } from '../../graphs/comparison-graph-vm'
 
 let requestId = 1
 
+/**
+ * Return the key used to store the data for one of the datasets referenced by
+ * the given predicate op.
+ *
+ * @param op The predicate operation.
+ * @param index The index of the referenced dataset.
+ */
+function refDataKey(op: CheckPredicateOp, index: number): string {
+  return `${op}::${index}`
+}
+
+/**
+ * Return the point-wise sum of the given sets of points.  Note that a point is only
+ * included in the result if a value is available at that time in every one of the
+ * given sets.
+ *
+ * @param pointArrays The sets of points to be summed.
+ */
+function sumPoints(pointArrays: Point[][]): Point[] {
+  const firstPoints = pointArrays[0]
+  const otherPointMaps = pointArrays.slice(1).map(points => new Map(points.map(p => [p.x, p.y])))
+
+  const summed: Point[] = []
+  for (const point of firstPoints) {
+    let sum = point.y
+    let complete = true
+    for (const otherPointMap of otherPointMaps) {
+      const otherY = otherPointMap.get(point.x)
+      if (otherY === undefined) {
+        complete = false
+        break
+      }
+      sum += otherY
+    }
+    if (complete) {
+      summed.push({ x: point.x, y: sum })
+    }
+  }
+
+  return summed
+}
+
 export interface CheckSummaryGraphBoxContent {
   comparisonGraphViewModel: ComparisonGraphViewModel
 }
@@ -73,22 +115,26 @@ export class CheckSummaryGraphBoxViewModel {
         return
       }
 
-      // Add the op as a data key so that we keep track of which
-      // datasets need to be resolved
-      this.expectedDataKeys.push(op)
-
       switch (opRef.kind) {
         case 'constant':
+          // Add the op as a data key so that we keep track of which datasets
+          // need to be resolved
+          this.expectedDataKeys.push(op)
+
           // Add the constant value to the map.  A straight line segment
           // will be generated when the graph view model is created.
           this.resolvedDataKeys.push(op)
           this.opConstantRefs.set(op, opRef.value)
           break
         case 'data': {
-          // Fetch the reference dataset
-          const refScenario = opRef.dataRef.scenario.spec
-          const refDatasetKey = opRef.dataRef.dataset.datasetKey
-          this.requestDataset(op, refScenario, refDatasetKey)
+          // Fetch each referenced dataset separately; if the op references more
+          // than one dataset, they will be combined into a single set of points
+          // once all responses have been received
+          opRef.dataRef.refs.forEach((ref, index) => {
+            const dataKey = refDataKey(op, index)
+            this.expectedDataKeys.push(dataKey)
+            this.requestDataset(dataKey, ref.scenario.spec, ref.dataset.datasetKey)
+          })
           break
         }
         default:
@@ -148,6 +194,39 @@ export class CheckSummaryGraphBoxViewModel {
   }
 
   /**
+   * Combine the data for each op that references one or more datasets, and store
+   * the resulting points under the key for that op.  When an op references multiple
+   * datasets, the points are combined according to the op declared in the data ref
+   * (currently `sum` is the only supported op).
+   */
+  private combineRefData(): void {
+    const combineOp = (op: CheckPredicateOp) => {
+      const opRef = this.predicateReport.opRefs.get(op)
+      if (opRef === undefined || opRef.kind !== 'data') {
+        return
+      }
+
+      const pointArrays = opRef.dataRef.refs.map((_, index) => this.resolvedData.get(refDataKey(op, index)))
+      if (pointArrays.some(points => points === undefined)) {
+        return
+      }
+
+      if (opRef.dataRef.op === 'sum') {
+        this.resolvedData.set(op, sumPoints(pointArrays))
+      } else {
+        // There is a single referenced dataset, so no combining is needed
+        this.resolvedData.set(op, pointArrays[0])
+      }
+    }
+    combineOp('gt')
+    combineOp('gte')
+    combineOp('lt')
+    combineOp('lte')
+    combineOp('eq')
+    combineOp('approx')
+  }
+
+  /**
    * Should be called when a dataset response is received from the data coordinator.
    * If there are other pending requests, this will be a no-op.  Once all responses
    * are received, this will build the comparison graph view model.
@@ -157,6 +236,9 @@ export class CheckSummaryGraphBoxViewModel {
     if (this.resolvedDataKeys.length !== this.expectedDataKeys.length) {
       return
     }
+
+    // Combine the referenced datasets for each op into a single set of points
+    this.combineRefData()
 
     // Determine the min/max times for the primary dataset
     const primaryPoints = this.resolvedData.get('primary')

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box-vm.ts
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box-vm.ts
@@ -213,10 +213,12 @@ export class CheckSummaryGraphBoxViewModel {
 
       if (opRef.dataRef.op === 'sum') {
         this.resolvedData.set(op, sumPoints(pointArrays))
-      } else {
+      } else if (pointArrays.length === 1) {
         // There is a single referenced dataset, so no combining is needed
         this.resolvedData.set(op, pointArrays[0])
       }
+      // Note that if multiple datasets are referenced but the op is not recognized,
+      // we intentionally leave the data unset so that no reference line is displayed
     }
     combineOp('gt')
     combineOp('gte')

--- a/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.stories.svelte
+++ b/packages/check-ui-shell/src/components/check/summary/check-summary-graph-box.stories.svelte
@@ -22,7 +22,7 @@ import { mockBundleModel } from '../../../_mocks/mock-bundle'
 import { mockDataset } from '../../../_mocks/mock-data'
 import { inputVar, outputVar } from '../../../_mocks/mock-vars'
 
-import { dataset, opConstantRef, opDataRef } from '../../../_mocks/mock-check-report'
+import { dataset, opConstantRef, opDataRef, opSumDataRef } from '../../../_mocks/mock-check-report'
 import { inputAtValue } from '../../../_mocks/mock-check-scenario'
 
 import StoryDecorator from '../../_storybook/story-decorator.svelte'
@@ -56,9 +56,13 @@ function createPredicateReport(
   }
 }
 
+function scaledDataset(scale: number): Dataset {
+  return new Map(Array.from(mockDataset(), ([time, value]) => [time, value * scale]))
+}
+
 function createGraphBoxViewModel(predicateReport: CheckPredicateReport): CheckSummaryGraphBoxViewModel {
   const inputVarNames = ['I1']
-  const outputVarNames = ['O1', 'O2', 'O2_Upper', 'O2_Lower']
+  const outputVarNames = ['O1', 'O1_Part1', 'O1_Part2', 'O2', 'O2_Upper', 'O2_Lower']
   const modelSpec: ModelSpec = {
     modelSizeInBytes: 0,
     dataSizeInBytes: 0,
@@ -71,6 +75,14 @@ function createGraphBoxViewModel(predicateReport: CheckPredicateReport): CheckSu
     for (const datasetKey of datasetKeys) {
       let ds: Dataset
       switch (datasetKey) {
+        // Note that O1_Part1 and O1_Part2 add up to O1, which makes them useful
+        // for demonstrating a predicate that references the sum of two datasets
+        case 'Model__o1_part1':
+          ds = scaledDataset(0.4)
+          break
+        case 'Model__o1_part2':
+          ds = scaledDataset(0.6)
+          break
         case 'Model__o2':
           ds = mockDataset(5)
           break
@@ -664,6 +676,37 @@ function createGraphBoxViewModel(predicateReport: CheckPredicateReport): CheckSu
       time: {
         after_incl: 2020,
         before_incl: 2090
+      }
+    })
+    args.viewModel = createGraphBoxViewModel(report)
+  }}
+/>
+
+<Story
+  name="Without time: approx (sum of datasets)"
+  {template}
+  beforeEach={async ({ args }) => {
+    const ops: [CheckPredicateOp, CheckPredicateOpRef][] = [
+      ['approx', opSumDataRef([dataset('Model', 'O1_Part1'), dataset('Model', 'O1_Part2')])]
+    ]
+    const report = createPredicateReport(ops, {
+      tolerance: 5
+    })
+    args.viewModel = createGraphBoxViewModel(report)
+  }}
+/>
+
+<Story
+  name="With time range: eq (sum of datasets)"
+  {template}
+  beforeEach={async ({ args }) => {
+    const ops: [CheckPredicateOp, CheckPredicateOpRef][] = [
+      ['eq', opSumDataRef([dataset('Model', 'O1_Part1'), dataset('Model', 'O1_Part2')])]
+    ]
+    const report = createPredicateReport(ops, {
+      time: {
+        after_incl: 2020,
+        before_incl: 2080
       }
     })
     args.viewModel = createGraphBoxViewModel(report)


### PR DESCRIPTION
Fixes #904 

See issue for details.  This only affects the model-check packages and only adds a feature (no impact on existing check tests).
